### PR TITLE
Add an error condition for non jdk Microsoft OpenJDK build

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -13890,8 +13890,7 @@ class MicrosoftDistributions extends base_installer_1.JavaBase {
                 throw new Error('Early access versions are not supported');
             }
             if (this.packageType !== 'jdk') {
-                this.packageType = 'jdk';
-                core.warning('Microsoft Build of OpenJDK always uses the `jdk` package type.  Remove the `java-package` argument when calling the action to silence this warning.');
+                throw new Error('Microsoft Build of OpenJDK provides only the `jdk` package type');
             }
             const availableVersionsRaw = yield this.getAvailableVersions();
             const opts = this.getPlatformOption();

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -13889,6 +13889,9 @@ class MicrosoftDistributions extends base_installer_1.JavaBase {
             if (!this.stable) {
                 throw new Error('Early access versions are not supported');
             }
+            if (this.packageType !== 'jdk') {
+                throw new Error(`${this.packageType} versions are not supported`);
+            }
             const availableVersionsRaw = yield this.getAvailableVersions();
             const opts = this.getPlatformOption();
             const availableVersions = availableVersionsRaw.map(item => ({

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -13890,7 +13890,8 @@ class MicrosoftDistributions extends base_installer_1.JavaBase {
                 throw new Error('Early access versions are not supported');
             }
             if (this.packageType !== 'jdk') {
-                throw new Error(`${this.packageType} versions are not supported`);
+                this.packageType = 'jdk';
+                core.warning('Microsoft Build of OpenJDK always uses the `jdk` package type.  Remove the `java-package` argument when calling the action to silence this warning.');
             }
             const availableVersionsRaw = yield this.getAvailableVersions();
             const opts = this.getPlatformOption();

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -65,6 +65,17 @@ steps:
 - run: java -cp java HelloWorldApp
 ```
 
+### Microsoft
+```yaml
+steps:
+- uses: actions/checkout@v2
+- uses: actions/setup-java@v2
+  with:
+    distribution: 'microsoft'
+    java-version: '11'
+- run: java -cp java HelloWorldApp
+```
+
 ## Installing custom Java package type
 ```yaml
 steps:

--- a/src/distributions/microsoft/installer.ts
+++ b/src/distributions/microsoft/installer.ts
@@ -46,10 +46,7 @@ export class MicrosoftDistributions extends JavaBase {
     }
 
     if (this.packageType !== 'jdk') {
-      this.packageType = 'jdk';
-      core.warning(
-        'Microsoft Build of OpenJDK always uses the `jdk` package type.  Remove the `java-package` argument when calling the action to silence this warning.'
-      );
+      throw new Error('Microsoft Build of OpenJDK provides only the `jdk` package type');
     }
 
     const availableVersionsRaw = await this.getAvailableVersions();

--- a/src/distributions/microsoft/installer.ts
+++ b/src/distributions/microsoft/installer.ts
@@ -46,7 +46,10 @@ export class MicrosoftDistributions extends JavaBase {
     }
 
     if (this.packageType !== 'jdk') {
-      throw new Error(`${this.packageType} versions are not supported`);
+      this.packageType = 'jdk';
+      core.warning(
+        'Microsoft Build of OpenJDK always uses the `jdk` package type.  Remove the `java-package` argument when calling the action to silence this warning.'
+      );
     }
 
     const availableVersionsRaw = await this.getAvailableVersions();

--- a/src/distributions/microsoft/installer.ts
+++ b/src/distributions/microsoft/installer.ts
@@ -45,6 +45,10 @@ export class MicrosoftDistributions extends JavaBase {
       throw new Error('Early access versions are not supported');
     }
 
+    if (this.packageType !== 'jdk') {
+      throw new Error(`${this.packageType} versions are not supported`);
+    }
+
     const availableVersionsRaw = await this.getAvailableVersions();
 
     const opts = this.getPlatformOption();


### PR DESCRIPTION
**Description:**
In scope of this pull request we update documentation and add logic to throw an error for non `jdk` versions for `Microsoft OpenJDK build`. `Microsoft OpenJDK build` supports only `jdk` for now.

**Related issue:**

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.