### PR TITLE
Fix typo on distribution "jdkfile" in Migration Guide

### DIFF
--- a/docs/switching-to-v2.md
+++ b/docs/switching-to-v2.md
@@ -24,7 +24,7 @@ steps:
     wget -O $RUNNER_TEMP/java_package.tar.gz $download_url
 - uses: actions/setup-java@v2
   with:
-    distribution: 'jdkFile'
+    distribution: 'jdkfile'
     jdkFile: ${{ runner.temp }}/java_package.tar.gz
     java-version: '11.0.0'
     architecture: x64


### PR DESCRIPTION
**Description:**
There is a small typo.
Its "jdkfile" and not "jdkFile", see https://github.com/actions/setup-java/blob/b53500dabc37db6cc1dcd35059bdcd85df25d140/src/distributions/distribution-factory.ts#L10

To avoid error: No supported distribution was found for input jdkFile

**Related issue:**

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.