### PR TITLE
Set output `cache-hit` to indicate if cache was hit

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ The action has a built-in functionality for caching and restoring dependencies. 
 - gradle: `**/*.gradle*`, `**/gradle-wrapper.properties`
 - maven: `**/pom.xml`
 
+The workflow output `cache-hit` is set to indicate if an exact match was found for the key [as actions/cache does](https://github.com/actions/cache/tree/main#outputs).
+
 The cache input is optional, and caching is turned off by default.
 
 #### Caching gradle dependencies

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -61873,9 +61873,11 @@ function restore(id) {
         ]);
         if (matchedKey) {
             core.saveState(CACHE_MATCHED_KEY, matchedKey);
+            core.setOutput('cache-hit', true);
             core.info(`Cache restored from key: ${matchedKey}`);
         }
         else {
+            core.setOutput('cache-hit', false);
             core.info(`${packageManager.id} cache is not found`);
         }
     });

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -61873,7 +61873,7 @@ function restore(id) {
         ]);
         if (matchedKey) {
             core.saveState(CACHE_MATCHED_KEY, matchedKey);
-            core.setOutput('cache-hit', true);
+            core.setOutput('cache-hit', matchedKey === primaryKey);
             core.info(`Cache restored from key: ${matchedKey}`);
         }
         else {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -18664,9 +18664,11 @@ function restore(id) {
         ]);
         if (matchedKey) {
             core.saveState(CACHE_MATCHED_KEY, matchedKey);
+            core.setOutput('cache-hit', true);
             core.info(`Cache restored from key: ${matchedKey}`);
         }
         else {
+            core.setOutput('cache-hit', false);
             core.info(`${packageManager.id} cache is not found`);
         }
     });

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -18664,7 +18664,7 @@ function restore(id) {
         ]);
         if (matchedKey) {
             core.saveState(CACHE_MATCHED_KEY, matchedKey);
-            core.setOutput('cache-hit', true);
+            core.setOutput('cache-hit', matchedKey === primaryKey);
             core.info(`Cache restored from key: ${matchedKey}`);
         }
         else {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -77,8 +77,10 @@ export async function restore(id: string) {
   ]);
   if (matchedKey) {
     core.saveState(CACHE_MATCHED_KEY, matchedKey);
+    core.setOutput('cache-hit', true);
     core.info(`Cache restored from key: ${matchedKey}`);
   } else {
+    core.setOutput('cache-hit', false);
     core.info(`${packageManager.id} cache is not found`);
   }
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -77,7 +77,7 @@ export async function restore(id: string) {
   ]);
   if (matchedKey) {
     core.saveState(CACHE_MATCHED_KEY, matchedKey);
-    core.setOutput('cache-hit', true);
+    core.setOutput('cache-hit', matchedKey === primaryKey);
     core.info(`Cache restored from key: ${matchedKey}`);
   } else {
     core.setOutput('cache-hit', false);


### PR DESCRIPTION
**Description:**
Add the `cache-hit` output to be able to execute later steps depending on if the cache was hit like it is possible with [actions/cache](https://github.com/actions/cache). Like described here: https://github.com/actions/cache/tree/main#Skipping-steps-based-on-cache-hit

**Related issue:**
~None~
Edit: Later this issue came up, which is addressed here: https://github.com/actions/setup-java/issues/306

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.