### PR TITLE
Describe cache key format in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ Currently, the following distributions are supported:
 **NOTE:** Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from `adopt` to `temurin` to keep receiving software and security updates. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).
 
 ### Caching packages dependencies
-The action has a built-in functionality for caching and restoring dependencies. It uses [actions/cache](https://github.com/actions/cache) under hood for caching dependencies but requires less configuration settings. Supported package managers are gradle and maven. The cache input is optional, and caching is turned off by default.
+The action has a built-in functionality for caching and restoring dependencies. It uses [actions/cache](https://github.com/actions/cache) under hood for caching dependencies but requires less configuration settings. Supported package managers are gradle and maven. The format of the used cache key is `setup-java-${{ platform }}-${{ packageManager }}-${{ fileHash }}`, where the hash is based on the following files:
+- gradle: `**/*.gradle*`, `**/gradle-wrapper.properties`
+- maven: `**/pom.xml`
+
+The cache input is optional, and caching is turned off by default.
 
 #### Caching gradle dependencies
 ```yaml


### PR DESCRIPTION
**Description:**
Several users, including myself, wondered what cache key format is being used under the hood (see e.g. [here](https://twitter.com/lorenzo_bettini/status/1432580351491194880) or [here](https://twitter.com/brenuart/status/1432623680333488131)). This PR adds a corresponding description – based on [`computeCacheKey`](https://github.com/actions/setup-java/blob/main/src/cache.ts#L52) – to the `README.md`.

**Related issue:**
n/a

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.