### PR TITLE
Updates the sbt cache docs in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Currently, the following distributions are supported:
 The action has a built-in functionality for caching and restoring dependencies. It uses [actions/cache](https://github.com/actions/cache) under hood for caching dependencies but requires less configuration settings. Supported package managers are gradle, maven and sbt. The format of the used cache key is `setup-java-${{ platform }}-${{ packageManager }}-${{ fileHash }}`, where the hash is based on the following files:
 - gradle: `**/*.gradle*`, `**/gradle-wrapper.properties`
 - maven: `**/pom.xml`
-- sbt:  `**/build.sbt`
+- sbt: all sbt build definition files `**/*.sbt`, `**/project/build.properties`, `**/project/**.{scala,sbt}`
 
 The workflow output `cache-hit` is set to indicate if an exact match was found for the key [as actions/cache does](https://github.com/actions/cache/tree/main#outputs).
 


### PR DESCRIPTION
**Description:**

The README's description of sbt's cache behaviour does not match the implementation. An `sbt` build can be modified from multiple places and the current cache invalidation behaviour correctly captures these cases. The README only mentions `build.sbt` files, which might mean teams with more experience using `sbt` unnecessarily add their own cache patterns here.

Here's the (current) implementation, for reference:
https://github.com/actions/setup-java/blob/860f60056505705214d223b91ed7a30f173f6142/src/cache.ts#L43

**Related issue:**
N/A

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.