### PR TITLE
Installing multiple JDKs that share the same JDK feature release number

### DIFF
--- a/__tests__/distributors/base-installer.test.ts
+++ b/__tests__/distributors/base-installer.test.ts
@@ -313,13 +313,31 @@ describe('normalizeVersion', () => {
     ['11.0.10', { version: '11.0.10', stable: true }],
     ['11-ea', { version: '11', stable: false }],
     ['11.0.2-ea', { version: '11.0.2', stable: false }]
-  ])('normalizeVersion from %s to %s', (input, expected) => {
-    expect(DummyJavaBase.prototype.normalizeVersion.call(null, input)).toEqual(expected);
+  ])('normalizeVersion from %s to %s if distribution is not local', (input, expected) => {
+    expect(DummyJavaBase.prototype.normalizeVersion.call({}, input)).toEqual(expected);
   });
 
-  it('normalizeVersion should throw an error for non semver', () => {
+  it.each([
+    ['11', { version: '11', stable: true }],
+    ['11.0', { version: '11.0', stable: true }],
+    ['11.0.10', { version: '11.0.10', stable: true }],
+    ['11-ea', { version: '11', stable: false }],
+    ['11.0.2-ea', { version: '11.0.2', stable: false }],
+    ['11g', { version: '11g', stable: true }]
+  ])('normalizeVersion from %s to %s if distribution is local', (input, expected) => {
+    expect(DummyJavaBase.prototype.normalizeVersion.call({distribution: 'jdkfile'}, input)).toEqual(expected);
+  });
+
+  it('normalizeVersion should throw an error for non semver if distribution is not local', () => {
     const version = '11g';
-    expect(DummyJavaBase.prototype.normalizeVersion.bind(null, version)).toThrowError(
+    expect(DummyJavaBase.prototype.normalizeVersion.bind({}, version)).toThrowError(
+      `The string '${version}' is not valid SemVer notation for a Java version. Please check README file for code snippets and more detailed information`
+    );
+  });
+
+  it('normalizeVersion should throw an error for non semver if distribution is local', () => {
+    const version = '11g';
+    expect(DummyJavaBase.prototype.normalizeVersion.bind({distribution: 'jdkfile'}, version)).not.toThrowError(
       `The string '${version}' is not valid SemVer notation for a Java version. Please check README file for code snippets and more detailed information`
     );
   });

--- a/__tests__/distributors/base-installer.test.ts
+++ b/__tests__/distributors/base-installer.test.ts
@@ -325,7 +325,9 @@ describe('normalizeVersion', () => {
     ['11.0.2-ea', { version: '11.0.2', stable: false }],
     ['11g', { version: '11g', stable: true }]
   ])('normalizeVersion from %s to %s if distribution is local', (input, expected) => {
-    expect(DummyJavaBase.prototype.normalizeVersion.call({distribution: 'jdkfile'}, input)).toEqual(expected);
+    expect(
+      DummyJavaBase.prototype.normalizeVersion.call({ distribution: 'jdkfile' }, input)
+    ).toEqual(expected);
   });
 
   it('normalizeVersion should throw an error for non semver if distribution is not local', () => {
@@ -337,7 +339,9 @@ describe('normalizeVersion', () => {
 
   it('normalizeVersion should throw an error for non semver if distribution is local', () => {
     const version = '11g';
-    expect(DummyJavaBase.prototype.normalizeVersion.bind({distribution: 'jdkfile'}, version)).not.toThrowError(
+    expect(
+      DummyJavaBase.prototype.normalizeVersion.bind({ distribution: 'jdkfile' }, version)
+    ).not.toThrowError(
       `The string '${version}' is not valid SemVer notation for a Java version. Please check README file for code snippets and more detailed information`
     );
   });

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -101850,7 +101850,7 @@ class JavaBase {
             version = version.replace('-ea.', '+');
             stable = false;
         }
-        if (!semver_1.default.validRange(version)) {
+        if (this.distribution !== 'jdkfile' && !semver_1.default.validRange(version)) {
             throw new Error(`The string '${version}' is not valid SemVer notation for a Java version. Please check README file for code snippets and more detailed information`);
         }
         return {

--- a/src/distributions/base-installer.ts
+++ b/src/distributions/base-installer.ts
@@ -129,7 +129,7 @@ export abstract class JavaBase {
       stable = false;
     }
 
-    if (!semver.validRange(version)) {
+    if (this.distribution !== 'jdkfile' && !semver.validRange(version)) {
       throw new Error(
         `The string '${version}' is not valid SemVer notation for a Java version. Please check README file for code snippets and more detailed information`
       );


### PR DESCRIPTION
**Description:**
 Instaling JDK with same feature version requires to set either [artificial](https://github.com/actions/setup-java/issues/359#issuecomment-1206281095) or non-semver valid `java-version` input.
 
 Samples of such JDKs:
  - openjdk-19-ea+33_linux-x64_bin.tar.gz
  - openjdk-19-jextract+2-3_linux-x64_bin.tar.gz

Currently it is not possible to set input to something like `19-ea` and users of action has to think out 'semver-like' java-version inout that is not straightforward. The PR relaxed the requirement for local distributons.

**Related issue:**
[Add link to the related issue.](https://github.com/actions/setup-java/issues/359)

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.