### PR TITLE
Add problem matcher for Checkstyle

### DIFF
--- a/.github/checkstyle.json
+++ b/.github/checkstyle.json
@@ -1,0 +1,19 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "checkstyle",
+            "severity": "warning",
+            "pattern": [
+                {
+                    "regexp": "^.*\\[(ERROR|WARN)\\]\\s+(.*):(\\d+):(\\d+):\\s+(.*)\\s+\\[(.*)\\]$",
+                    "severity": 1,
+                    "file": 2,
+                    "line": 3,
+                    "column": 4,
+                    "message": 5,
+                    "code": 6
+                }
+            ]
+        }
+    ]
+}

--- a/src/setup-java.ts
+++ b/src/setup-java.ts
@@ -38,6 +38,7 @@ async function run() {
 
     const matchersPath = path.join(__dirname, '..', '..', '.github');
     core.info(`##[add-matcher]${path.join(matchersPath, 'java.json')}`);
+    core.info(`##[add-matcher]${path.join(matchersPath, 'checkstyle.json')}`);
 
     await auth.configureAuthentication();
   } catch (error) {


### PR DESCRIPTION
**Description:**

This PR adds a problem matcher for Checkstyle to allow automatic GitHub annotations.

When run through Gradle, an example line is:
```
[ant:checkstyle] [ERROR] /root/Bound.java:7:2: 'import' has incorrect indentation level 1, expected level should be 0. [Indentation]
```

Alternatively, when run standalone, an example output is:
```
[WARN] /root/test.java:2:1: The name of the outer type and the file do not match. [OuterTypeFilename]
```

The regular expression matches both cases.

In the latter example, `WARN`, rather than `WARNING` is output. This is resolved by using a default severity of `warning`, which should be overridden in the case that the severity is `ERROR`.

**Related issue:**
Closes #197.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.