### PR TITLE
Support http url directly in jdkFile

### DIFF
--- a/.github/workflows/e2e-local-file.yml
+++ b/.github/workflows/e2e-local-file.yml
@@ -121,3 +121,39 @@ jobs:
       - name: Verify Java version
         run: bash __tests__/verify-java.sh "11.0.12" "${{ steps.setup-java.outputs.path }}"
         shell: bash
+
+  setup-java-remote-file-temurin:
+    name: Validate download from remote file Eclipse Temurin
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Download Eclipse Temurin file
+        run: |
+          if ($IsLinux) {
+            $downloadUrl = "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.12_7.tar.gz"
+            $localFilename = "java_package.tar.gz"
+          } elseif ($IsMacOS) {
+            $downloadUrl = "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x64_mac_hotspot_11.0.12_7.tar.gz"
+            $localFilename = "java_package.tar.gz"
+          } elseif ($IsWindows) {
+            $downloadUrl = "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x64_windows_hotspot_11.0.12_7.zip"
+            $localFilename = "java_package.zip"
+          }
+          echo "DownloadUrl=$downloadUrl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        shell: pwsh
+      - name: setup-java
+        uses: ./
+        id: setup-java
+        with:
+          distribution: 'jdkfile'
+          jdkFile: ${{ env.DownloadUrl }}
+          java-version: '11.0.0-ea'
+          architecture: x64
+      - name: Verify Java version
+        run: bash __tests__/verify-java.sh "11.0.12" "${{ steps.setup-java.outputs.path }}"
+        shell: bash

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ jobs:
 - [Installing custom Java package type](docs/advanced-usage.md#Installing-custom-Java-package-type)
 - [Installing custom Java architecture](docs/advanced-usage.md#Installing-custom-Java-architecture)
 - [Installing custom Java distribution from local file](docs/advanced-usage.md#Installing-Java-from-local-file)
+- [Installing Java from remote archive](docs/advanced-usage.md#Installing-Java-from-remote-archive)
 - [Testing against different Java distributions](docs/advanced-usage.md#Testing-against-different-Java-distributions)
 - [Testing against different platforms](docs/advanced-usage.md#Testing-against-different-platforms)
 - [Publishing using Apache Maven](docs/advanced-usage.md#Publishing-using-Apache-Maven)

--- a/__tests__/distributors/local-installer.test.ts
+++ b/__tests__/distributors/local-installer.test.ts
@@ -161,6 +161,36 @@ describe('setupJava', () => {
     );
   });
 
+  it('java is downloaded from remote jdkfile', async () => {
+    const inputs = {
+      version: '11.0.289',
+      architecture: 'x86',
+      packageType: 'jdk',
+      checkLatest: false
+    };
+    const expected = {
+      version: '11.0.289',
+      path: path.join('Java_jdkfile_jdk', inputs.version, inputs.architecture)
+    };
+
+    const jdkFile = 'https://example.com/jdk.tar.gz';
+
+    const spyTcDownloadTool = jest.spyOn(tc, 'downloadTool');
+    spyTcDownloadTool.mockReturnValue(Promise.resolve(expectedJdkFile));
+
+    mockJavaBase = new LocalDistribution(inputs, jdkFile);
+    await expect(mockJavaBase.setupJava()).resolves.toEqual(expected);
+    expect(spyTcFindAllVersions).toHaveBeenCalled();
+    expect(spyTcDownloadTool).toHaveBeenCalledWith(jdkFile);
+    expect(spyCoreInfo).not.toHaveBeenCalledWith(
+      `Resolved Java ${actualJavaVersion} from tool-cache`
+    );
+    expect(spyCoreInfo).toHaveBeenCalledWith(`Extracting Java from '${expectedJdkFile}'`);
+    expect(spyCoreInfo).toHaveBeenCalledWith(
+      `Java ${inputs.version} was not found in tool-cache. Trying to unpack JDK file...`
+    );
+  });
+
   it('jdk file is not found', async () => {
     const inputs = {
       version: '11.0.289',

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     required: false
     default: 'x64'
   jdkFile:
-    description: 'Path to where the compressed JDK is located'
+    description: 'Path to where the compressed JDK is located, or URL where it should be downloaded from'
     required: false
   check-latest:
     description: 'Set this option if you want the action to check for the latest available version that satisfies the version spec'

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -43501,17 +43501,9 @@ AbortError.prototype = Object.create(Error.prototype);
 AbortError.prototype.constructor = AbortError;
 AbortError.prototype.name = 'AbortError';
 
-const URL$1 = Url.URL || whatwgUrl.URL;
-
 // fix an issue where "PassThrough", "resolve" aren't a named export for node <10
 const PassThrough$1 = Stream.PassThrough;
-
-const isDomainOrSubdomain = function isDomainOrSubdomain(destination, original) {
-	const orig = new URL$1(original).hostname;
-	const dest = new URL$1(destination).hostname;
-
-	return orig === dest || orig[orig.length - dest.length - 1] === '.' && orig.endsWith(dest);
-};
+const resolve_url = Url.resolve;
 
 /**
  * Fetch function
@@ -43599,19 +43591,7 @@ function fetch(url, opts) {
 				const location = headers.get('Location');
 
 				// HTTP fetch step 5.3
-				let locationURL = null;
-				try {
-					locationURL = location === null ? null : new URL$1(location, request.url).toString();
-				} catch (err) {
-					// error here can only be invalid URL in Location: header
-					// do not throw when options.redirect == manual
-					// let the user extract the errorneous redirect URL
-					if (request.redirect !== 'manual') {
-						reject(new FetchError(`uri requested responds with an invalid redirect URL: ${location}`, 'invalid-redirect'));
-						finalize();
-						return;
-					}
-				}
+				const locationURL = location === null ? null : resolve_url(request.url, location);
 
 				// HTTP fetch step 5.5
 				switch (request.redirect) {
@@ -43658,12 +43638,6 @@ function fetch(url, opts) {
 							timeout: request.timeout,
 							size: request.size
 						};
-
-						if (!isDomainOrSubdomain(request.url, locationURL)) {
-							for (const name of ['authorization', 'www-authenticate', 'cookie', 'cookie2']) {
-								requestOpts.headers.delete(name);
-							}
-						}
 
 						// HTTP-redirect fetch step 9
 						if (res.statusCode !== 303 && request.body && getTotalBytes(request) === null) {

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -120,6 +120,21 @@ steps:
 - run: java -cp java HelloWorldApp
 ```
 
+## Installing Java from remote archive
+If your use-case requires a custom distribution or a version that is not provided by setup-java, you can specify URL directly and setup-java will take care of the installation and caching on the VM:
+
+```yaml
+steps:
+- uses: actions/setup-java@v2
+  with:
+    distribution: 'jdkfile'
+    jdkFile: https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz
+    java-version: '11.0.0'
+    architecture: x64
+    
+- run: java -cp java HelloWorldApp
+```
+
 ## Testing against different Java distributions
 **NOTE:** The different distributors can provide discrepant list of available versions / supported configurations. Please refer to the official documentation to see the list of supported versions.
 ```yaml


### PR DESCRIPTION
**Description:**
`jdkFile` parameter now supports http(s):// URLs directly, without need of extra step for downloading the archive.


**Related issue:**
#232

**Check list:**
- [X] Mark if documentation changes are required.
- [X] Mark if tests were added or updated to cover the changes.