### PR TITLE
✨ Support loading GPG private key from file path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ If `gpg-private-key` input is provided, the private key will be written to a fil
 
 See the help docs on [Publishing a Package](https://help.github.com/en/github/managing-packages-with-github-packages/configuring-apache-maven-for-use-with-github-packages#publishing-a-package) for more information on the `pom.xml` file.
 
+Alternatively, you can use `gpg-private-key-path` to point to a key file.
+
 ## Publishing using Gradle
 ```yaml
 jobs:

--- a/__tests__/gpg.test.ts
+++ b/__tests__/gpg.test.ts
@@ -1,4 +1,5 @@
 import path = require('path');
+import fs = require('fs');
 import io = require('@actions/io');
 import exec = require('@actions/exec');
 
@@ -30,6 +31,23 @@ describe('gpg tests', () => {
     it('attempts to import private key and returns null key id on failure', async () => {
       const privateKey = 'KEY CONTENTS';
       const keyId = await gpg.importKey(privateKey);
+
+      expect(keyId).toBeNull();
+
+      expect(exec.exec).toHaveBeenCalledWith(
+        'gpg',
+        expect.anything(),
+        expect.anything()
+      );
+    });
+  });
+
+  describe('importKeyFromPath', () => {
+    it('attempts to import private key from path and returns null key id on failure', async () => {
+      const privateKey = 'KEY CONTENTS';
+      const privateKeyPath = path.join(tempDir, 'test.asc');
+      fs.writeFileSync(privateKeyPath, privateKey);
+      const keyId = await gpg.importKeyFromPath(privateKeyPath);
 
       expect(keyId).toBeNull();
 

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,9 @@ inputs:
   gpg-private-key:
     description: 'GPG private key to import. Default is empty string.'
     required: false
+  gpg-private-key-path:
+    description: 'Path to the GPG private key to import. Default is empty string. Overriden by gpg-private-key'
+    required: false
   gpg-passphrase:
     description: 'Environment variable name for the GPG private key passphrase. Default is
        $GPG_PASSPHRASE.'

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -963,8 +963,10 @@ exports.INPUT_SERVER_ID = 'server-id';
 exports.INPUT_SERVER_USERNAME = 'server-username';
 exports.INPUT_SERVER_PASSWORD = 'server-password';
 exports.INPUT_SETTINGS_PATH = 'settings-path';
+exports.INPUT_GPG_PRIVATE_KEY_PATH = 'gpg-private-key-path';
 exports.INPUT_GPG_PRIVATE_KEY = 'gpg-private-key';
 exports.INPUT_GPG_PASSPHRASE = 'gpg-passphrase';
+exports.INPUT_DEFAULT_GPG_PRIVATE_KEY_PATH = undefined;
 exports.INPUT_DEFAULT_GPG_PRIVATE_KEY = undefined;
 exports.INPUT_DEFAULT_GPG_PASSPHRASE = 'GPG_PASSPHRASE';
 exports.STATE_GPG_PRIVATE_KEY_FINGERPRINT = 'gpg-private-key-fingerprint';
@@ -1627,6 +1629,15 @@ function importKey(privateKey) {
             encoding: 'utf-8',
             flag: 'w'
         });
+        const keyFingerprint = yield importKeyFromPath(exports.PRIVATE_KEY_FILE);
+        yield io.rmRF(exports.PRIVATE_KEY_FILE);
+        return keyFingerprint;
+    });
+}
+exports.importKey = importKey;
+function importKeyFromPath(privateKeyPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+        console.log(`from path: ${privateKeyPath}`);
         let output = '';
         const options = {
             silent: true,
@@ -1636,19 +1647,12 @@ function importKey(privateKey) {
                 }
             }
         };
-        yield exec.exec('gpg', [
-            '--batch',
-            '--import-options',
-            'import-show',
-            '--import',
-            exports.PRIVATE_KEY_FILE
-        ], options);
-        yield io.rmRF(exports.PRIVATE_KEY_FILE);
+        yield exec.exec('gpg', ['--batch', '--import-options', 'import-show', '--import', privateKeyPath], options);
         const match = output.match(PRIVATE_KEY_FINGERPRINT_REGEX);
         return match && match[0];
     });
 }
-exports.importKey = importKey;
+exports.importKeyFromPath = importKeyFromPath;
 function deleteKey(keyFingerprint) {
     return __awaiter(this, void 0, void 0, function* () {
         yield exec.exec('gpg', ['--batch', '--yes', '--delete-secret-keys', keyFingerprint], { silent: true });

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -25663,8 +25663,10 @@ exports.INPUT_SERVER_ID = 'server-id';
 exports.INPUT_SERVER_USERNAME = 'server-username';
 exports.INPUT_SERVER_PASSWORD = 'server-password';
 exports.INPUT_SETTINGS_PATH = 'settings-path';
+exports.INPUT_GPG_PRIVATE_KEY_PATH = 'gpg-private-key-path';
 exports.INPUT_GPG_PRIVATE_KEY = 'gpg-private-key';
 exports.INPUT_GPG_PASSPHRASE = 'gpg-passphrase';
+exports.INPUT_DEFAULT_GPG_PRIVATE_KEY_PATH = undefined;
 exports.INPUT_DEFAULT_GPG_PRIVATE_KEY = undefined;
 exports.INPUT_DEFAULT_GPG_PASSPHRASE = 'GPG_PASSPHRASE';
 exports.STATE_GPG_PRIVATE_KEY_FINGERPRINT = 'gpg-private-key-fingerprint';
@@ -28699,18 +28701,26 @@ function run() {
             const password = core.getInput(constants.INPUT_SERVER_PASSWORD, {
                 required: false
             });
+            const gpgPrivateKeyPath = core.getInput(constants.INPUT_GPG_PRIVATE_KEY_PATH, { required: false }) ||
+                constants.INPUT_DEFAULT_GPG_PRIVATE_KEY_PATH;
             const gpgPrivateKey = core.getInput(constants.INPUT_GPG_PRIVATE_KEY, { required: false }) ||
                 constants.INPUT_DEFAULT_GPG_PRIVATE_KEY;
             const gpgPassphrase = core.getInput(constants.INPUT_GPG_PASSPHRASE, { required: false }) ||
-                (gpgPrivateKey ? constants.INPUT_DEFAULT_GPG_PASSPHRASE : undefined);
+                (gpgPrivateKey || gpgPrivateKeyPath
+                    ? constants.INPUT_DEFAULT_GPG_PASSPHRASE
+                    : undefined);
             if (gpgPrivateKey) {
                 core.setSecret(gpgPrivateKey);
             }
             yield auth.configAuthentication(id, username, password, gpgPassphrase);
-            if (gpgPrivateKey) {
+            if (gpgPrivateKey || gpgPrivateKeyPath) {
                 core.info('importing private key');
-                const keyFingerprint = (yield gpg.importKey(gpgPrivateKey)) || '';
-                core.saveState(constants.STATE_GPG_PRIVATE_KEY_FINGERPRINT, keyFingerprint);
+                const keyFingerprint = gpgPrivateKey
+                    ? yield gpg.importKey(gpgPrivateKey)
+                    : gpgPrivateKeyPath
+                        ? yield gpg.importKeyFromPath(gpgPrivateKeyPath)
+                        : null;
+                core.saveState(constants.STATE_GPG_PRIVATE_KEY_FINGERPRINT, keyFingerprint || '');
             }
         }
         catch (error) {
@@ -32612,6 +32622,15 @@ function importKey(privateKey) {
             encoding: 'utf-8',
             flag: 'w'
         });
+        const keyFingerprint = yield importKeyFromPath(exports.PRIVATE_KEY_FILE);
+        yield io.rmRF(exports.PRIVATE_KEY_FILE);
+        return keyFingerprint;
+    });
+}
+exports.importKey = importKey;
+function importKeyFromPath(privateKeyPath) {
+    return __awaiter(this, void 0, void 0, function* () {
+        console.log(`from path: ${privateKeyPath}`);
         let output = '';
         const options = {
             silent: true,
@@ -32621,19 +32640,12 @@ function importKey(privateKey) {
                 }
             }
         };
-        yield exec.exec('gpg', [
-            '--batch',
-            '--import-options',
-            'import-show',
-            '--import',
-            exports.PRIVATE_KEY_FILE
-        ], options);
-        yield io.rmRF(exports.PRIVATE_KEY_FILE);
+        yield exec.exec('gpg', ['--batch', '--import-options', 'import-show', '--import', privateKeyPath], options);
         const match = output.match(PRIVATE_KEY_FINGERPRINT_REGEX);
         return match && match[0];
     });
 }
-exports.importKey = importKey;
+exports.importKeyFromPath = importKeyFromPath;
 function deleteKey(keyFingerprint) {
     return __awaiter(this, void 0, void 0, function* () {
         yield exec.exec('gpg', ['--batch', '--yes', '--delete-secret-keys', keyFingerprint], { silent: true });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,9 +7,11 @@ export const INPUT_SERVER_ID = 'server-id';
 export const INPUT_SERVER_USERNAME = 'server-username';
 export const INPUT_SERVER_PASSWORD = 'server-password';
 export const INPUT_SETTINGS_PATH = 'settings-path';
+export const INPUT_GPG_PRIVATE_KEY_PATH = 'gpg-private-key-path';
 export const INPUT_GPG_PRIVATE_KEY = 'gpg-private-key';
 export const INPUT_GPG_PASSPHRASE = 'gpg-passphrase';
 
+export const INPUT_DEFAULT_GPG_PRIVATE_KEY_PATH = undefined;
 export const INPUT_DEFAULT_GPG_PRIVATE_KEY = undefined;
 export const INPUT_DEFAULT_GPG_PASSPHRASE = 'GPG_PASSPHRASE';
 

--- a/src/gpg.ts
+++ b/src/gpg.ts
@@ -15,6 +15,15 @@ export async function importKey(privateKey: string) {
     flag: 'w'
   });
 
+  const keyFingerprint = await importKeyFromPath(PRIVATE_KEY_FILE);
+
+  await io.rmRF(PRIVATE_KEY_FILE);
+
+  return keyFingerprint;
+}
+
+export async function importKeyFromPath(privateKeyPath: string) {
+  console.log(`from path: ${privateKeyPath}`);
   let output = '';
 
   const options: ExecOptions = {
@@ -28,17 +37,9 @@ export async function importKey(privateKey: string) {
 
   await exec.exec(
     'gpg',
-    [
-      '--batch',
-      '--import-options',
-      'import-show',
-      '--import',
-      PRIVATE_KEY_FILE
-    ],
+    ['--batch', '--import-options', 'import-show', '--import', privateKeyPath],
     options
   );
-
-  await io.rmRF(PRIVATE_KEY_FILE);
 
   const match = output.match(PRIVATE_KEY_FINGERPRINT_REGEX);
   return match && match[0];


### PR DESCRIPTION
Currently, GPG keys must be passed as an action input, which is basically an environment variable named `INPUT_GPG_PRIVATE_KEY`. Environment variables do not support arbitrary characters (newlines, null, etc...), so the input must be pre-encoded, conventionally in Base64. Say you decode it with `base64 --decode`, you still have to [process it](https://github.community/t/set-output-truncates-multiline-strings/16852) to encode the value to replace special characters before passing it to `echo ::set-output...`, in a very error-prone and leaky way.

This pull request provides an alternative way to load a GPG key from a file.

Summoning @jaredpetersen as they were the original contributor for GPG support.