### PR TITLE
Add Microsoft Java 11.0.15

### DIFF
--- a/src/distributions/microsoft/installer.ts
+++ b/src/distributions/microsoft/installer.ts
@@ -93,6 +93,9 @@ export class MicrosoftDistributions extends JavaBase {
       jdkVersions.push({
         version: [11, 0, 13, 8, 1]
       });
+      jdkVersions.push({
+        version: [11, 0, 15]
+      });
     }
 
     return jdkVersions;


### PR DESCRIPTION
**Description:**
11.0.15 is LTS version. It's important to have it in the list.

**Related issue:**
Fix https://github.com/actions/setup-java/issues/329

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.