### PR TITLE
Add `cache-mode` option to control cache usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Currently, the following distributions are supported:
 ### Caching packages dependencies
 The action has a built-in functionality for caching and restoring dependencies. It uses [actions/cache](https://github.com/actions/cache) under hood for caching dependencies but requires less configuration settings. Supported package managers are gradle and maven. The cache input is optional, and caching is turned off by default.
 
+The option to use the cache in a read-only mode is available via the parameter `cache-is-read-only`, which
+defaults to `false`. When set to `true`, and caching is enabled, this allows PR workflows to benefit from 
+cached build artifacts, but not taint the cache with PR specific changes which may be in a state of flux.
+
 #### Caching gradle dependencies
 ```yaml
 steps:

--- a/README.md
+++ b/README.md
@@ -68,9 +68,11 @@ Currently, the following distributions are supported:
 ### Caching packages dependencies
 The action has a built-in functionality for caching and restoring dependencies. It uses [actions/cache](https://github.com/actions/cache) under hood for caching dependencies but requires less configuration settings. Supported package managers are gradle and maven. The cache input is optional, and caching is turned off by default.
 
-The option to use the cache in a read-only mode is available via the parameter `cache-is-read-only`, which
-defaults to `false`. When set to `true`, and caching is enabled, this allows PR workflows to benefit from 
-cached build artifacts, but not taint the cache with PR specific changes which may be in a state of flux.
+The interaction with the cache can be controlled by the `cache-mode` parameter. This allows for builds to
+be performed with no cache, and the output cached (`write` mode), builds to read the cache before running
+but not update the cache afterwards (`read` mode), or both (`both` mode). This feature allows you to
+populate the cache from your `main` branch, and then let PR builds benefit from that cache without polluting
+it with PR-specific build artifacts.
 
 #### Caching gradle dependencies
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,9 @@ inputs:
   cache:
     description: 'Name of the build platform to cache dependencies. It can be "maven" or "gradle".'
     required: false
+  cache-is-read-only:
+    description: 'Whether or not the build output should be cached. Default is true.'
+    default: true
   job-status:
     description: 'Workaround to pass job status to post job step. This variable is not intended for manual setting'
     default: ${{ job.status }}

--- a/action.yml
+++ b/action.yml
@@ -56,9 +56,9 @@ inputs:
   cache:
     description: 'Name of the build platform to cache dependencies. It can be "maven" or "gradle".'
     required: false
-  cache-is-read-only:
-    description: 'Whether or not the build output should be cached. Default is true.'
-    default: true
+  cache-mode:
+    description: 'Whether the cache should be read from pre-build, written to afterwards, or both'
+    default: both
   job-status:
     description: 'Workaround to pass job status to post job step. This variable is not intended for manual setting'
     default: ${{ job.status }}

--- a/src/cleanup-java.ts
+++ b/src/cleanup-java.ts
@@ -23,8 +23,9 @@ async function removePrivateKeyFromKeychain() {
 async function saveCache() {
   const jobStatus = isJobStatusSuccess();
   const cache = core.getInput(constants.INPUT_CACHE);
-  const readOnlyCache = core.getInput(constants.INPUT_CACHE_READ_ONLY)
-  return jobStatus && cache && !readOnlyCache ? save(cache) : Promise.resolve();
+  const cacheMode = core.getInput(constants.INPUT_CACHE_MODE)
+  const updateCache = Boolean(cacheMode === "both" || cacheMode === "write")
+  return jobStatus && cache && updateCache ? save(cache) : Promise.resolve();
 }
 
 /**

--- a/src/cleanup-java.ts
+++ b/src/cleanup-java.ts
@@ -23,7 +23,8 @@ async function removePrivateKeyFromKeychain() {
 async function saveCache() {
   const jobStatus = isJobStatusSuccess();
   const cache = core.getInput(constants.INPUT_CACHE);
-  return jobStatus && cache ? save(cache) : Promise.resolve();
+  const readOnlyCache = core.getInput(constants.INPUT_CACHE_READ_ONLY)
+  return jobStatus && cache && !readOnlyCache ? save(cache) : Promise.resolve();
 }
 
 /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,7 +17,7 @@ export const INPUT_DEFAULT_GPG_PRIVATE_KEY = undefined;
 export const INPUT_DEFAULT_GPG_PASSPHRASE = 'GPG_PASSPHRASE';
 
 export const INPUT_CACHE = 'cache';
-export const INPUT_CACHE_READ_ONLY = "cache-is-read-only";
+export const INPUT_CACHE_MODE = "cache-mode";
 export const INPUT_JOB_STATUS = 'job-status';
 
 export const STATE_GPG_PRIVATE_KEY_FINGERPRINT = 'gpg-private-key-fingerprint';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,6 +17,7 @@ export const INPUT_DEFAULT_GPG_PRIVATE_KEY = undefined;
 export const INPUT_DEFAULT_GPG_PASSPHRASE = 'GPG_PASSPHRASE';
 
 export const INPUT_CACHE = 'cache';
+export const INPUT_CACHE_READ_ONLY = "cache-is-read-only";
 export const INPUT_JOB_STATUS = 'job-status';
 
 export const STATE_GPG_PRIVATE_KEY_FINGERPRINT = 'gpg-private-key-fingerprint';

--- a/src/setup-java.ts
+++ b/src/setup-java.ts
@@ -42,7 +42,9 @@ async function run() {
     core.info(`##[add-matcher]${path.join(matchersPath, 'java.json')}`);
 
     await auth.configureAuthentication();
-    if (cache) {
+    const cacheMode = core.getInput(constants.INPUT_CACHE_MODE)
+    const restoreCache = Boolean(cacheMode === "both" || cacheMode === "read")
+    if (cache && restoreCache) {
       await restore(cache);
     }
   } catch (error) {


### PR DESCRIPTION
**Description:**
Introduces the optional `cache-mode` input, which allows workflows to have read-only and write-only caches, as well as
the default read-write caches.

This can reduce workflow runtime for situations, such as PRs, where the build artifacts may be disposable and of little use to other workflow runs, because PRs on the `main` branch can create the cache (using `write` or `both` mode), and PRs can build using that cache without polluting it with PR revision specific build output (using `read` mode)

**Related issue:**
https://github.com/actions/setup-java/issues/267

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.