### PR TITLE
Improve dependencies cache usage

### DIFF
--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -98,8 +98,12 @@ describe('dependency cache', () => {
         await restore('maven', 'YYYY-MM');
         expect(spyCacheRestore).toBeCalledWith(
           [expect.stringContaining('/.m2/repository')],
-          expect.stringContaining('setup-java-YYYY-MM-macOS-maven-'),
-          ['setup-java-YYYY-MM-macOS-maven-', 'setup-java-YYYY-MM-macOS-', 'setup-java-YYYY-MM-']
+          expect.stringContaining(`setup-java-YYYY-MM-${process.env['RUNNER_OS']}-maven-`),
+          [
+            `setup-java-YYYY-MM-${process.env['RUNNER_OS']}-maven-`,
+            `setup-java-YYYY-MM-${process.env['RUNNER_OS']}-`,
+            'setup-java-YYYY-MM-'
+          ]
         );
         expect(spyWarning).not.toBeCalled();
         expect(spyInfo).toBeCalledWith('maven cache is not found');

--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -92,6 +92,18 @@ describe('dependency cache', () => {
         expect(spyWarning).not.toBeCalled();
         expect(spyInfo).toBeCalledWith('maven cache is not found');
       });
+      it('downloads cache with a custom key prefix', async () => {
+        createFile(join(workspace, 'pom.xml'));
+
+        await restore('maven', 'YYYY-MM');
+        expect(spyCacheRestore).toBeCalledWith(
+          [expect.stringContaining('/.m2/repository')],
+          expect.stringContaining('setup-java-YYYY-MM-macOS-maven-'),
+          ['setup-java-YYYY-MM-macOS-maven-', 'setup-java-YYYY-MM-macOS-', 'setup-java-YYYY-MM-']
+        );
+        expect(spyWarning).not.toBeCalled();
+        expect(spyInfo).toBeCalledWith('maven cache is not found');
+      });
     });
     describe('for gradle', () => {
       it('throws error if no build.gradle found', async () => {

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,9 @@ inputs:
   cache:
     description: 'Name of the build platform to cache dependencies. It can be "maven", "gradle" or "sbt".'
     required: false
+  cache-key-prefix:
+    description: 'Custom key prefix to give extra flexibility on managing the cache expiration'
+    required: false
   job-status:
     description: 'Workaround to pass job status to post job step. This variable is not intended for manual setting'
     default: ${{ job.status }}

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -14,6 +14,7 @@
 - [Publishing using Apache Maven](#Publishing-using-Apache-Maven)
 - [Publishing using Gradle](#Publishing-using-Gradle)
 - [Hosted Tool Cache](#Hosted-Tool-Cache)
+- [Expiring Dependencies Cache](#Expiring-Dependencies-Cache)
 
 See [action.yml](../action.yml) for more details on task inputs.
 
@@ -350,3 +351,33 @@ GitHub Hosted Runners have a tool cache that comes with some Java versions pre-i
 Currently, LTS versions of Adopt OpenJDK (`adopt`) are cached on the GitHub Hosted Runners.
 
 The tools cache gets updated on a weekly basis. For information regarding locally cached versions of Java on GitHub hosted runners, check out [GitHub Actions Virtual Environments](https://github.com/actions/virtual-environments).
+
+## Expiring Dependencies Cache
+
+You can define the `cache-key-prefix` input and either bump it manually, or use a certain time period. That way you can prevent the cache from growing abnormally.
+
+### Manually
+```yaml
+steps:
+- uses: actions/checkout@v3
+- uses: actions/setup-java@v3
+  with:
+    cache-key-prefix: V1
+- run: java -cp java HelloWorldApp
+```
+And then just bump `V1` manually.
+
+### Monthly
+```yaml
+steps:
+- uses: actions/checkout@v3
+- name: Get current month
+  id: month
+  run: echo "::set-output name=month::$(date +'%Y-%m')"
+- uses: actions/setup-java@v3
+  with:
+    cache-key-prefix: ${{ steps.month.outputs.month }}
+- run: java -cp java HelloWorldApp
+```
+The cache is busted automatically every month. 
+You can define any time period that better suits your pipeline.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,6 +17,7 @@ export const INPUT_DEFAULT_GPG_PRIVATE_KEY = undefined;
 export const INPUT_DEFAULT_GPG_PASSPHRASE = 'GPG_PASSPHRASE';
 
 export const INPUT_CACHE = 'cache';
+export const INPUT_CACHE_KEY_PREFIX = 'cache-key-prefix';
 export const INPUT_JOB_STATUS = 'job-status';
 
 export const STATE_GPG_PRIVATE_KEY_FINGERPRINT = 'gpg-private-key-fingerprint';

--- a/src/setup-java.ts
+++ b/src/setup-java.ts
@@ -15,6 +15,7 @@ async function run() {
     const packageType = core.getInput(constants.INPUT_JAVA_PACKAGE);
     const jdkFile = core.getInput(constants.INPUT_JDK_FILE);
     const cache = core.getInput(constants.INPUT_CACHE);
+    const cacheKeyPrefix = core.getInput(constants.INPUT_CACHE_KEY_PREFIX);
     const checkLatest = getBooleanInput(constants.INPUT_CHECK_LATEST, false);
 
     const installerOptions: JavaInstallerOptions = {
@@ -43,7 +44,7 @@ async function run() {
 
     await auth.configureAuthentication();
     if (cache && isCacheFeatureAvailable()) {
-      await restore(cache);
+      await restore(cache, cacheKeyPrefix);
     }
   } catch (error) {
     core.setFailed(error.message);


### PR DESCRIPTION
**Description:**
- Add `restore-keys` back
- Introduce new optional input to be used as a cache key prefix, and allow for more flexibility in expiring tainted caches
- Documentation

**Related issue:**
https://github.com/actions/setup-java/issues/366

**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.