### PR TITLE
Added 'adopt-hotspot' and 'adopt-openj9'

### DIFF
--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        distribution: ['adopt', 'zulu']
+        distribution: ['adopt', 'adopt-openj9', 'zulu'] # internally 'adopt-hotspot' is the same as 'adopt'
         version: ['8', '11', '15']
     steps:
       - name: Checkout
@@ -91,7 +91,7 @@ jobs:
       - name: Verify Java
         run: bash __tests__/verify-java.sh "11" "${{ steps.setup-java.outputs.path }}"
         shell: bash
-  
+
   setup-java-ea-versions-zulu:
     name: zulu ${{ matrix.version }} (jdk-x64) - ${{ matrix.os }}
     needs: setup-java-major-minor-versions

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Currently, the following distributions are supported:
 | Keyword | Distribution | Official site | License |
 |-|-|-|-|
 | `zulu` | Zulu OpenJDK | [Link](https://www.azul.com/downloads/zulu-community/?package=jdk) | [Link](https://www.azul.com/products/zulu-and-zulu-enterprise/zulu-terms-of-use/) |
-| `adopt` | Adopt OpenJDK | [Link](https://adoptopenjdk.net/) | [Link](https://adoptopenjdk.net/about.html)
+| `adopt` or `adopt-hotspot` | Adopt OpenJDK Hotspot | [Link](https://adoptopenjdk.net/) | [Link](https://adoptopenjdk.net/about.html)
+| `adopt-openj9` | Adopt OpenJDK OpenJ9 | [Link](https://adoptopenjdk.net/) | [Link](https://adoptopenjdk.net/about.html)
 
 **NOTE:** The different distributors can provide discrepant list of available versions / supported configurations. Please refer to the official documentation to see the list of supported versions.
 

--- a/__tests__/distributors/adopt-installer.test.ts
+++ b/__tests__/distributors/adopt-installer.test.ts
@@ -1,8 +1,6 @@
 import { HttpClient } from '@actions/http-client';
 
-import * as semver from 'semver';
-
-import { AdoptDistribution } from '../../src/distributions/adopt/installer';
+import { AdoptDistribution, AdoptImplementation } from '../../src/distributions/adopt/installer';
 import { JavaInstallerOptions } from '../../src/distributions/base-models';
 
 let manifestData = require('../data/adopt.json') as [];
@@ -28,26 +26,54 @@ describe('getAvailableVersions', () => {
   it.each([
     [
       { version: '11', architecture: 'x64', packageType: 'jdk', checkLatest: false },
-      'os=mac&architecture=x64&image_type=jdk&release_type=ga&page_size=20&page=0'
+      AdoptImplementation.Hotspot,
+      'os=mac&architecture=x64&image_type=jdk&release_type=ga&jvm_impl=hotspot&page_size=20&page=0'
     ],
     [
       { version: '11', architecture: 'x86', packageType: 'jdk', checkLatest: false },
-      'os=mac&architecture=x86&image_type=jdk&release_type=ga&page_size=20&page=0'
+      AdoptImplementation.Hotspot,
+      'os=mac&architecture=x86&image_type=jdk&release_type=ga&jvm_impl=hotspot&page_size=20&page=0'
     ],
     [
       { version: '11', architecture: 'x64', packageType: 'jre', checkLatest: false },
-      'os=mac&architecture=x64&image_type=jre&release_type=ga&page_size=20&page=0'
+      AdoptImplementation.Hotspot,
+      'os=mac&architecture=x64&image_type=jre&release_type=ga&jvm_impl=hotspot&page_size=20&page=0'
     ],
     [
       { version: '11-ea', architecture: 'x64', packageType: 'jdk', checkLatest: false },
-      'os=mac&architecture=x64&image_type=jdk&release_type=ea&page_size=20&page=0'
+      AdoptImplementation.Hotspot,
+      'os=mac&architecture=x64&image_type=jdk&release_type=ea&jvm_impl=hotspot&page_size=20&page=0'
+    ],
+    [
+      { version: '11', architecture: 'x64', packageType: 'jdk', checkLatest: false },
+      AdoptImplementation.OpenJ9,
+      'os=mac&architecture=x64&image_type=jdk&release_type=ga&jvm_impl=openj9&page_size=20&page=0'
+    ],
+    [
+      { version: '11', architecture: 'x86', packageType: 'jdk', checkLatest: false },
+      AdoptImplementation.OpenJ9,
+      'os=mac&architecture=x86&image_type=jdk&release_type=ga&jvm_impl=openj9&page_size=20&page=0'
+    ],
+    [
+      { version: '11', architecture: 'x64', packageType: 'jre', checkLatest: false },
+      AdoptImplementation.OpenJ9,
+      'os=mac&architecture=x64&image_type=jre&release_type=ga&jvm_impl=openj9&page_size=20&page=0'
+    ],
+    [
+      { version: '11-ea', architecture: 'x64', packageType: 'jdk', checkLatest: false },
+      AdoptImplementation.OpenJ9,
+      'os=mac&architecture=x64&image_type=jdk&release_type=ea&jvm_impl=openj9&page_size=20&page=0'
     ]
   ])(
     'build correct url for %s',
-    async (installerOptions: JavaInstallerOptions, expectedParameters) => {
-      const distribution = new AdoptDistribution(installerOptions);
+    async (
+      installerOptions: JavaInstallerOptions,
+      impl: AdoptImplementation,
+      expectedParameters
+    ) => {
+      const distribution = new AdoptDistribution(installerOptions, impl);
       const baseUrl = 'https://api.adoptopenjdk.net/v3/assets/version/%5B1.0,100.0%5D';
-      const expectedUrl = `${baseUrl}?project=jdk&vendor=adoptopenjdk&heap_size=normal&jvm_impl=hotspot&sort_method=DEFAULT&sort_order=DESC&${expectedParameters}`;
+      const expectedUrl = `${baseUrl}?project=jdk&vendor=adoptopenjdk&heap_size=normal&sort_method=DEFAULT&sort_order=DESC&${expectedParameters}`;
       distribution['getPlatformOption'] = () => 'mac';
 
       await distribution['getAvailableVersions']();
@@ -76,12 +102,10 @@ describe('getAvailableVersions', () => {
         result: []
       });
 
-    const distribution = new AdoptDistribution({
-      version: '11',
-      architecture: 'x64',
-      packageType: 'jdk',
-      checkLatest: false
-    });
+    const distribution = new AdoptDistribution(
+      { version: '11', architecture: 'x64', packageType: 'jdk', checkLatest: false },
+      AdoptImplementation.Hotspot
+    );
     const availableVersions = await distribution['getAvailableVersions']();
     expect(availableVersions).not.toBeNull();
     expect(availableVersions.length).toBe(manifestData.length * 2);
@@ -102,24 +126,20 @@ describe('findPackageForDownload', () => {
     ['15.0.1+9', '15.0.1+9'],
     ['15.0.1+9.1', '15.0.1+9.1']
   ])('version is resolved correctly %s -> %s', async (input, expected) => {
-    const distribution = new AdoptDistribution({
-      version: '11',
-      architecture: 'x64',
-      packageType: 'jdk',
-      checkLatest: false
-    });
+    const distribution = new AdoptDistribution(
+      { version: '11', architecture: 'x64', packageType: 'jdk', checkLatest: false },
+      AdoptImplementation.Hotspot
+    );
     distribution['getAvailableVersions'] = async () => manifestData;
     const resolvedVersion = await distribution['findPackageForDownload'](input);
     expect(resolvedVersion.version).toBe(expected);
   });
 
   it('version is found but binaries list is empty', async () => {
-    const distribution = new AdoptDistribution({
-      version: '11',
-      architecture: 'x64',
-      packageType: 'jdk',
-      checkLatest: false
-    });
+    const distribution = new AdoptDistribution(
+      { version: '11', architecture: 'x64', packageType: 'jdk', checkLatest: false },
+      AdoptImplementation.Hotspot
+    );
     distribution['getAvailableVersions'] = async () => manifestData;
     await expect(distribution['findPackageForDownload']('9.0.8')).rejects.toThrowError(
       /Could not find satisfied version for SemVer */
@@ -127,12 +147,10 @@ describe('findPackageForDownload', () => {
   });
 
   it('version is not found', async () => {
-    const distribution = new AdoptDistribution({
-      version: '11',
-      architecture: 'x64',
-      packageType: 'jdk',
-      checkLatest: false
-    });
+    const distribution = new AdoptDistribution(
+      { version: '11', architecture: 'x64', packageType: 'jdk', checkLatest: false },
+      AdoptImplementation.Hotspot
+    );
     distribution['getAvailableVersions'] = async () => manifestData;
     await expect(distribution['findPackageForDownload']('7.x')).rejects.toThrowError(
       /Could not find satisfied version for SemVer */
@@ -140,12 +158,10 @@ describe('findPackageForDownload', () => {
   });
 
   it('version list is empty', async () => {
-    const distribution = new AdoptDistribution({
-      version: '11',
-      architecture: 'x64',
-      packageType: 'jdk',
-      checkLatest: false
-    });
+    const distribution = new AdoptDistribution(
+      { version: '11', architecture: 'x64', packageType: 'jdk', checkLatest: false },
+      AdoptImplementation.Hotspot
+    );
     distribution['getAvailableVersions'] = async () => [];
     await expect(distribution['findPackageForDownload']('11')).rejects.toThrowError(
       /Could not find satisfied version for SemVer */

--- a/__tests__/distributors/adopt-installer.test.ts
+++ b/__tests__/distributors/adopt-installer.test.ts
@@ -110,6 +110,24 @@ describe('getAvailableVersions', () => {
     expect(availableVersions).not.toBeNull();
     expect(availableVersions.length).toBe(manifestData.length * 2);
   });
+
+  it.each([
+    [AdoptImplementation.Hotspot, 'jdk', 'Java_Adopt_jdk'],
+    [AdoptImplementation.Hotspot, 'jre', 'Java_Adopt_jre'],
+    [AdoptImplementation.OpenJ9, 'jdk', 'Java_Adopt-OpenJ9_jdk'],
+    [AdoptImplementation.OpenJ9, 'jre', 'Java_Adopt-OpenJ9_jre']
+  ])(
+    'find right toolchain folder',
+    (impl: AdoptImplementation, packageType: string, expected: string) => {
+      const distribution = new AdoptDistribution(
+        { version: '11', architecture: 'x64', packageType: packageType, checkLatest: false },
+        impl
+      );
+
+      // @ts-ignore - because it is protected
+      expect(distribution.toolcacheFolderName).toBe(expected);
+    }
+  );
 });
 
 describe('findPackageForDownload', () => {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -26910,7 +26910,7 @@ var AdoptImplementation;
 class AdoptDistribution extends base_installer_1.JavaBase {
     constructor(installerOptions, jvmImpl) {
         super(`Adopt-${jvmImpl}`, installerOptions);
-        this.jvmImpl = jvmImpl.toLowerCase();
+        this.jvmImpl = jvmImpl;
     }
     findPackageForDownload(version) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -26981,7 +26981,7 @@ class AdoptDistribution extends base_installer_1.JavaBase {
                 `architecture=${arch}`,
                 `image_type=${imageType}`,
                 `release_type=${releaseType}`,
-                `jvm_impl=${this.jvmImpl}`
+                `jvm_impl=${this.jvmImpl.toLowerCase()}`
             ].join('&');
             // need to iterate through all pages to retrieve the list of all versions
             // Adopt API doesn't provide way to retrieve the count of pages to iterate so infinity loop

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -22,7 +22,7 @@ steps:
 - uses: actions/checkout@v2
 - uses: actions/setup-java@v2
   with:
-    distribution: 'adopt'
+    distribution: 'adopt-hotspot' # See 'Supported distributions' for available options @ README.md
     java-version: '11'
 - run: java -cp java HelloWorldApp
 ```

--- a/src/distributions/adopt/installer.ts
+++ b/src/distributions/adopt/installer.ts
@@ -16,11 +16,11 @@ export enum AdoptImplementation {
 }
 
 export class AdoptDistribution extends JavaBase {
-  private jvmImpl: string;
-
-  constructor(installerOptions: JavaInstallerOptions, jvmImpl: AdoptImplementation) {
+  constructor(
+    installerOptions: JavaInstallerOptions,
+    private readonly jvmImpl: AdoptImplementation
+  ) {
     super(`Adopt-${jvmImpl}`, installerOptions);
-    this.jvmImpl = jvmImpl.toLowerCase();
   }
 
   protected async findPackageForDownload(version: string): Promise<JavaDownloadRelease> {
@@ -105,7 +105,7 @@ export class AdoptDistribution extends JavaBase {
       `architecture=${arch}`,
       `image_type=${imageType}`,
       `release_type=${releaseType}`,
-      `jvm_impl=${this.jvmImpl}`
+      `jvm_impl=${this.jvmImpl.toLowerCase()}`
     ].join('&');
 
     // need to iterate through all pages to retrieve the list of all versions

--- a/src/distributions/adopt/installer.ts
+++ b/src/distributions/adopt/installer.ts
@@ -7,13 +7,20 @@ import semver from 'semver';
 
 import { JavaBase } from '../base-installer';
 import { IAdoptAvailableVersions } from './models';
-import { JavaInstallerOptions, JavaDownloadRelease, JavaInstallerResults } from '../base-models';
-import { MACOS_JAVA_CONTENT_POSTFIX } from '../../constants';
+import { JavaDownloadRelease, JavaInstallerOptions, JavaInstallerResults } from '../base-models';
 import { extractJdkFile, getDownloadArchiveExtension, isVersionSatisfies } from '../../util';
 
+export enum AdoptImplementation {
+  Hotspot = 'Hotspot',
+  OpenJ9 = 'OpenJ9'
+}
+
 export class AdoptDistribution extends JavaBase {
-  constructor(installerOptions: JavaInstallerOptions) {
-    super('Adopt', installerOptions);
+  private jvmImpl: string;
+
+  constructor(installerOptions: JavaInstallerOptions, jvmImpl: AdoptImplementation) {
+    super(`Adopt-${jvmImpl}`, installerOptions);
+    this.jvmImpl = jvmImpl.toLowerCase();
   }
 
   protected async findPackageForDownload(version: string): Promise<JavaDownloadRelease> {
@@ -70,6 +77,15 @@ export class AdoptDistribution extends JavaBase {
     return { version: javaRelease.version, path: javaPath };
   }
 
+  protected get toolcacheFolderName(): string {
+    if (this.jvmImpl === AdoptImplementation.Hotspot) {
+      // exclude Hotspot postfix from distribution name because Hosted runners have pre-cached Adopt OpenJDK under "Java_Adopt_jdk"
+      // for more information see: https://github.com/actions/setup-java/pull/155#discussion_r610451063
+      return `Java_Adopt_${this.packageType}`;
+    }
+    return super.toolcacheFolderName;
+  }
+
   private async getAvailableVersions(): Promise<IAdoptAvailableVersions[]> {
     const platform = this.getPlatformOption();
     const arch = this.architecture;
@@ -83,13 +99,13 @@ export class AdoptDistribution extends JavaBase {
       `project=jdk`,
       'vendor=adoptopenjdk',
       `heap_size=normal`,
-      `jvm_impl=hotspot`,
       'sort_method=DEFAULT',
       'sort_order=DESC',
       `os=${platform}`,
       `architecture=${arch}`,
       `image_type=${imageType}`,
-      `release_type=${releaseType}`
+      `release_type=${releaseType}`,
+      `jvm_impl=${this.jvmImpl}`
     ].join('&');
 
     // need to iterate through all pages to retrieve the list of all versions

--- a/src/distributions/distribution-factory.ts
+++ b/src/distributions/distribution-factory.ts
@@ -1,11 +1,13 @@
-import { AdoptDistribution } from './adopt/installer';
 import { JavaBase } from './base-installer';
 import { JavaInstallerOptions } from './base-models';
 import { LocalDistribution } from './local/installer';
 import { ZuluDistribution } from './zulu/installer';
+import { AdoptDistribution, AdoptImplementation } from './adopt/installer';
 
 enum JavaDistribution {
   Adopt = 'adopt',
+  AdoptHotspot = 'adopt-hotspot',
+  AdoptOpenJ9 = 'adopt-openj9',
   Zulu = 'zulu',
   JdkFile = 'jdkfile'
 }
@@ -19,7 +21,10 @@ export function getJavaDistribution(
     case JavaDistribution.JdkFile:
       return new LocalDistribution(installerOptions, jdkFile);
     case JavaDistribution.Adopt:
-      return new AdoptDistribution(installerOptions);
+    case JavaDistribution.AdoptHotspot:
+      return new AdoptDistribution(installerOptions, AdoptImplementation.Hotspot);
+    case JavaDistribution.AdoptOpenJ9:
+      return new AdoptDistribution(installerOptions, AdoptImplementation.OpenJ9);
     case JavaDistribution.Zulu:
       return new ZuluDistribution(installerOptions);
     default:


### PR DESCRIPTION
**Description:**
Added the ability to select the implementation of the adoptopenjdk distributions.

**Related issue:**
https://github.com/actions/setup-java/issues/13#issuecomment-813344524

**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.