### PR TITLE
Add "Contents/Home" postfix on macOS if provider creates it

### DIFF
--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -33,6 +33,15 @@ jobs:
       - name: Verify Java
         run: bash __tests__/verify-java.sh "${{ matrix.version }}" "${{ steps.setup-java.outputs.path }}"
         shell: bash
+       - name: setup-java
+        uses: ./
+        id: setup-java2
+        with:
+          java-version: ${{ matrix.version }}
+          distribution: ${{ matrix.distribution }}
+      - name: Verify Java
+        run: bash __tests__/verify-java.sh "${{ matrix.version }}" "${{ steps.setup-java2.outputs.path }}"
+        shell: bash
 
   setup-java-major-minor-versions:
     name: ${{ matrix.distribution }} ${{ matrix.version }} (jdk-x64) - ${{ matrix.os }}

--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -42,6 +42,10 @@ jobs:
       - name: Verify Java
         run: bash __tests__/verify-java.sh "${{ matrix.version }}" "${{ steps.setup-java2.outputs.path }}"
         shell: bash
+      - name: Verify Java
+        run: ls -la "${{ steps.setup-java2.outputs.path }}"
+        shell: bash
+          
 
   setup-java-major-minor-versions:
     name: ${{ matrix.distribution }} ${{ matrix.version }} (jdk-x64) - ${{ matrix.os }}

--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -101,6 +101,9 @@ jobs:
         with:
           java-version: ${{ matrix.version }}
           distribution: zulu
+      - name: Verify Java
+        run: bash __tests__/verify-java.sh "${{ matrix.version }}" "${{ steps.setup-java.outputs.path }}"
+        shell: bash
 
   setup-java-ea-versions-adopt:
     name: adopt ${{ matrix.version }} (jdk-x64) - ${{ matrix.os }}
@@ -120,6 +123,9 @@ jobs:
         with:
           java-version: ${{ matrix.version }}
           distribution: adopt
+      - name: Verify Java
+        run: bash __tests__/verify-java.sh "${{ matrix.version }}" "${{ steps.setup-java.outputs.path }}"
+        shell: bash
 
   setup-java-custom-package-type:
     name: ${{ matrix.distribution }} ${{ matrix.version }} (${{ matrix.java-package }}-x64) - ${{ matrix.os }}

--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -33,19 +33,6 @@ jobs:
       - name: Verify Java
         run: bash __tests__/verify-java.sh "${{ matrix.version }}" "${{ steps.setup-java.outputs.path }}"
         shell: bash
-      - name: setup-java
-        uses: ./
-        id: setup-java2
-        with:
-          java-version: ${{ matrix.version }}
-          distribution: ${{ matrix.distribution }}
-      - name: Verify Java
-        run: bash __tests__/verify-java.sh "${{ matrix.version }}" "${{ steps.setup-java2.outputs.path }}"
-        shell: bash
-      - name: Verify Java
-        run: ls -la "${{ steps.setup-java2.outputs.path }}"
-        shell: bash
-          
 
   setup-java-major-minor-versions:
     name: ${{ matrix.distribution }} ${{ matrix.version }} (jdk-x64) - ${{ matrix.os }}

--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Verify Java
         run: bash __tests__/verify-java.sh "${{ matrix.version }}" "${{ steps.setup-java.outputs.path }}"
         shell: bash
-       - name: setup-java
+      - name: setup-java
         uses: ./
         id: setup-java2
         with:

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -14008,8 +14008,7 @@ class ZuluDistribution extends base_installer_1.JavaBase {
             extractedJavaPath = yield util_1.extractJdkFile(javaArchivePath, extension);
             const archiveName = fs_1.default.readdirSync(extractedJavaPath)[0];
             const archivePath = path_1.default.join(extractedJavaPath, archiveName);
-            const jdkPath = this.findJDKInstallationSubfolder(archivePath);
-            const javaPath = yield tc.cacheDir(jdkPath, this.toolcacheFolderName, this.getToolcacheVersionName(javaRelease.version), this.architecture);
+            const javaPath = yield tc.cacheDir(archivePath, this.toolcacheFolderName, this.getToolcacheVersionName(javaRelease.version), this.architecture);
             return { version: javaRelease.version, path: javaPath };
         });
     }
@@ -14081,20 +14080,6 @@ class ZuluDistribution extends base_installer_1.JavaBase {
             return `${mainVersion}+${version_array[3]}`;
         }
         return mainVersion;
-    }
-    findJDKInstallationSubfolder(archiveFolder) {
-        if (process.platform != 'darwin') {
-            return archiveFolder;
-        }
-        // Zulu archive on macOS contains a set of symlinks and zulu-<major_version>.jdk subfolder
-        const jdkFolders = fs_1.default
-            .readdirSync(archiveFolder, { withFileTypes: true })
-            .filter(item => item.isDirectory() && !item.isSymbolicLink())
-            .filter(item => /^zulu-\d+\.\w+$/.test(item.name));
-        if (jdkFolders.length === 0) {
-            return archiveFolder;
-        }
-        return path_1.default.join(archiveFolder, jdkFolders[0].name);
     }
 }
 exports.ZuluDistribution = ZuluDistribution;

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -14083,11 +14083,14 @@ class ZuluDistribution extends base_installer_1.JavaBase {
         return mainVersion;
     }
     findJDKInstallationSubfolder(archiveFolder) {
-        // Zulu archive contains a bunch of symlinks and zulu-<major_version>.jdk subfolder
+        if (process.platform != 'darwin') {
+            return archiveFolder;
+        }
+        // Zulu archive on macOS contains a set of symlinks and zulu-<major_version>.jdk subfolder
         const jdkFolders = fs_1.default
             .readdirSync(archiveFolder, { withFileTypes: true })
-            .filter(item => !item.isSymbolicLink())
-            .filter(item => item.name.startsWith('zulu-') && item.name.endsWith('.jdk'));
+            .filter(item => item.isDirectory() && !item.isSymbolicLink())
+            .filter(item => /^zulu-\d+\.\w+$/.test(item.name));
         if (jdkFolders.length === 0) {
             return archiveFolder;
         }

--- a/src/distributions/adopt/installer.ts
+++ b/src/distributions/adopt/installer.ts
@@ -67,10 +67,6 @@ export class AdoptDistribution extends JavaBase {
 
     javaPath = await tc.cacheDir(archivePath, this.toolcacheFolderName, version, this.architecture);
 
-    if (process.platform === 'darwin') {
-      javaPath = path.join(javaPath, MACOS_JAVA_CONTENT_POSTFIX);
-    }
-
     return { version: javaRelease.version, path: javaPath };
   }
 

--- a/src/distributions/zulu/installer.ts
+++ b/src/distributions/zulu/installer.ts
@@ -72,10 +72,8 @@ export class ZuluDistribution extends JavaBase {
     const archiveName = fs.readdirSync(extractedJavaPath)[0];
     const archivePath = path.join(extractedJavaPath, archiveName);
 
-    const jdkPath = this.findJDKInstallationSubfolder(archivePath);
-
     const javaPath = await tc.cacheDir(
-      jdkPath,
+      archivePath,
       this.toolcacheFolderName,
       this.getToolcacheVersionName(javaRelease.version),
       this.architecture
@@ -161,22 +159,5 @@ export class ZuluDistribution extends JavaBase {
     }
 
     return mainVersion;
-  }
-
-  private findJDKInstallationSubfolder(archiveFolder: string) {
-    if (process.platform != 'darwin') {
-      return archiveFolder;
-    }
-
-    // Zulu archive on macOS contains a set of symlinks and zulu-<major_version>.jdk subfolder
-    const jdkFolders = fs
-      .readdirSync(archiveFolder, { withFileTypes: true })
-      .filter(item => item.isDirectory() && !item.isSymbolicLink())
-      .filter(item => /^zulu-\d+\.\w+$/.test(item.name));
-    if (jdkFolders.length === 0) {
-      return archiveFolder;
-    }
-
-    return path.join(archiveFolder, jdkFolders[0].name);
   }
 }

--- a/src/distributions/zulu/installer.ts
+++ b/src/distributions/zulu/installer.ts
@@ -171,7 +171,7 @@ export class ZuluDistribution extends JavaBase {
     // Zulu archive on macOS contains a set of symlinks and zulu-<major_version>.jdk subfolder
     const jdkFolders = fs
       .readdirSync(archiveFolder, { withFileTypes: true })
-      .filter(item => item.isDirectory() && !item.isSymbolicLink() )
+      .filter(item => item.isDirectory() && !item.isSymbolicLink())
       .filter(item => /^zulu-\d+\.\w+$/.test(item.name));
     if (jdkFolders.length === 0) {
       return archiveFolder;

--- a/src/distributions/zulu/installer.ts
+++ b/src/distributions/zulu/installer.ts
@@ -164,11 +164,15 @@ export class ZuluDistribution extends JavaBase {
   }
 
   private findJDKInstallationSubfolder(archiveFolder: string) {
-    // Zulu archive contains a bunch of symlinks and zulu-<major_version>.jdk subfolder
+    if (process.platform != 'darwin') {
+      return archiveFolder;
+    }
+
+    // Zulu archive on macOS contains a set of symlinks and zulu-<major_version>.jdk subfolder
     const jdkFolders = fs
       .readdirSync(archiveFolder, { withFileTypes: true })
-      .filter(item => !item.isSymbolicLink())
-      .filter(item => item.name.startsWith('zulu-') && item.name.endsWith('.jdk'));
+      .filter(item => item.isDirectory() && !item.isSymbolicLink() )
+      .filter(item => /^zulu-\d+\.\w+$/.test(item.name));
     if (jdkFolders.length === 0) {
       return archiveFolder;
     }

--- a/src/distributions/zulu/installer.ts
+++ b/src/distributions/zulu/installer.ts
@@ -72,8 +72,10 @@ export class ZuluDistribution extends JavaBase {
     const archiveName = fs.readdirSync(extractedJavaPath)[0];
     const archivePath = path.join(extractedJavaPath, archiveName);
 
+    const jdkPath = this.findJDKInstallationSubfolder(archivePath);
+
     const javaPath = await tc.cacheDir(
-      archivePath,
+      jdkPath,
       this.toolcacheFolderName,
       this.getToolcacheVersionName(javaRelease.version),
       this.architecture
@@ -159,5 +161,18 @@ export class ZuluDistribution extends JavaBase {
     }
 
     return mainVersion;
+  }
+
+  private findJDKInstallationSubfolder(archiveFolder: string) {
+    // Zulu archive contains a bunch of symlinks and zulu-<major_version>.jdk subfolder
+    const jdkFolders = fs
+      .readdirSync(archiveFolder, { withFileTypes: true })
+      .filter(item => !item.isSymbolicLink())
+      .filter(item => item.name.startsWith('zulu-') && item.name.endsWith('.jdk'));
+    if (jdkFolders.length === 0) {
+      return archiveFolder;
+    }
+
+    return path.join(archiveFolder, jdkFolders[0].name);
   }
 }


### PR DESCRIPTION
**Description:**
JDK folder on MacOS can contain additional nested folders for some providers.
Previously, we have included these folders to PATH only when download Java from remote. We should do the same when resolve Java from tool-cache. So decide to move this logic to base class to avoid duplication.

![image](https://user-images.githubusercontent.com/16715858/111768626-38e82f80-88b9-11eb-9aee-45dc84ed13c6.png)