### PR TITLE
Add cron for e2e tests

### DIFF
--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -9,7 +9,8 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
-
+  schedule:
+    - cron:  '0 */12 * * *'
 jobs:
   setup-java-major-versions:
     name: ${{ matrix.distribution }} ${{ matrix.version }} (jdk-x64) - ${{ matrix.os }}


### PR DESCRIPTION
**Description:**
In scope of this pull request we add cron for e2e tests.
 - Cron's description: `At minute 0 past every 12th hour.`

**Related issue:**

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.