### PR TITLE
Add Cache Hit Output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,8 @@ outputs:
     description: 'Actual version of the java environment that has been installed'
   path:
     description: 'Path to where the java environment has been installed (same as $JAVA_HOME)'
+  cache-hit:
+    description: 'A boolean value to indicate an exact match was found for the primary key'
 runs:
   using: 'node16'
   main: 'dist/setup/index.js'


### PR DESCRIPTION
**Description:**

Cache hit was being used as stated in this pr https://github.com/actions/setup-java/pull/275.
However, it was not included in the outputs of the action. It did not cause any mayor issues, but if you were to lint the workflows, then an output not defined error would pop up.
This Commit just adds the output to the list. Nothing more

**Related issue:**
https://github.com/actions/setup-java/pull/275
https://github.com/actions/setup-java/issues/306

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.