### PR TITLE
Add Maven Toolchains Declaration (#276)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The `setup-java` action provides the following functionality for GitHub Actions 
 - Caching dependencies managed by Apache Maven
 - Caching dependencies managed by Gradle
 - Caching dependencies managed by sbt
+- [Maven Toolchains declaration](https://maven.apache.org/guides/mini/guide-using-toolchains.html) for specified JDK versions
 
 This action allows you to work with Java and Scala projects.
 
@@ -37,7 +38,7 @@ This action allows you to work with Java and Scala projects.
   - `cache`: Quick [setup caching](#caching-packages-dependencies) for the dependencies managed through one of the predifined package managers. It can be one of "maven", "gradle" or "sbt". 
 
   #### Maven options
-  The action has a bunch of inputs to generate maven's [settings.xml](https://maven.apache.org/settings.html) on the fly and pass the values to Apache Maven GPG Plugin. See [advanced usage](docs/advanced-usage.md) for more.
+  The action has a bunch of inputs to generate maven's [settings.xml](https://maven.apache.org/settings.html) on the fly and pass the values to Apache Maven GPG Plugin as well as Apache Maven Toolchains. See [advanced usage](docs/advanced-usage.md) for more.
 
   - `overwrite-settings`: By default action overwrites the settings.xml. In order to skip generation of file if it exists set this to `false`.
 
@@ -52,6 +53,10 @@ This action allows you to work with Java and Scala projects.
   - `gpg-private-key`: GPG private key to import. Default is empty string.'
 
   - `gpg-passphrase`: description: 'Environment variable name for the GPG private key passphrase. Default is GPG_PASSPHRASE.
+
+  - `mvn-toolchain-id`: Name of Maven Toolchain ID if the default name of `${distribution}_${java-version}` is not wanted.
+
+  - `mvn-toolchain-vendor`: Name of Maven Toolchain Vendor if the default name of `${distribution}` is not wanted.
 
 ### Basic Configuration
 
@@ -203,7 +208,11 @@ All versions are added to the PATH. The last version will be used and available 
             15
 ```
 
+### Using Maven Toolchains
+In the example above multiple JDKs are installed for the same job. The result after the last JDK is installed is a Maven Toolchains declaration containing references to all three JDKs. The values for `id`, `version`, and `vendor` of the individual Toolchain entries are the given input values for `distribution` and `java-version` (`vendor` being the combination of `${distribution}_${java-version}`) by default.
+
 ### Advanced Configuration
+
 - [Selecting a Java distribution](docs/advanced-usage.md#Selecting-a-Java-distribution)
   - [Eclipse Temurin](docs/advanced-usage.md#Eclipse-Temurin)
   - [Adopt](docs/advanced-usage.md#Adopt)
@@ -219,6 +228,7 @@ All versions are added to the PATH. The last version will be used and available 
 - [Publishing using Apache Maven](docs/advanced-usage.md#Publishing-using-Apache-Maven)
 - [Publishing using Gradle](docs/advanced-usage.md#Publishing-using-Gradle)
 - [Hosted Tool Cache](docs/advanced-usage.md#Hosted-Tool-Cache)
+- [Modifying Maven Toolchains](docs/advanced-usage.md#Modifying-Maven-Toolchains)
 
 ## License
 

--- a/__tests__/auth.test.ts
+++ b/__tests__/auth.test.ts
@@ -5,9 +5,10 @@ import * as core from '@actions/core';
 import os from 'os';
 
 import * as auth from '../src/auth';
+import { M2_DIR, MVN_SETTINGS_FILE } from '../src/constants';
 
-const m2Dir = path.join(__dirname, auth.M2_DIR);
-const settingsFile = path.join(m2Dir, auth.SETTINGS_FILE);
+const m2Dir = path.join(__dirname, M2_DIR);
+const settingsFile = path.join(m2Dir, MVN_SETTINGS_FILE);
 
 describe('auth tests', () => {
   let spyOSHomedir: jest.SpyInstance;
@@ -38,7 +39,7 @@ describe('auth tests', () => {
     const password = 'TOLKIEN';
 
     const altHome = path.join(__dirname, 'runner', 'settings');
-    const altSettingsFile = path.join(altHome, auth.SETTINGS_FILE);
+    const altSettingsFile = path.join(altHome, MVN_SETTINGS_FILE);
     await io.rmRF(altHome); // ensure it doesn't already exist
 
     await auth.createAuthenticationSettings(id, username, password, altHome, true);

--- a/__tests__/toolchains.test.ts
+++ b/__tests__/toolchains.test.ts
@@ -1,0 +1,292 @@
+import * as fs from 'fs';
+import os from 'os';
+import * as path from 'path';
+import * as core from '@actions/core';
+import * as io from '@actions/io';
+import * as toolchains from '../src/toolchains';
+import { M2_DIR, MVN_TOOLCHAINS_FILE } from '../src/constants';
+
+const m2Dir = path.join(__dirname, M2_DIR);
+const toolchainsFile = path.join(m2Dir, MVN_TOOLCHAINS_FILE);
+
+describe('toolchains tests', () => {
+  let spyOSHomedir: jest.SpyInstance;
+  let spyInfo: jest.SpyInstance;
+
+  beforeEach(async () => {
+    await io.rmRF(m2Dir);
+    spyOSHomedir = jest.spyOn(os, 'homedir');
+    spyOSHomedir.mockReturnValue(__dirname);
+    spyInfo = jest.spyOn(core, 'info');
+    spyInfo.mockImplementation(() => null);
+  }, 300000);
+
+  afterAll(async () => {
+    try {
+      await io.rmRF(m2Dir);
+    } catch {
+      console.log('Failed to remove test directories');
+    }
+    jest.resetAllMocks();
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  }, 100000);
+
+  it('creates toolchains.xml in alternate locations', async () => {
+    const jdkInfo = {
+      version: '17',
+      vendor: 'Eclipse Temurin',
+      id: 'temurin_17',
+      jdkHome: '/opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.1-12/x64'
+    };
+
+    const altHome = path.join(__dirname, 'runner', 'toolchains');
+    const altToolchainsFile = path.join(altHome, MVN_TOOLCHAINS_FILE);
+    await io.rmRF(altHome); // ensure it doesn't already exist
+
+    await toolchains.createToolchainsSettings({
+      jdkInfo,
+      settingsDirectory: altHome,
+      overwriteSettings: true
+    });
+
+    expect(fs.existsSync(m2Dir)).toBe(false);
+    expect(fs.existsSync(toolchainsFile)).toBe(false);
+
+    expect(fs.existsSync(altHome)).toBe(true);
+    expect(fs.existsSync(altToolchainsFile)).toBe(true);
+    expect(fs.readFileSync(altToolchainsFile, 'utf-8')).toEqual(
+      toolchains.generateToolchainDefinition(
+        '',
+        jdkInfo.version,
+        jdkInfo.vendor,
+        jdkInfo.id,
+        jdkInfo.jdkHome
+      )
+    );
+
+    await io.rmRF(altHome);
+  }, 100000);
+
+  it('creates toolchains.xml with minimal configuration', async () => {
+    const jdkInfo = {
+      version: '17',
+      vendor: 'Eclipse Temurin',
+      id: 'temurin_17',
+      jdkHome: '/opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.1-12/x64'
+    };
+
+    const result = `<?xml version="1.0"?>
+<toolchains xmlns="https://maven.apache.org/TOOLCHAINS/1.1.0"
+  xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://maven.apache.org/TOOLCHAINS/1.1.0 https://maven.apache.org/xsd/toolchains-1.1.0.xsd">
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>17</version>
+      <vendor>Eclipse Temurin</vendor>
+      <id>temurin_17</id>
+    </provides>
+    <configuration>
+      <jdkHome>/opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.1-12/x64</jdkHome>
+    </configuration>
+  </toolchain>
+</toolchains>`;
+
+    await toolchains.createToolchainsSettings({
+      jdkInfo,
+      settingsDirectory: m2Dir,
+      overwriteSettings: true
+    });
+
+    expect(fs.existsSync(m2Dir)).toBe(true);
+    expect(fs.existsSync(toolchainsFile)).toBe(true);
+    expect(fs.readFileSync(toolchainsFile, 'utf-8')).toEqual(
+      toolchains.generateToolchainDefinition(
+        '',
+        jdkInfo.version,
+        jdkInfo.vendor,
+        jdkInfo.id,
+        jdkInfo.jdkHome
+      )
+    );
+    expect(
+      toolchains.generateToolchainDefinition(
+        '',
+        jdkInfo.version,
+        jdkInfo.vendor,
+        jdkInfo.id,
+        jdkInfo.jdkHome
+      )
+    ).toEqual(result);
+  }, 100000);
+
+  it('reuses existing toolchains.xml files', async () => {
+    const jdkInfo = {
+      version: '17',
+      vendor: 'Eclipse Temurin',
+      id: 'temurin_17',
+      jdkHome: '/opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.1-12/x64'
+    };
+
+    const originalFile = `<toolchains>
+        <toolchain>
+            <type>jdk</type>
+        <provides>
+        <version>1.6</version>
+        <vendor>Sun</vendor>
+        <id>sun_1.6</id>
+        </provides>
+        <configuration>
+        <jdkHome>/opt/jdk/sun/1.6</jdkHome>
+        </configuration>
+        </toolchain>
+      </toolchains>`;
+    const result = `<?xml version="1.0"?>
+<toolchains>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>1.6</version>
+      <vendor>Sun</vendor>
+      <id>sun_1.6</id>
+    </provides>
+    <configuration>
+      <jdkHome>/opt/jdk/sun/1.6</jdkHome>
+    </configuration>
+  </toolchain>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>17</version>
+      <vendor>Eclipse Temurin</vendor>
+      <id>temurin_17</id>
+    </provides>
+    <configuration>
+      <jdkHome>/opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.1-12/x64</jdkHome>
+    </configuration>
+  </toolchain>
+</toolchains>`;
+
+    fs.mkdirSync(m2Dir, { recursive: true });
+    fs.writeFileSync(toolchainsFile, originalFile);
+    expect(fs.existsSync(m2Dir)).toBe(true);
+    expect(fs.existsSync(toolchainsFile)).toBe(true);
+
+    await toolchains.createToolchainsSettings({
+      jdkInfo,
+      settingsDirectory: m2Dir,
+      overwriteSettings: true
+    });
+
+    expect(fs.existsSync(m2Dir)).toBe(true);
+    expect(fs.existsSync(toolchainsFile)).toBe(true);
+    expect(fs.readFileSync(toolchainsFile, 'utf-8')).toEqual(
+      toolchains.generateToolchainDefinition(
+        originalFile,
+        jdkInfo.version,
+        jdkInfo.vendor,
+        jdkInfo.id,
+        jdkInfo.jdkHome
+      )
+    );
+    expect(
+      toolchains.generateToolchainDefinition(
+        originalFile,
+        jdkInfo.version,
+        jdkInfo.vendor,
+        jdkInfo.id,
+        jdkInfo.jdkHome
+      )
+    ).toEqual(result);
+  }, 100000);
+
+  it('does not overwrite existing toolchains.xml files', async () => {
+    const jdkInfo = {
+      version: '17',
+      vendor: 'Eclipse Temurin',
+      id: 'temurin_17',
+      jdkHome: '/opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.1-12/x64'
+    };
+
+    const originalFile = `<toolchains>
+        <toolchain>
+            <type>jdk</type>
+        <provides>
+        <version>1.6</version>
+        <vendor>Sun</vendor>
+        <id>sun_1.6</id>
+        </provides>
+        <configuration>
+        <jdkHome>/opt/jdk/sun/1.6</jdkHome>
+        </configuration>
+        </toolchain>
+      </toolchains>`;
+
+    fs.mkdirSync(m2Dir, { recursive: true });
+    fs.writeFileSync(toolchainsFile, originalFile);
+    expect(fs.existsSync(m2Dir)).toBe(true);
+    expect(fs.existsSync(toolchainsFile)).toBe(true);
+
+    await toolchains.createToolchainsSettings({
+      jdkInfo,
+      settingsDirectory: m2Dir,
+      overwriteSettings: false
+    });
+
+    expect(fs.existsSync(m2Dir)).toBe(true);
+    expect(fs.existsSync(toolchainsFile)).toBe(true);
+    expect(fs.readFileSync(toolchainsFile, 'utf-8')).toEqual(originalFile);
+  }, 100000);
+
+  it('generates valid toolchains.xml with minimal configuration', () => {
+    const jdkInfo = {
+      version: 'JAVA_VERSION',
+      vendor: 'JAVA_VENDOR',
+      id: 'VENDOR_VERSION',
+      jdkHome: 'JAVA_HOME'
+    };
+
+    const expectedToolchains = `<?xml version="1.0"?>
+<toolchains xmlns="https://maven.apache.org/TOOLCHAINS/1.1.0"
+  xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://maven.apache.org/TOOLCHAINS/1.1.0 https://maven.apache.org/xsd/toolchains-1.1.0.xsd">
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>${jdkInfo.version}</version>
+      <vendor>${jdkInfo.vendor}</vendor>
+      <id>${jdkInfo.id}</id>
+    </provides>
+    <configuration>
+      <jdkHome>${jdkInfo.jdkHome}</jdkHome>
+    </configuration>
+  </toolchain>
+</toolchains>`;
+
+    expect(
+      toolchains.generateToolchainDefinition(
+        '',
+        jdkInfo.version,
+        jdkInfo.vendor,
+        jdkInfo.id,
+        jdkInfo.jdkHome
+      )
+    ).toEqual(expectedToolchains);
+  }, 100000);
+
+  it('creates toolchains.xml with correct id when none is supplied', async () => {
+    const version = '17';
+    const distributionName = 'temurin';
+    const id = 'temurin_17';
+    const jdkHome = '/opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.1-12/x64';
+
+    await toolchains.configureToolchains(version, distributionName, jdkHome, undefined);
+
+    expect(fs.existsSync(m2Dir)).toBe(true);
+    expect(fs.existsSync(toolchainsFile)).toBe(true);
+    expect(fs.readFileSync(toolchainsFile, 'utf-8')).toEqual(
+      toolchains.generateToolchainDefinition('', version, distributionName, id, jdkHome)
+    );
+  }, 100000);
+});

--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,12 @@ inputs:
   token:
     description: Used to pull java versions from setup-java. Since there is a default value, token is typically not supplied by the user.
     default: ${{ github.token }}
+  mvn-toolchain-id:
+    description: 'Name of Maven Toolchain ID if the default name of "${distribution}_${java-version}" is not wanted. See examples of supported syntax in Advanced Usage file'
+    required: false
+  mvn-toolchain-vendor:
+    description: 'Name of Maven Toolchain Vendor if the default name of "${distribution}" is not wanted. See examples of supported syntax in Advanced Usage file'
+    required: false
 outputs:
   distribution:
     description: 'Distribution of Java that has been installed'

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -68406,7 +68406,7 @@ else {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.STATE_GPG_PRIVATE_KEY_FINGERPRINT = exports.INPUT_JOB_STATUS = exports.INPUT_CACHE = exports.INPUT_DEFAULT_GPG_PASSPHRASE = exports.INPUT_DEFAULT_GPG_PRIVATE_KEY = exports.INPUT_GPG_PASSPHRASE = exports.INPUT_GPG_PRIVATE_KEY = exports.INPUT_OVERWRITE_SETTINGS = exports.INPUT_SETTINGS_PATH = exports.INPUT_SERVER_PASSWORD = exports.INPUT_SERVER_USERNAME = exports.INPUT_SERVER_ID = exports.INPUT_CHECK_LATEST = exports.INPUT_JDK_FILE = exports.INPUT_DISTRIBUTION = exports.INPUT_JAVA_PACKAGE = exports.INPUT_ARCHITECTURE = exports.INPUT_JAVA_VERSION = exports.MACOS_JAVA_CONTENT_POSTFIX = void 0;
+exports.INPUT_MVN_TOOLCHAIN_VENDOR = exports.INPUT_MVN_TOOLCHAIN_ID = exports.MVN_TOOLCHAINS_FILE = exports.MVN_SETTINGS_FILE = exports.M2_DIR = exports.STATE_GPG_PRIVATE_KEY_FINGERPRINT = exports.INPUT_JOB_STATUS = exports.INPUT_CACHE = exports.INPUT_DEFAULT_GPG_PASSPHRASE = exports.INPUT_DEFAULT_GPG_PRIVATE_KEY = exports.INPUT_GPG_PASSPHRASE = exports.INPUT_GPG_PRIVATE_KEY = exports.INPUT_OVERWRITE_SETTINGS = exports.INPUT_SETTINGS_PATH = exports.INPUT_SERVER_PASSWORD = exports.INPUT_SERVER_USERNAME = exports.INPUT_SERVER_ID = exports.INPUT_CHECK_LATEST = exports.INPUT_JDK_FILE = exports.INPUT_DISTRIBUTION = exports.INPUT_JAVA_PACKAGE = exports.INPUT_ARCHITECTURE = exports.INPUT_JAVA_VERSION = exports.MACOS_JAVA_CONTENT_POSTFIX = void 0;
 exports.MACOS_JAVA_CONTENT_POSTFIX = 'Contents/Home';
 exports.INPUT_JAVA_VERSION = 'java-version';
 exports.INPUT_ARCHITECTURE = 'architecture';
@@ -68426,6 +68426,11 @@ exports.INPUT_DEFAULT_GPG_PASSPHRASE = 'GPG_PASSPHRASE';
 exports.INPUT_CACHE = 'cache';
 exports.INPUT_JOB_STATUS = 'job-status';
 exports.STATE_GPG_PRIVATE_KEY_FINGERPRINT = 'gpg-private-key-fingerprint';
+exports.M2_DIR = '.m2';
+exports.MVN_SETTINGS_FILE = 'settings.xml';
+exports.MVN_TOOLCHAINS_FILE = 'toolchains.xml';
+exports.INPUT_MVN_TOOLCHAIN_ID = 'mvn-toolchain-id';
+exports.INPUT_MVN_TOOLCHAIN_VENDOR = 'mvn-toolchain-vendor';
 
 
 /***/ }),

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -10,15 +10,12 @@ import * as constants from './constants';
 import * as gpg from './gpg';
 import { getBooleanInput } from './util';
 
-export const M2_DIR = '.m2';
-export const SETTINGS_FILE = 'settings.xml';
-
 export async function configureAuthentication() {
   const id = core.getInput(constants.INPUT_SERVER_ID);
   const username = core.getInput(constants.INPUT_SERVER_USERNAME);
   const password = core.getInput(constants.INPUT_SERVER_PASSWORD);
   const settingsDirectory =
-    core.getInput(constants.INPUT_SETTINGS_PATH) || path.join(os.homedir(), M2_DIR);
+    core.getInput(constants.INPUT_SETTINGS_PATH) || path.join(os.homedir(), constants.M2_DIR);
   const overwriteSettings = getBooleanInput(constants.INPUT_OVERWRITE_SETTINGS, true);
   const gpgPrivateKey =
     core.getInput(constants.INPUT_GPG_PRIVATE_KEY) || constants.INPUT_DEFAULT_GPG_PRIVATE_KEY;
@@ -54,7 +51,7 @@ export async function createAuthenticationSettings(
   overwriteSettings: boolean,
   gpgPassphrase: string | undefined = undefined
 ) {
-  core.info(`Creating ${SETTINGS_FILE} with server-id: ${id}`);
+  core.info(`Creating ${constants.MVN_SETTINGS_FILE} with server-id: ${id}`);
   // when an alternate m2 location is specified use only that location (no .m2 directory)
   // otherwise use the home/.m2/ path
   await io.mkdirP(settingsDirectory);
@@ -106,7 +103,7 @@ export function generate(
 }
 
 async function write(directory: string, settings: string, overwriteSettings: boolean) {
-  const location = path.join(directory, SETTINGS_FILE);
+  const location = path.join(directory, constants.MVN_SETTINGS_FILE);
   const settingsExists = fs.existsSync(location);
   if (settingsExists && overwriteSettings) {
     core.info(`Overwriting existing file ${location}`);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,3 +20,9 @@ export const INPUT_CACHE = 'cache';
 export const INPUT_JOB_STATUS = 'job-status';
 
 export const STATE_GPG_PRIVATE_KEY_FINGERPRINT = 'gpg-private-key-fingerprint';
+
+export const M2_DIR = '.m2';
+export const MVN_SETTINGS_FILE = 'settings.xml';
+export const MVN_TOOLCHAINS_FILE = 'toolchains.xml';
+export const INPUT_MVN_TOOLCHAIN_ID = 'mvn-toolchain-id';
+export const INPUT_MVN_TOOLCHAIN_VENDOR = 'mvn-toolchain-vendor';

--- a/src/toolchains.ts
+++ b/src/toolchains.ts
@@ -1,0 +1,158 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as core from '@actions/core';
+import * as io from '@actions/io';
+import * as constants from './constants';
+
+import { getBooleanInput } from './util';
+import { create as xmlCreate } from 'xmlbuilder2';
+
+interface JdkInfo {
+  version: string;
+  vendor: string;
+  id: string;
+  jdkHome: string;
+}
+
+export async function configureToolchains(
+  version: string,
+  distributionName: string,
+  jdkHome: string,
+  toolchainId?: string
+) {
+  const vendor = core.getInput(constants.INPUT_MVN_TOOLCHAIN_VENDOR) || distributionName;
+  const id = toolchainId || `${vendor}_${version}`;
+  const settingsDirectory =
+    core.getInput(constants.INPUT_SETTINGS_PATH) || path.join(os.homedir(), constants.M2_DIR);
+  const overwriteSettings = getBooleanInput(constants.INPUT_OVERWRITE_SETTINGS, true);
+
+  await createToolchainsSettings({
+    jdkInfo: {
+      version,
+      vendor,
+      id,
+      jdkHome
+    },
+    settingsDirectory,
+    overwriteSettings
+  });
+}
+
+export async function createToolchainsSettings({
+  jdkInfo,
+  settingsDirectory,
+  overwriteSettings
+}: {
+  jdkInfo: JdkInfo;
+  settingsDirectory: string;
+  overwriteSettings: boolean;
+}) {
+  core.info(
+    `Creating ${constants.MVN_TOOLCHAINS_FILE} for JDK version ${jdkInfo.version} from ${jdkInfo.vendor}`
+  );
+  // when an alternate m2 location is specified use only that location (no .m2 directory)
+  // otherwise use the home/.m2/ path
+  await io.mkdirP(settingsDirectory);
+  const originalToolchains = await readExistingToolchainsFile(settingsDirectory);
+  const updatedToolchains = generateToolchainDefinition(
+    originalToolchains,
+    jdkInfo.version,
+    jdkInfo.vendor,
+    jdkInfo.id,
+    jdkInfo.jdkHome
+  );
+  await writeToolchainsFileToDisk(settingsDirectory, updatedToolchains, overwriteSettings);
+}
+
+// only exported for testing purposes
+export function generateToolchainDefinition(
+  original: string,
+  version: string,
+  vendor: string,
+  id: string,
+  jdkHome: string
+) {
+  let xmlObj;
+  if (original?.length) {
+    xmlObj = xmlCreate(original)
+      .root()
+      .ele({
+        toolchain: {
+          type: 'jdk',
+          provides: {
+            version: `${version}`,
+            vendor: `${vendor}`,
+            id: `${id}`
+          },
+          configuration: {
+            jdkHome: `${jdkHome}`
+          }
+        }
+      });
+  } else
+    xmlObj = xmlCreate({
+      toolchains: {
+        '@xmlns': 'https://maven.apache.org/TOOLCHAINS/1.1.0',
+        '@xmlns:xsi': 'https://www.w3.org/2001/XMLSchema-instance',
+        '@xsi:schemaLocation':
+          'https://maven.apache.org/TOOLCHAINS/1.1.0 https://maven.apache.org/xsd/toolchains-1.1.0.xsd',
+        toolchain: [
+          {
+            type: 'jdk',
+            provides: {
+              version: `${version}`,
+              vendor: `${vendor}`,
+              id: `${id}`
+            },
+            configuration: {
+              jdkHome: `${jdkHome}`
+            }
+          }
+        ]
+      }
+    });
+
+  return xmlObj.end({
+    format: 'xml',
+    wellFormed: false,
+    headless: false,
+    prettyPrint: true,
+    width: 80
+  });
+}
+
+async function readExistingToolchainsFile(directory: string) {
+  const location = path.join(directory, constants.MVN_TOOLCHAINS_FILE);
+  if (fs.existsSync(location)) {
+    return fs.readFileSync(location, {
+      encoding: 'utf-8',
+      flag: 'r'
+    });
+  }
+  return '';
+}
+
+async function writeToolchainsFileToDisk(
+  directory: string,
+  settings: string,
+  overwriteSettings: boolean
+) {
+  const location = path.join(directory, constants.MVN_TOOLCHAINS_FILE);
+  const settingsExists = fs.existsSync(location);
+  if (settingsExists && overwriteSettings) {
+    core.info(`Overwriting existing file ${location}`);
+  } else if (!settingsExists) {
+    core.info(`Writing to ${location}`);
+  } else {
+    core.info(
+      `Skipping generation of ${location} because file already exists and overwriting is not enabled`
+    );
+    return;
+  }
+
+  return fs.writeFileSync(location, settings, {
+    encoding: 'utf-8',
+    flag: 'w'
+  });
+}


### PR DESCRIPTION
**Description:**
* Add Maven Toolchains Declaration after JDK is installed
* Extract common/shared Maven constants

**Related issue:**
#276 

**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.

---

I also used my fork + branch on a private repository's pipeline to verify a valid toolchains declaration is created for the specified JDK and used by a Maven based build job.

Technically, using `${env.JAVA_HOME}` inside the `toolchains.xml` file is possible, however, this will get interesting with #44 very fast. Not to mention that e.g. version and vendor are not exposed as variables anyway.