### PR TITLE
Add `overwrite-settings` to disable overwriting settings.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,9 @@ The two `settings.xml` files created from the above example look like the follow
 </servers>
 ```
 
-***NOTE: The `settings.xml` file is created in the Actions $HOME directory. If you have an existing `settings.xml` file at that location, it will be overwritten. See below for using the `settings-path` to change your `settings.xml` file location.***	
+***NOTE:*** The `settings.xml` file is created in the Actions $HOME directory. If you have an existing `settings.xml` file at that location, it will be overwritten. See below for using the `settings-path` to change your `settings.xml` file location.
+
+If you don't want to overwrite the `settings.xml` file, you can set `overwrite-settings: false`.
 
 See the help docs on [Publishing a Package](https://help.github.com/en/github/managing-packages-with-github-packages/configuring-apache-maven-for-use-with-github-packages#publishing-a-package) for more information on the `pom.xml` file.
 

--- a/__tests__/auth.test.ts
+++ b/__tests__/auth.test.ts
@@ -86,6 +86,23 @@ describe('auth tests', () => {
     );
   }, 100000);
 
+  it('does not overwrite existing settings.xml files', async () => {
+    const id = 'packages';
+    const username = 'USERNAME';
+    const password = 'PASSWORD';
+
+    fs.mkdirSync(m2Dir, {recursive: true});
+    fs.writeFileSync(settingsFile, 'FAKE FILE');
+    expect(fs.existsSync(m2Dir)).toBe(true);
+    expect(fs.existsSync(settingsFile)).toBe(true);
+
+    await auth.configAuthentication(id, username, password, false);
+
+    expect(fs.existsSync(m2Dir)).toBe(true);
+    expect(fs.existsSync(settingsFile)).toBe(true);
+    expect(fs.readFileSync(settingsFile, 'utf-8')).toEqual('FAKE FILE');
+  }, 100000);
+
   it('does not create settings.xml without required parameters', async () => {
     await auth.configAuthentication('FOO');
 
@@ -94,6 +111,7 @@ describe('auth tests', () => {
     expect(fs.readFileSync(settingsFile, 'utf-8')).toEqual(
       auth.generate('FOO', auth.DEFAULT_USERNAME, auth.DEFAULT_PASSWORD)
     );
+    fs.unlinkSync(settingsFile);
 
     await auth.configAuthentication(undefined, 'BAR', undefined);
 
@@ -102,6 +120,7 @@ describe('auth tests', () => {
     expect(fs.readFileSync(settingsFile, 'utf-8')).toEqual(
       auth.generate(auth.DEFAULT_ID, 'BAR', auth.DEFAULT_PASSWORD)
     );
+    fs.unlinkSync(settingsFile);
 
     await auth.configAuthentication(undefined, undefined, 'BAZ');
 
@@ -110,6 +129,7 @@ describe('auth tests', () => {
     expect(fs.readFileSync(settingsFile, 'utf-8')).toEqual(
       auth.generate(auth.DEFAULT_ID, auth.DEFAULT_USERNAME, 'BAZ')
     );
+    fs.unlinkSync(settingsFile);
 
     await auth.configAuthentication();
 

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,9 @@ inputs:
   settings-path:
     description: 'Path to where the settings.xml file will be written. Default is ~/.m2.'
     required: false
+  overwrite-settings:
+    description: 'Overwrite the settings.xml file if it exists. Default is "true".'
+    required: false
 outputs:
   path:
     description: 'Path to where the java environment has been installed (same as $JAVA_HOME)'

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -14,7 +14,8 @@ export const DEFAULT_PASSWORD = 'GITHUB_TOKEN';
 export async function configAuthentication(
   id = DEFAULT_ID,
   username = DEFAULT_USERNAME,
-  password = DEFAULT_PASSWORD
+  password = DEFAULT_PASSWORD,
+  overwriteSettings = true
 ) {
   console.log(
     `creating ${SETTINGS_FILE} with server-id: ${id};`,
@@ -28,7 +29,7 @@ export async function configAuthentication(
   );
   await io.mkdirP(directory);
   core.debug(`created directory ${directory}`);
-  await write(directory, generate(id, username, password));
+  await write(directory, generate(id, username, password), overwriteSettings);
 }
 
 function escapeXML(value: string) {
@@ -59,12 +60,20 @@ export function generate(
   `;
 }
 
-async function write(directory: string, settings: string) {
+async function write(
+  directory: string,
+  settings: string,
+  overwriteSettings: boolean
+) {
   const location = path.join(directory, SETTINGS_FILE);
-  if (fs.existsSync(location)) {
+  const exists = fs.existsSync(location);
+  if (exists && overwriteSettings) {
     console.warn(`overwriting existing file ${location}`);
-  } else {
+  } else if (!exists) {
     console.log(`writing ${location}`);
+  } else {
+    console.log(`not overwriting existing file ${location}`);
+    return;
   }
 
   return fs.writeFileSync(location, settings, {

--- a/src/setup-java.ts
+++ b/src/setup-java.ts
@@ -23,8 +23,15 @@ async function run() {
       core.getInput('server-username', {required: false}) || undefined;
     const password =
       core.getInput('server-password', {required: false}) || undefined;
+    const overwriteSettings =
+      core.getInput('overwrite-settings', {required: false}) || 'true';
 
-    await auth.configAuthentication(id, username, password);
+    await auth.configAuthentication(
+      id,
+      username,
+      password,
+      overwriteSettings === 'true'
+    );
   } catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
In some scenarios there's already a valid Maven settings file which shouldn't or cannot be overwritten by actions/setup-java.

The `overwrite-settings` (default: `true`) configuration setting enables users to disable the generation of the Maven settings file by actions/setup-java.

Closes #79
Refs joschi/setup-jdk#11