### PR TITLE
Fix the Licensed workflow

### DIFF
--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install licensed
         run: |
           cd $RUNNER_TEMP
-          curl -Lfs -o licensed.tar.gz https://github.com/github/licensed/releases/download/2.12.2/licensed-2.12.2-linux-x64.tar.gz
+          curl -Lfs -o licensed.tar.gz https://github.com/github/licensed/releases/download/3.3.1/licensed-3.3.1-linux-x64.tar.gz
           sudo tar -xzf licensed.tar.gz
           sudo mv licensed /usr/local/bin/licensed
       - run: licensed status


### PR DESCRIPTION
**Description:**
The Licensed workflow is failing in https://github.com/actions/setup-java/pull/252.  I don't see any changes there that would cause it to fail.  This PR is to make sure it still passes on `main` and to fix any issues.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.

**Testing**
Red run before fix: https://github.com/actions/setup-java/actions/runs/1555484816
Green run after fix: https://github.com/actions/setup-java/actions/runs/1555526992