### PR TITLE
Add 'latest' as alias for version 'x'

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Examples of version specifications that the java-version parameter will accept:
   
   e.g. ```8.0.x, >11.0.3, >=13.0.1, <8.0.212```
   
+  e.g. ```latest``` (same as ```x```)
+
 - An early access (EA) Java version
 
   e.g. ```14-ea, 15-ea```

--- a/dist/index.js
+++ b/dist/index.js
@@ -4873,6 +4873,11 @@ function getDownloadInfo(refs, version, javaPackage) {
     return { version: curVersion, url: curUrl };
 }
 function normalizeVersion(version) {
+    // 'latest' means the most recent of any JDK version
+    // semver won't match pre-release versions
+    if (version === 'latest') {
+        version = 'x';
+    }
     if (version.slice(0, 2) === '1.') {
         // Trim leading 1. for versions like 1.8
         version = version.slice(2);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -271,6 +271,12 @@ function getDownloadInfo(
 }
 
 function normalizeVersion(version: string): string {
+  // 'latest' means the most recent of any JDK version
+  // semver won't match pre-release versions
+  if (version === 'latest') {
+    version = 'x';
+  }
+
   if (version.slice(0, 2) === '1.') {
     // Trim leading 1. for versions like 1.8
     version = version.slice(2);


### PR DESCRIPTION
With the new release cycle a new JDK version is released once every six months. It may not seems like that often, but still adds overhead to update the build matrix with the latest JDK version. It is more convenient to set the build to run on the LTS versions that the project supports plus the latest JDK version. I've created a [proof of concept](https://github.com/plamentotev/plexus-archiver/pull/2/checks?check_run_id=580910207) workflow [1]. 

While it is possible to specify that you want the latest JDK version by using semver X-Ranges (like 'x' for example), 'latest' is more readable as explicitly states the intention. Also if you use the value from the build matrix in your job name, "JDK:latest" is better than "JDK:x".

 [1] The workflow uses my change as asked by the contributors guide