### PR TITLE
JDK 8 specific version help

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ steps:
 - uses: actions/checkout@latest
 - uses: actions/setup-java@v1
   with:
-    java-version: '9.0.4' // The JDK version to make available on the path. Takes a whole or semver Jdk version, or 1.x syntax (e.g. 1.8 => Jdk 8.x)
+    java-version: '9.0.4' // The JDK version to make available on the path. Takes a whole or semver Jdk version, or 1.x syntax (e.g. 1.8 => Jdk 8.x). To specify a specific version for JDK 8 or older use the following pattern (8.0.x)
     architecture: x64 // (x64 or x86) - defaults to x64
 - run: java -cp java HelloWorldApp
 ```


### PR DESCRIPTION
It wasn't clear to me how to specify a version for JDK8 or older. I tried `1.8.152` for example and that doesn't work. `8.0.152` is the correct syntax however that was confusing given `1.8` is supported. This should help those in my situation. If you feel it can be improved please let me know