### PR TITLE
Normalize extendedJavaHome environment variable

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -4742,6 +4742,10 @@ function getJava(version, arch, jdkFile, javaPackage) {
             toolPath = yield tc.cacheDir(jdkDir, javaPackage, getCacheVersionString(version), arch);
         }
         let extendedJavaHome = 'JAVA_HOME_' + version + '_' + arch;
+        // For portability reasons environment variables should only consist of
+        // uppercase letters, digits, and the underscore. Therefore we convert
+        // the extendedJavaHome variable to upper case and replace '.' symbols and
+        // any other non-alphanumeric characters with an underscore.
         extendedJavaHome = extendedJavaHome.toUpperCase().replace(/[^0-9A-Z_]/g, '_');
         core.exportVariable('JAVA_HOME', toolPath);
         core.exportVariable(extendedJavaHome, toolPath);

--- a/dist/index.js
+++ b/dist/index.js
@@ -4742,6 +4742,7 @@ function getJava(version, arch, jdkFile, javaPackage) {
             toolPath = yield tc.cacheDir(jdkDir, javaPackage, getCacheVersionString(version), arch);
         }
         let extendedJavaHome = 'JAVA_HOME_' + version + '_' + arch;
+        extendedJavaHome = extendedJavaHome.toUpperCase().replace(/[^0-9A-Z_]/g, '_');
         core.exportVariable('JAVA_HOME', toolPath);
         core.exportVariable(extendedJavaHome, toolPath);
         core.addPath(path.join(toolPath, 'bin'));

--- a/dist/index.js
+++ b/dist/index.js
@@ -4742,6 +4742,7 @@ function getJava(version, arch, jdkFile, javaPackage) {
             toolPath = yield tc.cacheDir(jdkDir, javaPackage, getCacheVersionString(version), arch);
         }
         let extendedJavaHome = 'JAVA_HOME_' + version + '_' + arch;
+        core.exportVariable(extendedJavaHome, toolPath); //TODO: remove for v2
         // For portability reasons environment variables should only consist of
         // uppercase letters, digits, and the underscore. Therefore we convert
         // the extendedJavaHome variable to upper case and replace '.' symbols and

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -87,6 +87,7 @@ export async function getJava(
   }
 
   let extendedJavaHome = 'JAVA_HOME_' + version + '_' + arch;
+  core.exportVariable(extendedJavaHome, toolPath); //TODO: remove for v2
   // For portability reasons environment variables should only consist of
   // uppercase letters, digits, and the underscore. Therefore we convert
   // the extendedJavaHome variable to upper case and replace '.' symbols and

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -87,6 +87,7 @@ export async function getJava(
   }
 
   let extendedJavaHome = 'JAVA_HOME_' + version + '_' + arch;
+  extendedJavaHome = extendedJavaHome.toUpperCase().replace(/[^0-9A-Z_]/g, '_');
   core.exportVariable('JAVA_HOME', toolPath);
   core.exportVariable(extendedJavaHome, toolPath);
   core.addPath(path.join(toolPath, 'bin'));

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -87,6 +87,10 @@ export async function getJava(
   }
 
   let extendedJavaHome = 'JAVA_HOME_' + version + '_' + arch;
+  // For portability reasons environment variables should only consist of
+  // uppercase letters, digits, and the underscore. Therefore we convert
+  // the extendedJavaHome variable to upper case and replace '.' symbols and
+  // any other non-alphanumeric characters with an underscore.
   extendedJavaHome = extendedJavaHome.toUpperCase().replace(/[^0-9A-Z_]/g, '_');
   core.exportVariable('JAVA_HOME', toolPath);
   core.exportVariable(extendedJavaHome, toolPath);


### PR DESCRIPTION
The extendedJavaHome environment variable contains `.` symbols in the version.  ~~This causes the environment variable to be ignored by the action runner.~~  This makes the variable inaccessible with `bash`'s `${VAR}` syntax . It's best to replace those and other non standard symbols with and underscore. 

For reference:
> Environment variable names used by the utilities in the Shell and Utilities volume of IEEE Std 1003.1-2001 consist solely of uppercase letters, digits, and the '_' (underscore) from the characters defined in Portable Character Set .

See also: https://unix.stackexchange.com/questions/93532/exporting-a-variable-with-dot-in-it