### PR TITLE
Housekeeping: remove the config for husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,11 +44,5 @@
     "prettier": "^1.19.1",
     "ts-jest": "^26.5.3",
     "typescript": "^4.2.3"
-  },
-  "husky": {
-    "skipCI": true,
-    "hooks": {
-      "pre-commit": "npm run build && npm run format"
-    }
   }
 }


### PR DESCRIPTION
**Description:**

It seems that the Husky has been removed by 980efe8 at 2019 Nov, then
it's better to remove the config for Husky in `package.json`.

If Husky is still necessary, I can propose a [new config for the husky v7](https://typicode.github.io/husky/#/?id=migrate-from-v4-to-v7).

**Related issue:**
None

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.