### PR TITLE
Add "overwrite-settings" input parameter

### DIFF
--- a/.github/workflows/e2e-publishing.yml
+++ b/.github/workflows/e2e-publishing.yml
@@ -82,8 +82,8 @@ jobs:
           $xmlPath = Join-Path $HOME ".m2" "settings.xml"
           Get-Content $xmlPath | ForEach-Object { Write-Host $_ }
 
-          $xml = Get-Content $xmlPath -Raw
-          if ($raw -notlike '*maven*') {
+          $content = Get-Content $xmlPath -Raw
+          if ($content -notlike '*maven*') {
             throw "settings.xml file is not overwritten"
           }
   
@@ -120,7 +120,7 @@ jobs:
           $content = Get-Content -Path $xmlPath -Raw
           Write-Host $content
 
-          if ($content -ne "Fake_XML") {
+          if ($content -notlike "*Fake_XML*") {
             throw "settings.xml file was overwritten but it should not be"
           }
 

--- a/.github/workflows/e2e-publishing.yml
+++ b/.github/workflows/e2e-publishing.yml
@@ -52,7 +52,7 @@ jobs:
           }
 
   test-publishing-overwrite:
-    name: Validate settings.xml is not overwritten if flag is false
+    name: settings.xml is overwritten if flag is true
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -63,7 +63,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Create fake settings.xml
         run: |
-          $xmlPath = Join-Path $HOME ".m2" "settings.xml"
+          $xmlDirectory = Join-Path $HOME ".m2"
+          $xmlPath = Join-Path $xmlDirectory "settings.xml"
+          New-Item -Path $xmlDirectory -ItemType Directory
           Set-Content -Path $xmlPath -Value "Fake_XML"
       - name: setup-java
         uses: ./
@@ -86,7 +88,7 @@ jobs:
           }
   
   test-publishing-skip-overwrite:
-    name: Validate settings.xml is not overwritten if flag is false
+    name: settings.xml is not overwritten if flag is false
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -97,7 +99,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Create fake settings.xml
         run: |
-          $xmlPath = Join-Path $HOME ".m2" "settings.xml"
+          $xmlDirectory = Join-Path $HOME ".m2"
+          $xmlPath = Join-Path $xmlDirectory "settings.xml"
+          New-Item -Path $xmlDirectory -ItemType Directory
           Set-Content -Path $xmlPath -Value "Fake_XML"
       - name: setup-java
         uses: ./
@@ -119,7 +123,7 @@ jobs:
           }
 
   test-publishing-custom-location:
-    name: Validate settings.xml in custom location
+    name: settings.xml in custom location
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e-publishing.yml
+++ b/.github/workflows/e2e-publishing.yml
@@ -83,7 +83,7 @@ jobs:
           Get-Content $xmlPath | ForEach-Object { Write-Host $_ }
 
           $xml = Get-Content $xmlPath -Raw
-          if ($raw -notlike 'maven') {
+          if ($raw -notlike '*maven*') {
             throw "settings.xml file is not overwritten"
           }
   
@@ -118,6 +118,8 @@ jobs:
         run: |
           $xmlPath = Join-Path $HOME ".m2" "settings.xml"
           $content = Get-Content -Path $xmlPath -Raw
+          Write-Host $content
+
           if ($content -ne "Fake_XML") {
             throw "settings.xml file was overwritten but it should not be"
           }

--- a/.github/workflows/e2e-publishing.yml
+++ b/.github/workflows/e2e-publishing.yml
@@ -11,6 +11,10 @@ on:
     paths-ignore:
       - '**.md'
 
+defaults:
+  run:
+    shell: pwsh
+
 jobs:
   setup-java-publishing:
     name: Validate settings.xml
@@ -34,12 +38,7 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Validate settings.xml
         run: |
-          $homePath = $env:USERPROFILE
-          if (-not $homePath) {
-            $homePath = $env:HOME
-          }
-          $xmlPath = Join-Path $homePath ".m2" "settings.xml"
-
+          $xmlPath = Join-Path $HOME ".m2" "settings.xml"
           Get-Content $xmlPath | ForEach-Object { Write-Host $_ }
 
           [xml]$xml = Get-Content $xmlPath
@@ -51,7 +50,73 @@ jobs:
           if (($servers[1].id -ne 'gpg.passphrase') -or ($servers[1].passphrase -ne '${env.MAVEN_GPG_PASSPHRASE}')) {
             throw "Generated XML file is incorrect"
           }
-        shell: pwsh
+
+  test-publishing-overwrite:
+    name: Validate settings.xml is not overwritten if flag is false
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Create fake settings.xml
+        run: |
+          $xmlPath = Join-Path $HOME ".m2" "settings.xml"
+          Set-Content -Path $xmlPath -Value "Fake_XML"
+      - name: setup-java
+        uses: ./
+        id: setup-java
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+          server-id: maven
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_CENTRAL_TOKEN
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      - name: Validate settings.xml is overwritten
+        run: |
+          $xmlPath = Join-Path $HOME ".m2" "settings.xml"
+          Get-Content $xmlPath | ForEach-Object { Write-Host $_ }
+
+          $xml = Get-Content $xmlPath -Raw
+          if ($raw -notlike 'maven') {
+            throw "settings.xml file is not overwritten"
+          }
+  
+  test-publishing-skip-overwrite:
+    name: Validate settings.xml is not overwritten if flag is false
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Create fake settings.xml
+        run: |
+          $xmlPath = Join-Path $HOME ".m2" "settings.xml"
+          Set-Content -Path $xmlPath -Value "Fake_XML"
+      - name: setup-java
+        uses: ./
+        id: setup-java
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+          server-id: maven
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_CENTRAL_TOKEN
+          overwrite-settings: false
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      - name: Validate that settings.xml is not overwritten
+        run: |
+          $xmlPath = Join-Path $HOME ".m2" "settings.xml"
+          $content = Get-Content -Path $xmlPath -Raw
+          if ($content -ne "Fake_XML") {
+            throw "settings.xml file was overwritten but it should not be"
+          }
 
   test-publishing-custom-location:
     name: Validate settings.xml in custom location
@@ -80,4 +145,3 @@ jobs:
           if (-not (Test-Path $path)) {
             throw "settings.xml file is not found in expected location"
           }
-        shell: pwsh

--- a/README.md
+++ b/README.md
@@ -20,12 +20,24 @@ This action provides the following functionality for GitHub Actions runners:
 Inputs `java-version` and `distribution` are mandatory. See [Supported distributions](../README.md#Supported-distributions) section for a list of available options.
 
 ### Basic
+**Adopt OpenJDK**
 ```yaml
 steps:
 - uses: actions/checkout@v2
 - uses: actions/setup-java@v2-preview
   with:
     distribution: 'adopt' # See 'Supported distributions' for available options
+    java-version: '11'
+- run: java -cp java HelloWorldApp
+```
+
+**Zulu OpenJDK**
+```yaml
+steps:
+- uses: actions/checkout@v2
+- uses: actions/setup-java@v2-preview
+  with:
+    distribution: 'zulu' # See 'Supported distributions' for available options
     java-version: '11'
 - run: java -cp java HelloWorldApp
 ```

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,10 @@ inputs:
   settings-path:
     description: 'Path to where the settings.xml file will be written. Default is ~/.m2.'
     required: false
+  overwrite-settings:
+    description: 'Overwrite the settings.xml file if it exists. Default is "true".'
+    required: false
+    default: true
   gpg-private-key:
     description: 'GPG private key to import. Default is empty string.'
     required: false

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -2685,17 +2685,22 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getToolcachePath = exports.isVersionSatisfies = exports.getDownloadArchiveExtension = exports.extractJdkFile = exports.getVersionFromToolcachePath = exports.getTempDir = void 0;
+exports.getToolcachePath = exports.isVersionSatisfies = exports.getDownloadArchiveExtension = exports.extractJdkFile = exports.getVersionFromToolcachePath = exports.getBooleanInput = exports.getTempDir = void 0;
 const os_1 = __importDefault(__webpack_require__(87));
 const path_1 = __importDefault(__webpack_require__(622));
 const fs = __importStar(__webpack_require__(747));
 const semver = __importStar(__webpack_require__(876));
+const core = __importStar(__webpack_require__(470));
 const tc = __importStar(__webpack_require__(533));
 function getTempDir() {
     let tempDirectory = process.env['RUNNER_TEMP'] || os_1.default.tmpdir();
     return tempDirectory;
 }
 exports.getTempDir = getTempDir;
+function getBooleanInput(inputName, defaultValue = false) {
+    return (core.getInput(inputName) || String(defaultValue)).toUpperCase() === 'TRUE';
+}
+exports.getBooleanInput = getBooleanInput;
 function getVersionFromToolcachePath(toolPath) {
     if (toolPath) {
         return path_1.default.basename(path_1.default.dirname(toolPath));
@@ -6824,7 +6829,7 @@ function isUnixExecutable(stats) {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.STATE_GPG_PRIVATE_KEY_FINGERPRINT = exports.INPUT_DEFAULT_GPG_PASSPHRASE = exports.INPUT_DEFAULT_GPG_PRIVATE_KEY = exports.INPUT_GPG_PASSPHRASE = exports.INPUT_GPG_PRIVATE_KEY = exports.INPUT_SETTINGS_PATH = exports.INPUT_SERVER_PASSWORD = exports.INPUT_SERVER_USERNAME = exports.INPUT_SERVER_ID = exports.INPUT_JDK_FILE = exports.INPUT_DISTRIBUTION = exports.INPUT_JAVA_PACKAGE = exports.INPUT_ARCHITECTURE = exports.INPUT_JAVA_VERSION = exports.MACOS_JAVA_CONTENT_POSTFIX = void 0;
+exports.STATE_GPG_PRIVATE_KEY_FINGERPRINT = exports.INPUT_DEFAULT_GPG_PASSPHRASE = exports.INPUT_DEFAULT_GPG_PRIVATE_KEY = exports.INPUT_GPG_PASSPHRASE = exports.INPUT_GPG_PRIVATE_KEY = exports.INPUT_OVERWRITE_SETTINGS = exports.INPUT_SETTINGS_PATH = exports.INPUT_SERVER_PASSWORD = exports.INPUT_SERVER_USERNAME = exports.INPUT_SERVER_ID = exports.INPUT_JDK_FILE = exports.INPUT_DISTRIBUTION = exports.INPUT_JAVA_PACKAGE = exports.INPUT_ARCHITECTURE = exports.INPUT_JAVA_VERSION = exports.MACOS_JAVA_CONTENT_POSTFIX = void 0;
 exports.MACOS_JAVA_CONTENT_POSTFIX = 'Contents/Home';
 exports.INPUT_JAVA_VERSION = 'java-version';
 exports.INPUT_ARCHITECTURE = 'architecture';
@@ -6835,6 +6840,7 @@ exports.INPUT_SERVER_ID = 'server-id';
 exports.INPUT_SERVER_USERNAME = 'server-username';
 exports.INPUT_SERVER_PASSWORD = 'server-password';
 exports.INPUT_SETTINGS_PATH = 'settings-path';
+exports.INPUT_OVERWRITE_SETTINGS = 'overwrite-settings';
 exports.INPUT_GPG_PRIVATE_KEY = 'gpg-private-key';
 exports.INPUT_GPG_PASSPHRASE = 'gpg-passphrase';
 exports.INPUT_DEFAULT_GPG_PRIVATE_KEY = undefined;

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -13341,7 +13341,7 @@ function write(directory, settings, overwriteSettings) {
             core.info(`Writing to ${location}`);
         }
         else {
-            core.info(`Skipping generation '${location}' - it already exists and overwriting is not required`);
+            core.info(`Skipping generation ${location} because file already exists and overwriting is not required`);
             return;
         }
         return fs.writeFileSync(location, settings, {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -13272,6 +13272,7 @@ function configureAuthentication() {
         const username = core.getInput(constants.INPUT_SERVER_USERNAME);
         const password = core.getInput(constants.INPUT_SERVER_PASSWORD);
         const settingsDirectory = core.getInput(constants.INPUT_SETTINGS_PATH) || path.join(os.homedir(), exports.M2_DIR);
+        // Consider setting overwriteSettings = false by default in next major release
         const overwriteSettings = util_1.getBooleanInput(constants.INPUT_OVERWRITE_SETTINGS, true);
         const gpgPrivateKey = core.getInput(constants.INPUT_GPG_PRIVATE_KEY) || constants.INPUT_DEFAULT_GPG_PRIVATE_KEY;
         const gpgPassphrase = core.getInput(constants.INPUT_GPG_PASSPHRASE) ||

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -13272,7 +13272,6 @@ function configureAuthentication() {
         const username = core.getInput(constants.INPUT_SERVER_USERNAME);
         const password = core.getInput(constants.INPUT_SERVER_PASSWORD);
         const settingsDirectory = core.getInput(constants.INPUT_SETTINGS_PATH) || path.join(os.homedir(), exports.M2_DIR);
-        // Consider setting overwriteSettings = false by default in next major release
         const overwriteSettings = util_1.getBooleanInput(constants.INPUT_OVERWRITE_SETTINGS, true);
         const gpgPrivateKey = core.getInput(constants.INPUT_GPG_PRIVATE_KEY) || constants.INPUT_DEFAULT_GPG_PRIVATE_KEY;
         const gpgPassphrase = core.getInput(constants.INPUT_GPG_PASSPHRASE) ||

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -206,7 +206,9 @@ The two `settings.xml` files created from the above example look like the follow
 </settings>
 ```
 
-***NOTE: The `settings.xml` file is created in the Actions $HOME/.m2 directory. If you have an existing `settings.xml` file at that location, it will be overwritten. See below for using the `settings-path` to change your `settings.xml` file location.***
+***NOTE***: The `settings.xml` file is created in the Actions $HOME/.m2 directory. If you have an existing `settings.xml` file at that location, it will be overwritten. See below for using the `settings-path` to change your `settings.xml` file location.
+
+If you don't want to overwrite the `settings.xml` file, you can set `overwrite-settings: false`
 
 ### Extra setup for pom.xml:
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -114,7 +114,7 @@ async function write(directory: string, settings: string, overwriteSettings: boo
     core.info(`Writing to ${location}`);
   } else {
     core.info(
-      `Skipping generation '${location}' - it already exists and overwriting is not required`
+      `Skipping generation ${location} because file already exists and overwriting is not required`
     );
     return;
   }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -19,6 +19,7 @@ export async function configureAuthentication() {
   const password = core.getInput(constants.INPUT_SERVER_PASSWORD);
   const settingsDirectory =
     core.getInput(constants.INPUT_SETTINGS_PATH) || path.join(os.homedir(), M2_DIR);
+  // Consider setting overwriteSettings = false by default in next major release
   const overwriteSettings = getBooleanInput(constants.INPUT_OVERWRITE_SETTINGS, true);
   const gpgPrivateKey =
     core.getInput(constants.INPUT_GPG_PRIVATE_KEY) || constants.INPUT_DEFAULT_GPG_PRIVATE_KEY;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -19,7 +19,6 @@ export async function configureAuthentication() {
   const password = core.getInput(constants.INPUT_SERVER_PASSWORD);
   const settingsDirectory =
     core.getInput(constants.INPUT_SETTINGS_PATH) || path.join(os.homedir(), M2_DIR);
-  // Consider setting overwriteSettings = false by default in next major release
   const overwriteSettings = getBooleanInput(constants.INPUT_OVERWRITE_SETTINGS, true);
   const gpgPrivateKey =
     core.getInput(constants.INPUT_GPG_PRIVATE_KEY) || constants.INPUT_DEFAULT_GPG_PRIVATE_KEY;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,7 @@ export const INPUT_SERVER_ID = 'server-id';
 export const INPUT_SERVER_USERNAME = 'server-username';
 export const INPUT_SERVER_PASSWORD = 'server-password';
 export const INPUT_SETTINGS_PATH = 'settings-path';
+export const INPUT_OVERWRITE_SETTINGS = 'overwrite-settings';
 export const INPUT_GPG_PRIVATE_KEY = 'gpg-private-key';
 export const INPUT_GPG_PASSPHRASE = 'gpg-passphrase';
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,12 +2,17 @@ import os from 'os';
 import path from 'path';
 import * as fs from 'fs';
 import * as semver from 'semver';
+import * as core from '@actions/core';
 
 import * as tc from '@actions/tool-cache';
 export function getTempDir() {
   let tempDirectory = process.env['RUNNER_TEMP'] || os.tmpdir();
 
   return tempDirectory;
+}
+
+export function getBooleanInput(inputName: string, defaultValue: boolean = false) {
+  return (core.getInput(inputName) || String(defaultValue)).toUpperCase() === 'TRUE';
 }
 
 export function getVersionFromToolcachePath(toolPath: string) {


### PR DESCRIPTION
**Description:**
In some scenarios there's already a valid Maven settings file which shouldn't or cannot be overwritten by actions/setup-java.

The `overwrite-settings` (default: `true`) configuration setting enables users to disable the generation of the Maven settings file by actions/setup-java.

This pull-request was inspired by https://github.com/actions/setup-java/pull/82, just adopt changes to V2-preview branch.

Included changes:
- Add `overwrite-settings` input
- Add e2e and unit tests to cover new logic
- Implement `getBooleanInput` util func based on https://github.com/actions/checkout/blob/main/src/input-helper.ts#L118
- Move logic to read settingsDirectory to `configureAuthentication` function to have all related logic at the same place.
- Update README to include usage example for both Zulu and Adopt

**Related issue:**
Closes https://github.com/actions/setup-java/issues/79

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.