### PR TITLE
Add breaking change warning to 'main' branch

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -28814,6 +28814,7 @@ function run() {
                 const keyFingerprint = (yield gpg.importKey(gpgPrivateKey)) || '';
                 core.saveState(constants.STATE_GPG_PRIVATE_KEY_FINGERPRINT, keyFingerprint);
             }
+            core.warning(`All setup-java actions pinned to 'main' branch will fail on 5th April 2021. Please explicitly reference your action to the 'v1' tag ('actions/setup-java@v1') to avoid build failures. Find more details in https://github.com/actions/setup-java/issues/137`);
         }
         catch (error) {
             core.setFailed(error.message);

--- a/src/setup-java.ts
+++ b/src/setup-java.ts
@@ -55,6 +55,10 @@ async function run() {
         keyFingerprint
       );
     }
+
+    core.warning(
+      `All setup-java actions pinned to 'main' branch will fail on 5th April 2021. Please explicitly reference your action to the 'v1' tag ('actions/setup-java@v1') to avoid build failures. Find more details in https://github.com/actions/setup-java/issues/137`
+    );
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/src/setup-java.ts
+++ b/src/setup-java.ts
@@ -57,7 +57,7 @@ async function run() {
     }
 
     core.warning(
-      `All setup-java actions pinned to 'main' branch will fail on 5th April 2021. Please explicitly reference your action to the 'v1' tag ('actions/setup-java@v1') to avoid build failures. Find more details in https://github.com/actions/setup-java/issues/137`
+      `All setup-java actions pinned to the 'main' branch will fail on April 5th 2021. Please explicitly reference your action with the 'v1' tag ('actions/setup-java@v1') to avoid build failures. Find more details at https://github.com/actions/setup-java/issues/137`
     );
   } catch (error) {
     core.setFailed(error.message);


### PR DESCRIPTION
**Description:**
This PR adds warning for people who pinned their workflows to `main` branch.
We are not going to cut new release from main branch with these changes so this warning won't affect `v1` customers.
This warning will be removed at 5th April when we push `v2-preview` branch to `main`

**Related issue:**
https://github.com/actions/setup-java/issues/137