### PR TITLE
Normalize the version before it is looked up in the tool cache

### DIFF
--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -143,6 +143,20 @@ describe('installer tests', () => {
     return;
   });
 
+  it('Uses 1.x version of Java installed in cache', async () => {
+    const JavaDir: string = path.join(toolDir, 'jdk', '8.0.181', 'x64');
+    await io.mkdirP(JavaDir);
+    fs.writeFileSync(`${JavaDir}.complete`, 'hello');
+    // This will throw if it doesn't find it in the cache
+    await installer.getJava(
+      '1.8',
+      'x64',
+      'path shouldnt matter, found in cache',
+      'jdk'
+    );
+    return;
+  });
+
   it('Doesnt use version of Java that was only partially installed in cache', async () => {
     const JavaDir: string = path.join(toolDir, 'jdk', '251.0.0', 'x64');
     await io.mkdirP(JavaDir);

--- a/dist/index.js
+++ b/dist/index.js
@@ -4668,6 +4668,7 @@ if (!tempDirectory) {
 }
 function getJava(version, arch, jdkFile, javaPackage) {
     return __awaiter(this, void 0, void 0, function* () {
+        version = normalizeVersion(version);
         let toolPath = tc.find(javaPackage, version);
         if (toolPath) {
             core.debug(`Tool found in cache ${toolPath}`);
@@ -4805,7 +4806,6 @@ function unzipJavaDownload(repoRoot, fileEnding, destinationFolder, extension) {
     });
 }
 function getDownloadInfo(refs, version, javaPackage) {
-    version = normalizeVersion(version);
     let extension = '';
     if (IS_WINDOWS) {
         extension = `-win_x64.zip`;

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -32,6 +32,8 @@ export async function getJava(
   jdkFile: string,
   javaPackage: string
 ): Promise<void> {
+  version = normalizeVersion(version);
+
   let toolPath = tc.find(javaPackage, version);
 
   if (toolPath) {
@@ -190,7 +192,6 @@ function getDownloadInfo(
   version: string,
   javaPackage: string
 ): {version: string; url: string} {
-  version = normalizeVersion(version);
   let extension = '';
   if (IS_WINDOWS) {
     extension = `-win_x64.zip`;


### PR DESCRIPTION
Currently the resolved version is cached. For example something like 8.0.141. On other hand when a version is looked up in the cache the string provided by the user is used. This may lead to unexpected behavior. 1.8 will not match 8.0.141. Normalizing the version string before looking up in the tool cache will solve the problem. The normalized version (8.x) will match the entry in the cache as expected.

Normalizing the string in the beginning of the flow won't hurt as it is a valid version specification. What is more it the user can supply the normalized version directly so the code should be able to work with it.

Fixes #54 