### PR TITLE
Restrict blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a bug report
 title: ''
-labels: needs triage
+labels: bug, needs triage
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a bug report
 title: ''
-labels: bug
+labels: needs triage
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: feature request
+labels: feature request, needs triage
 assignees: ''
 ---
 


### PR DESCRIPTION
**Description:**
In scope of this pull request we add such logic as 
- disable creating blank issue
- add `needs triage` label in the first time issue is created

**Related issue:** https://github.com/actions/virtual-environments-internal/issues/1700

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.