### PR TITLE
Add an error condition for an unstable Microsoft OpenJDK build

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -13886,6 +13886,9 @@ class MicrosoftDistributions extends base_installer_1.JavaBase {
             if (this.architecture !== 'x64' && this.architecture !== 'aarch64') {
                 throw new Error(`Unsupported architecture: ${this.architecture}`);
             }
+            if (!this.stable) {
+                throw new Error('Unstable versions are not supported');
+            }
             const availableVersionsRaw = yield this.getAvailableVersions();
             const opts = this.getPlatformOption();
             const availableVersions = availableVersionsRaw.map(item => ({

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -13887,7 +13887,7 @@ class MicrosoftDistributions extends base_installer_1.JavaBase {
                 throw new Error(`Unsupported architecture: ${this.architecture}`);
             }
             if (!this.stable) {
-                throw new Error('Unstable versions are not supported');
+                throw new Error('Early access versions are not supported');
             }
             const availableVersionsRaw = yield this.getAvailableVersions();
             const opts = this.getPlatformOption();

--- a/src/distributions/microsoft/installer.ts
+++ b/src/distributions/microsoft/installer.ts
@@ -40,6 +40,11 @@ export class MicrosoftDistributions extends JavaBase {
     if (this.architecture !== 'x64' && this.architecture !== 'aarch64') {
       throw new Error(`Unsupported architecture: ${this.architecture}`);
     }
+
+    if (!this.stable) {
+      throw new Error('Unstable versions are not supported');
+    }
+
     const availableVersionsRaw = await this.getAvailableVersions();
 
     const opts = this.getPlatformOption();

--- a/src/distributions/microsoft/installer.ts
+++ b/src/distributions/microsoft/installer.ts
@@ -42,7 +42,7 @@ export class MicrosoftDistributions extends JavaBase {
     }
 
     if (!this.stable) {
-      throw new Error('Unstable versions are not supported');
+      throw new Error('Early access versions are not supported');
     }
 
     const availableVersionsRaw = await this.getAvailableVersions();


### PR DESCRIPTION
**Description:**
In scope of this pull request we add condition to throw an error for an unstable `Microsoft OpenJDK` build. Some distributions support early access versions with syntax `11-ea`. For now `Microsoft OpenJDK` does not provide `ea` versions. The action will not throw an error if user tries to install `ea` version for `Microsoft OpenJDK`

**Related issue:**

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.