### PR TITLE
cleanup: Use --delete-secret-and-public-key to delete GPG_PRIVATE_KEY

### DIFF
--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -63237,10 +63237,9 @@ function importKey(privateKey) {
 exports.importKey = importKey;
 function deleteKey(keyFingerprint) {
     return __awaiter(this, void 0, void 0, function* () {
-        yield exec.exec('gpg', ['--batch', '--yes', '--delete-secret-keys', keyFingerprint], {
+        yield exec.exec('gpg', ['--batch', '--yes', '--delete-secret-and-public-key', keyFingerprint], {
             silent: true
         });
-        yield exec.exec('gpg', ['--batch', '--yes', '--delete-keys', keyFingerprint], { silent: true });
     });
 }
 exports.deleteKey = deleteKey;

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -94689,10 +94689,9 @@ function importKey(privateKey) {
 exports.importKey = importKey;
 function deleteKey(keyFingerprint) {
     return __awaiter(this, void 0, void 0, function* () {
-        yield exec.exec('gpg', ['--batch', '--yes', '--delete-secret-keys', keyFingerprint], {
+        yield exec.exec('gpg', ['--batch', '--yes', '--delete-secret-and-public-key', keyFingerprint], {
             silent: true
         });
-        yield exec.exec('gpg', ['--batch', '--yes', '--delete-keys', keyFingerprint], { silent: true });
     });
 }
 exports.deleteKey = deleteKey;

--- a/src/gpg.ts
+++ b/src/gpg.ts
@@ -39,8 +39,7 @@ export async function importKey(privateKey: string) {
 }
 
 export async function deleteKey(keyFingerprint: string) {
-  await exec.exec('gpg', ['--batch', '--yes', '--delete-secret-keys', keyFingerprint], {
+  await exec.exec('gpg', ['--batch', '--yes', '--delete-secret-and-public-key', keyFingerprint], {
     silent: true
   });
-  await exec.exec('gpg', ['--batch', '--yes', '--delete-keys', keyFingerprint], { silent: true });
 }


### PR DESCRIPTION
**Description:**
This deletes the secret key(s) and public keys(s) for the fingerprint
of the installed GPG_PRIVATE_KEY.

If the installed GPG_PRIVATE_KEY only contains a signing subkey without
the primary private key, the --delete-secret-and-public-key will
successfully delete the keys.

**Related issue:**
Issue #200 can occur when the installed GPG_PRIVATE_KEY only contains a signing subkey without
the primary private key.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.