### PR TITLE
Add support for JDKs with JavaFX

### DIFF
--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -52,7 +52,7 @@ describe('installer tests', () => {
   }, 100000);
 
   it('Installs version of Java from jdkFile if no matching version is installed', async () => {
-    await installer.getJava('12', 'x64', javaFilePath);
+    await installer.getJava('12', 'x64', javaFilePath, false);
     const JavaDir = path.join(toolDir, 'Java', '12.0.0', 'x64');
 
     expect(fs.existsSync(`${JavaDir}.complete`)).toBe(true);
@@ -62,7 +62,7 @@ describe('installer tests', () => {
   it('Throws if invalid directory to jdk', async () => {
     let thrown = false;
     try {
-      await installer.getJava('1000', 'x64', 'bad path');
+      await installer.getJava('1000', 'x64', 'bad path', false);
     } catch {
       thrown = true;
     }
@@ -70,7 +70,7 @@ describe('installer tests', () => {
   });
 
   it('Downloads java if no file given', async () => {
-    await installer.getJava('8.0.102', 'x64', '');
+    await installer.getJava('8.0.102', 'x64', '', false);
     const JavaDir = path.join(toolDir, 'Java', '8.0.102', 'x64');
 
     expect(fs.existsSync(`${JavaDir}.complete`)).toBe(true);
@@ -78,7 +78,7 @@ describe('installer tests', () => {
   }, 100000);
 
   it('Downloads java with 1.x syntax', async () => {
-    await installer.getJava('1.10', 'x64', '');
+    await installer.getJava('1.10', 'x64', '', false);
     const JavaDir = path.join(toolDir, 'Java', '10.0.2', 'x64');
 
     expect(fs.existsSync(`${JavaDir}.complete`)).toBe(true);
@@ -86,7 +86,7 @@ describe('installer tests', () => {
   }, 100000);
 
   it('Downloads java with normal semver syntax', async () => {
-    await installer.getJava('9.0.x', 'x64', '');
+    await installer.getJava('9.0.x', 'x64', '', false);
     const JavaDir = path.join(toolDir, 'Java', '9.0.7', 'x64');
 
     expect(fs.existsSync(`${JavaDir}.complete`)).toBe(true);
@@ -96,7 +96,7 @@ describe('installer tests', () => {
   it('Throws if invalid directory to jdk', async () => {
     let thrown = false;
     try {
-      await installer.getJava('1000', 'x64', 'bad path');
+      await installer.getJava('1000', 'x64', 'bad path', false);
     } catch {
       thrown = true;
     }
@@ -111,7 +111,8 @@ describe('installer tests', () => {
     await installer.getJava(
       '250',
       'x64',
-      'path shouldnt matter, found in cache'
+      'path shouldnt matter, found in cache',
+      false
     );
     return;
   });
@@ -122,7 +123,7 @@ describe('installer tests', () => {
     let thrown = false;
     try {
       // This will throw if it doesn't find it in the cache (because no such version exists)
-      await installer.getJava('251', 'x64', 'bad path');
+      await installer.getJava('251', 'x64', 'bad path', false);
     } catch {
       thrown = true;
     }

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
   jdkFile:
     description: 'Path to where the compressed JDK is located. The path could be in your source repository or a local path on the agent.'
     required: false
+  javafx:
+    description: 'Whether or not to install a JDK with JavaFX. Takes either true or false.'
+    required: false
+    default: 'false'
 # Deprecated option, do not use. Will not be supported after October 1, 2019
   version:
     description: 'Deprecated. Use java-version instead. Will not be supported after October 1, 2019'

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -1,9 +1,10 @@
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
@@ -41,9 +42,9 @@ if (!tempDirectory) {
     }
     tempDirectory = path.join(baseLocation, 'actions', 'temp');
 }
-function getJava(version, arch, jdkFile) {
+function getJava(version, arch, jdkFile, javafx) {
     return __awaiter(this, void 0, void 0, function* () {
-        let toolPath = tc.find('Java', version);
+        let toolPath = tc.find(javafx ? 'fx-jdk' : 'jdk', version);
         if (toolPath) {
             core.debug(`Tool found in cache ${toolPath}`);
         }
@@ -54,7 +55,7 @@ function getJava(version, arch, jdkFile) {
                 let http = new httpm.HttpClient('setup-java');
                 let contents = yield (yield http.get('https://static.azul.com/zulu/bin/')).readBody();
                 let refs = contents.match(/<a href.*\">/gi) || [];
-                const downloadInfo = getDownloadInfo(refs, version);
+                const downloadInfo = getDownloadInfo(refs, version, javafx);
                 jdkFile = yield tc.downloadTool(downloadInfo.url);
                 version = downloadInfo.version;
                 compressedFileExtension = IS_WINDOWS ? '.zip' : '.tar.gz';
@@ -66,7 +67,7 @@ function getJava(version, arch, jdkFile) {
             let tempDir = path.join(tempDirectory, 'temp_' + Math.floor(Math.random() * 2000000000));
             const jdkDir = yield unzipJavaDownload(jdkFile, compressedFileExtension, tempDir);
             core.debug(`jdk extracted to ${jdkDir}`);
-            toolPath = yield tc.cacheDir(jdkDir, 'Java', getCacheVersionString(version), arch);
+            toolPath = yield tc.cacheDir(jdkDir, javafx ? 'fx-jdk' : 'jdk', getCacheVersionString(version), arch);
         }
         let extendedJavaHome = 'JAVA_HOME_' + version + '_' + arch;
         core.exportVariable('JAVA_HOME', toolPath);
@@ -162,7 +163,7 @@ function unzipJavaDownload(repoRoot, fileEnding, destinationFolder, extension) {
         }
     });
 }
-function getDownloadInfo(refs, version) {
+function getDownloadInfo(refs, version, javafx) {
     version = normalizeVersion(version);
     let extension = '';
     if (IS_WINDOWS) {
@@ -185,13 +186,18 @@ function getDownloadInfo(refs, version) {
         }
         // If we haven't returned, means we're looking at the correct platform
         let versions = ref.match(/jdk.*-/gi) || [];
+        if (javafx) { // If getting a JDK with JavaFX, the version prefix is different
+            versions = ref.match(/ca-fx-jdk.*-/gi) || [];
+        }
         if (versions.length > 1) {
             throw new Error(`Invalid ref received from https://static.azul.com/zulu/bin/: ${ref}`);
         }
         if (versions.length == 0) {
             return;
         }
-        const refVersion = versions[0].slice('jdk'.length, versions[0].length - 1);
+        // If getting a JDK with JavaFX, the version prefix is different
+        let jdkVersionPrefix = javafx ? 'ca-fx-jdk' : 'jdk';
+        const refVersion = versions[0].slice(jdkVersionPrefix.length, versions[0].length - 1);
         if (semver.satisfies(refVersion, version)) {
             versionMap.set(refVersion, 'https://static.azul.com/zulu/bin/' +
                 ref.slice('<a href="'.length, ref.length - '">'.length));

--- a/lib/setup-java.js
+++ b/lib/setup-java.js
@@ -1,9 +1,10 @@
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
@@ -27,7 +28,8 @@ function run() {
             }
             const arch = core.getInput('architecture', { required: true });
             const jdkFile = core.getInput('jdkFile', { required: false }) || '';
-            yield installer.getJava(version, arch, jdkFile);
+            const javafx = core.getInput('javafx', { required: false }) == 'true';
+            yield installer.getJava(version, arch, jdkFile, javafx);
             const matchersPath = path.join(__dirname, '..', '.github');
             console.log(`##[add-matcher]${path.join(matchersPath, 'java.json')}`);
         }

--- a/src/setup-java.ts
+++ b/src/setup-java.ts
@@ -10,8 +10,9 @@ async function run() {
     }
     const arch = core.getInput('architecture', {required: true});
     const jdkFile = core.getInput('jdkFile', {required: false}) || '';
+    const javafx = core.getInput('javafx', {required: false}) == 'true';
 
-    await installer.getJava(version, arch, jdkFile);
+    await installer.getJava(version, arch, jdkFile, javafx);
 
     const matchersPath = path.join(__dirname, '..', '.github');
     console.log(`##[add-matcher]${path.join(matchersPath, 'java.json')}`);


### PR DESCRIPTION
I've tested this on my own repository, and it works well.

I wasn't sure what to set the name of the toolcache to, so [I just changed it to](https://github.com/actions/setup-java/compare/master...airsquared:master#diff-8c84d074e67a54fc5a18692e0b853feaR35) `'fx-jdk'` for JDKs with JavaFX and `'jdk'` for JDKs without JavaFX (you might want to change this to something else).

To use this, just do:

```
- uses: airsquared/setup-java@master
  with:
    java-version: '1.8'
    javafx: true
```


Closes #18.