### PR TITLE
Update readme with caching examples and test matrix

### DIFF
--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        distribution: ['adopt', 'adopt-openj9', 'temurin', 'zulu'] # internally 'adopt-hotspot' is the same as 'adopt'
+        distribution: ['temurin', 'adopt', 'adopt-openj9', 'zulu'] # internally 'adopt-hotspot' is the same as 'adopt'
         version: ['8', '11', '16']
     steps:
       - name: Checkout
@@ -43,30 +43,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        distribution: ['adopt', 'zulu']
+        distribution: ['temurin', 'zulu']
         version:
         - '11.0'
-        - '8.0.282'
-        - '11.0.2+7'
-        include:
-          - distribution: 'adopt'
-            version: '12.0.2+10.1'
-            os: macos-latest
-          - distribution: 'adopt'
-            version: '12.0.2+10.1'
-            os: windows-latest
-          - distribution: 'adopt'
-            version: '12.0.2+10.1'
-            os: ubuntu-latest
-          - distribution: 'temurin'
-            version: '16.0.2+7'
-            os: macos-latest
-          - distribution: 'temurin'
-            version: '16.0.2+7'
-            os: windows-latest
-          - distribution: 'temurin'
-            version: '16.0.2+7'
-            os: ubuntu-latest
+        - '8.0.302'
+        - '16.0.2+7'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -88,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        distribution: ['adopt', 'temurin', 'zulu']
+        distribution: ['temurin', 'zulu']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -125,28 +106,6 @@ jobs:
         run: bash __tests__/verify-java.sh "${{ matrix.version }}" "${{ steps.setup-java.outputs.path }}"
         shell: bash
 
-  setup-java-ea-versions-adopt:
-    name: adopt ${{ matrix.version }} (jdk-x64) - ${{ matrix.os }}
-    needs: setup-java-major-minor-versions
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
-        version: ['17-ea', '15.0.0-ea.14.1.202003160455']
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: setup-java
-        uses: ./
-        id: setup-java
-        with:
-          java-version: ${{ matrix.version }}
-          distribution: adopt
-      - name: Verify Java
-        run: bash __tests__/verify-java.sh "${{ matrix.version }}" "${{ steps.setup-java.outputs.path }}"
-        shell: bash
-
   setup-java-ea-versions-temurin:
     name: temurin ${{ matrix.version }} (jdk-x64) - ${{ matrix.os }}
     needs: setup-java-major-minor-versions
@@ -177,10 +136,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        distribution: ['adopt', 'temurin', 'zulu']
+        distribution: ['temurin', 'zulu']
         java-package: ['jre']
-        version:
-        - '16.0'
+        version: ['16.0']
         include:
           - distribution: 'zulu'
             java-package: jre+fx

--- a/README.md
+++ b/README.md
@@ -15,24 +15,13 @@ This action provides the following functionality for GitHub Actions runners:
 - Caching dependencies managed by Gradle
 
 ## V2 vs V1
-- V2 supports custom distributions and provides support for Zulu OpenJDK, Adopt OpenJDK and Eclipse Temurin out of the box. V1 supports only Zulu OpenJDK
+- V2 supports custom distributions and provides support for Zulu OpenJDK, Eclipse Temurin and Adopt OpenJDK  out of the box. V1 supports only Zulu OpenJDK
 - V2 requires you to specify distribution along with the version. V1 defaults to Zulu OpenJDK, only version input is required. Follow [the migration guide](docs/switching-to-v2.md) to switch from V1 to V2
 
 ## Usage
 Inputs `java-version` and `distribution` are mandatory. See [Supported distributions](#supported-distributions) section for a list of available options.
 
 ### Basic
-**Adopt OpenJDK**
-```yaml
-steps:
-- uses: actions/checkout@v2
-- uses: actions/setup-java@v2
-  with:
-    distribution: 'adopt' # See 'Supported distributions' for available options
-    java-version: '11'
-- run: java -cp java HelloWorldApp
-```
-
 **Eclipse Temurin**
 ```yaml
 steps:
@@ -40,7 +29,7 @@ steps:
 - uses: actions/setup-java@v2
   with:
     distribution: 'temurin' # See 'Supported distributions' for available options
-    java-version: '8'
+    java-version: '11'
 - run: java -cp java HelloWorldApp
 ```
 
@@ -57,32 +46,49 @@ steps:
 
 #### Supported version syntax
 The `java-version` input supports an exact version or a version range using [SemVer](https://semver.org/) notation:
-- major versions: `8`, `11`, `15`
+- major versions: `8`, `11`, `16`
 - more specific versions: `11.0`, `11.0.4`, `8.0.232`, `8.0.282+8`
 - early access (EA) versions: `15-ea`, `15.0.0-ea`, `15.0.0-ea.2`, `15.0.0+2-ea`
 
 #### Supported distributions
 Currently, the following distributions are supported:
-| Keyword | Distribution | Official site | License |
+| Keyword | Distribution | Official site | License
 |-|-|-|-|
-| `zulu` | Zulu OpenJDK | [Link](https://www.azul.com/downloads/zulu-community/?package=jdk) | [Link](https://www.azul.com/products/zulu-and-zulu-enterprise/zulu-terms-of-use/) |
-| `adopt` or `adopt-hotspot` | Adopt OpenJDK Hotspot | [Link](https://adoptopenjdk.net/) | [Link](https://adoptopenjdk.net/about.html)
-| `adopt-openj9` | Adopt OpenJDK OpenJ9 | [Link](https://adoptopenjdk.net/) | [Link](https://adoptopenjdk.net/about.html)
 | `temurin` | Eclipse Temurin | [Link](https://adoptium.net/) | [Link](https://adoptium.net/about.html)
+| `zulu` | Zulu OpenJDK | [Link](https://www.azul.com/downloads/zulu-community/?package=jdk) | [Link](https://www.azul.com/products/zulu-and-zulu-enterprise/zulu-terms-of-use/) |
+| `adopt` or `adopt-hotspot` | Adopt OpenJDK Hotspot | [Link](https://adoptopenjdk.net/) | [Link](https://adoptopenjdk.net/about.html) |
+| `adopt-openj9` | Adopt OpenJDK OpenJ9 | [Link](https://adoptopenjdk.net/) | [Link](https://adoptopenjdk.net/about.html)
 
 **NOTE:** The different distributors can provide discrepant list of available versions / supported configurations. Please refer to the official documentation to see the list of supported versions.
 
-#### Supported cache types
-Currently, `gradle` and `maven` are supported. You can set `cache` input like below:
+**NOTE:** Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from `adopt` to `temurin` to keep receiving software and security updates. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).
+
+### Caching packages dependencies
+The action has a built-in functionality for caching and restoring dependencies. It uses [actions/cache](https://github.com/actions/cache) under hood for caching dependencies but requires less configuration settings. Supported package managers are gradle and maven. The cache input is optional, and caching is turned off by default.
+
+#### Caching gradle dependencies
 ```yaml
 steps:
 - uses: actions/checkout@v2
 - uses: actions/setup-java@v2
   with:
-    distribution: 'adopt'
+    distribution: 'temurin'
     java-version: '11'
-    cache: 'gradle' # will restore cache of dependencies and wrappers
+    cache: 'gradle'
 - run: ./gradlew build
+```
+
+#### Caching maven dependencies
+```yaml
+steps:
+- uses: actions/checkout@v2
+- uses: actions/setup-java@v2
+  with:
+    distribution: 'temurin'
+    java-version: '11'
+    cache: 'maven'
+- name: Build with Maven
+  run: mvn -B package --file pom.xml
 ```
 
 ### Check latest
@@ -125,6 +131,7 @@ jobs:
 
 ### Advanced
 - [Selecting a Java distribution](docs/advanced-usage.md#Selecting-a-Java-distribution)
+  - [Eclipse Temurin](docs/advanced-usage.md#Eclipse-Temurin)
   - [Adopt](docs/advanced-usage.md#Adopt)
   - [Zulu](docs/advanced-usage.md#Zulu)
 - [Installing custom Java package type](docs/advanced-usage.md#Installing-custom-Java-package-type)

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -1,5 +1,6 @@
 # Usage
 - [Selecting a Java distribution](#Selecting-a-Java-distribution)
+  - [Eclipse Temurin](#Eclipse-Temurin)
   - [Adopt](#Adopt)
   - [Zulu](#Zulu)
 - [Installing custom Java package type](#Installing-custom-Java-package-type)
@@ -16,13 +17,26 @@ See [action.yml](../action.yml) for more details on task inputs.
 ## Selecting a Java distribution
 Inputs `java-version` and `distribution` are mandatory and needs to be provided. See [Supported distributions](../README.md#Supported-distributions) for a list of available options.
 
-### Adopt
+### Eclipse Temurin
 ```yaml
 steps:
 - uses: actions/checkout@v2
 - uses: actions/setup-java@v2
   with:
-    distribution: 'adopt-hotspot' # See 'Supported distributions' for available options @ README.md
+    distribution: 'temurin'
+    java-version: '11'
+- run: java -cp java HelloWorldApp
+```
+
+### Adopt
+**NOTE:** Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from `adopt` to `temurin` to keep receiving software and security updates. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).
+
+```yaml
+steps:
+- uses: actions/checkout@v2
+- uses: actions/setup-java@v2
+  with:
+    distribution: 'adopt-hotspot'
     java-version: '11'
 - run: java -cp java HelloWorldApp
 ```
@@ -91,8 +105,8 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        distribution: [ 'zulu', 'adopt' ]
-        java: [ '8', '11', '13', '15' ]
+        distribution: [ 'zulu', 'temurin' ]
+        java: [ '8', '11' ]
     name: Java ${{ matrix.Java }} (${{ matrix.distribution }}) sample
     steps:
       - uses: actions/checkout@v2
@@ -119,7 +133,7 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - run: java -cp java HelloWorldApp
 ```
@@ -150,7 +164,7 @@ jobs:
     - name: Set up Apache Maven Central
       uses: actions/setup-java@v2
       with: # running setup-java again overwrites the settings.xml
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: '11'
         server-id: maven # Value of the distributionManagement/repository/id field of the pom.xml
         server-username: MAVEN_USERNAME # env variable for username in deploy


### PR DESCRIPTION
**Description:**
- Update README to set Temurin before AdoptOpenJDK and add note about Adopt deprecation
- Extend information about caching like it is done in setup-node
- Reduce CI test matrix by excluding the most of Adopt test cases. 