### PR TITLE
Discussion: Is it better to remove OS from the cache key?

### DIFF
--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { restore, save } from '../src/cache';
+import { computeCacheKey, findPackageManager, restore, save } from '../src/cache';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as core from '@actions/core';
@@ -92,6 +92,19 @@ describe('dependency cache', () => {
         expect(spyWarning).not.toBeCalled();
         expect(spyInfo).toBeCalledWith('maven cache is not found');
       });
+      it('generates same cache key for every supported OS', async () => {
+        const packageManager = findPackageManager('maven');
+
+        process.env['RUNNER_OS'] = 'Windows';
+        const keyForWin = await computeCacheKey(packageManager);
+        process.env['RUNNER_OS'] = 'Linux';
+        const keyForLinux = await computeCacheKey(packageManager);
+        process.env['RUNNER_OS'] = 'macOS';
+        const keyForMacOS = await computeCacheKey(packageManager);
+
+        expect(keyForWin).toBe(keyForLinux);
+        expect(keyForWin).toBe(keyForMacOS);
+      });
     });
     describe('for gradle', () => {
       it('throws error if no build.gradle found', async () => {
@@ -116,6 +129,19 @@ describe('dependency cache', () => {
         expect(spyCacheRestore).toBeCalled();
         expect(spyWarning).not.toBeCalled();
         expect(spyInfo).toBeCalledWith('gradle cache is not found');
+      });
+      it('generates same cache key for every supported OS', async () => {
+        const packageManager = findPackageManager('gradle');
+
+        process.env['RUNNER_OS'] = 'Windows';
+        const keyForWin = await computeCacheKey(packageManager);
+        process.env['RUNNER_OS'] = 'Linux';
+        const keyForLinux = await computeCacheKey(packageManager);
+        process.env['RUNNER_OS'] = 'macOS';
+        const keyForMacOS = await computeCacheKey(packageManager);
+
+        expect(keyForWin).toEqual(keyForLinux);
+        expect(keyForWin).toEqual(keyForMacOS);
       });
     });
   });

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -64536,7 +64536,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.save = exports.restore = void 0;
+exports.save = exports.restore = exports.computeCacheKey = exports.findPackageManager = void 0;
 const path_1 = __webpack_require__(622);
 const os_1 = __importDefault(__webpack_require__(87));
 const cache = __importStar(__webpack_require__(692));
@@ -64566,6 +64566,7 @@ function findPackageManager(id) {
     }
     return packageManager;
 }
+exports.findPackageManager = findPackageManager;
 /**
  * A function that generates a cache key to use.
  * Format of the generated key will be "${{ platform }}-${{ id }}-${{ fileHash }}"".
@@ -64578,6 +64579,7 @@ function computeCacheKey(packageManager) {
         return `${CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${packageManager.id}-${hash}`;
     });
 }
+exports.computeCacheKey = computeCacheKey;
 /**
  * Restore the dependency cache
  * @param id ID of the package manager, should be "maven" or "gradle"

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -64569,14 +64569,14 @@ function findPackageManager(id) {
 exports.findPackageManager = findPackageManager;
 /**
  * A function that generates a cache key to use.
- * Format of the generated key will be "${{ platform }}-${{ id }}-${{ fileHash }}"".
+ * Format of the generated key will be "setup-java-${{ id }}-${{ fileHash }}"".
  * If there is no file matched to {@link PackageManager.path}, the generated key ends with a dash (-).
  * @see {@link https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#matching-a-cache-key|spec of cache key}
  */
 function computeCacheKey(packageManager) {
     return __awaiter(this, void 0, void 0, function* () {
         const hash = yield glob.hashFiles(packageManager.pattern.join('\n'));
-        return `${CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${packageManager.id}-${hash}`;
+        return `${CACHE_KEY_PREFIX}-${packageManager.id}-${hash}`;
     });
 }
 exports.computeCacheKey = computeCacheKey;
@@ -64594,7 +64594,7 @@ function restore(id) {
             throw new Error(`No file in ${process.cwd()} matched to [${packageManager.pattern}], make sure you have checked out the target repository`);
         }
         const matchedKey = yield cache.restoreCache(packageManager.path, primaryKey, [
-            `${CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${id}`
+            `${CACHE_KEY_PREFIX}-${id}`
         ]);
         if (matchedKey) {
             core.saveState(CACHE_MATCHED_KEY, matchedKey);

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -18956,14 +18956,14 @@ function findPackageManager(id) {
 exports.findPackageManager = findPackageManager;
 /**
  * A function that generates a cache key to use.
- * Format of the generated key will be "${{ platform }}-${{ id }}-${{ fileHash }}"".
+ * Format of the generated key will be "setup-java-${{ id }}-${{ fileHash }}"".
  * If there is no file matched to {@link PackageManager.path}, the generated key ends with a dash (-).
  * @see {@link https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#matching-a-cache-key|spec of cache key}
  */
 function computeCacheKey(packageManager) {
     return __awaiter(this, void 0, void 0, function* () {
         const hash = yield glob.hashFiles(packageManager.pattern.join('\n'));
-        return `${CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${packageManager.id}-${hash}`;
+        return `${CACHE_KEY_PREFIX}-${packageManager.id}-${hash}`;
     });
 }
 exports.computeCacheKey = computeCacheKey;
@@ -18981,7 +18981,7 @@ function restore(id) {
             throw new Error(`No file in ${process.cwd()} matched to [${packageManager.pattern}], make sure you have checked out the target repository`);
         }
         const matchedKey = yield cache.restoreCache(packageManager.path, primaryKey, [
-            `${CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${id}`
+            `${CACHE_KEY_PREFIX}-${id}`
         ]);
         if (matchedKey) {
             core.saveState(CACHE_MATCHED_KEY, matchedKey);

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -18923,7 +18923,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.save = exports.restore = void 0;
+exports.save = exports.restore = exports.computeCacheKey = exports.findPackageManager = void 0;
 const path_1 = __webpack_require__(622);
 const os_1 = __importDefault(__webpack_require__(87));
 const cache = __importStar(__webpack_require__(692));
@@ -18953,6 +18953,7 @@ function findPackageManager(id) {
     }
     return packageManager;
 }
+exports.findPackageManager = findPackageManager;
 /**
  * A function that generates a cache key to use.
  * Format of the generated key will be "${{ platform }}-${{ id }}-${{ fileHash }}"".
@@ -18965,6 +18966,7 @@ function computeCacheKey(packageManager) {
         return `${CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${packageManager.id}-${hash}`;
     });
 }
+exports.computeCacheKey = computeCacheKey;
 /**
  * Restore the dependency cache
  * @param id ID of the package manager, should be "maven" or "gradle"

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -45,13 +45,13 @@ export function findPackageManager(id: string): PackageManager {
 
 /**
  * A function that generates a cache key to use.
- * Format of the generated key will be "${{ platform }}-${{ id }}-${{ fileHash }}"".
+ * Format of the generated key will be "setup-java-${{ id }}-${{ fileHash }}"".
  * If there is no file matched to {@link PackageManager.path}, the generated key ends with a dash (-).
  * @see {@link https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#matching-a-cache-key|spec of cache key}
  */
 export async function computeCacheKey(packageManager: PackageManager) {
   const hash = await glob.hashFiles(packageManager.pattern.join('\n'));
-  return `${CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${packageManager.id}-${hash}`;
+  return `${CACHE_KEY_PREFIX}-${packageManager.id}-${hash}`;
 }
 
 /**
@@ -73,7 +73,7 @@ export async function restore(id: string) {
   }
 
   const matchedKey = await cache.restoreCache(packageManager.path, primaryKey, [
-    `${CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${id}`
+    `${CACHE_KEY_PREFIX}-${id}`
   ]);
   if (matchedKey) {
     core.saveState(CACHE_MATCHED_KEY, matchedKey);

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -35,7 +35,7 @@ const supportedPackageManager: PackageManager[] = [
   }
 ];
 
-function findPackageManager(id: string): PackageManager {
+export function findPackageManager(id: string): PackageManager {
   const packageManager = supportedPackageManager.find(packageManager => packageManager.id === id);
   if (packageManager === undefined) {
     throw new Error(`unknown package manager specified: ${id}`);
@@ -49,7 +49,7 @@ function findPackageManager(id: string): PackageManager {
  * If there is no file matched to {@link PackageManager.path}, the generated key ends with a dash (-).
  * @see {@link https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#matching-a-cache-key|spec of cache key}
  */
-async function computeCacheKey(packageManager: PackageManager) {
+export async function computeCacheKey(packageManager: PackageManager) {
   const hash = await glob.hashFiles(packageManager.pattern.join('\n'));
   return `${CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${packageManager.id}-${hash}`;
 }


### PR DESCRIPTION
**Description:**

This PR is for discussion about the `RUNNER_OS` in the cache key.

I found an opinion at Twitter: [it's needless because Java's package are portable](https://twitter.com/rmannibucau/status/1432579398415392769), and I agree with it.
In my understanding, the Maven repository provides no feature to serve different files to different OSs.

I prepared necessary changes to hold discussion with you. How do you think about this change?
It may make the build efficient in some case, especially when we run builds on multiple OSs in serial.

**Related issue:**

* #213 
* #215

**Check list:**
- [x] Mark if documentation changes are required; This PR requires updates in the change from #215 
- [x] Mark if tests were added or updated to cover the changes.