### PR TITLE
Support Gradle version catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Currently, the following distributions are supported:
 
 ### Caching packages dependencies
 The action has a built-in functionality for caching and restoring dependencies. It uses [actions/cache](https://github.com/actions/cache) under hood for caching dependencies but requires less configuration settings. Supported package managers are gradle, maven and sbt. The format of the used cache key is `setup-java-${{ platform }}-${{ packageManager }}-${{ fileHash }}`, where the hash is based on the following files:
-- gradle: `**/*.gradle*`, `**/gradle-wrapper.properties`, `buildSrc/**/Versions.kt`, `buildSrc/**/Dependencies.kt`
+- gradle: `**/*.gradle*`, `**/gradle-wrapper.properties`, `buildSrc/**/Versions.kt`, `buildSrc/**/Dependencies.kt`, and `gradle/*.versions.toml`
 - maven: `**/pom.xml`
 - sbt: all sbt build definition files `**/*.sbt`, `**/project/build.properties`, `**/project/**.{scala,sbt}`
 

--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -98,7 +98,7 @@ describe('dependency cache', () => {
         await expect(restore('gradle')).rejects.toThrowError(
           `No file in ${projectRoot(
             workspace
-          )} matched to [**/*.gradle*,**/gradle-wrapper.properties,buildSrc/**/Versions.kt,buildSrc/**/Dependencies.kt], make sure you have checked out the target repository`
+          )} matched to [**/*.gradle*,**/gradle-wrapper.properties,buildSrc/**/Versions.kt,buildSrc/**/Dependencies.kt,gradle/*.versions.toml], make sure you have checked out the target repository`
         );
       });
       it('downloads cache based on build.gradle', async () => {
@@ -111,6 +111,15 @@ describe('dependency cache', () => {
       });
       it('downloads cache based on build.gradle.kts', async () => {
         createFile(join(workspace, 'build.gradle.kts'));
+
+        await restore('gradle');
+        expect(spyCacheRestore).toBeCalled();
+        expect(spyWarning).not.toBeCalled();
+        expect(spyInfo).toBeCalledWith('gradle cache is not found');
+      });
+      it('downloads cache based on libs.versions.toml', async () => {
+        createDirectory(join(workspace, 'gradle'));
+        createFile(join(workspace, 'gradle', 'libs.versions.toml'));
 
         await restore('gradle');
         expect(spyCacheRestore).toBeCalled();

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -68190,7 +68190,8 @@ const supportedPackageManager = [
             '**/*.gradle*',
             '**/gradle-wrapper.properties',
             'buildSrc/**/Versions.kt',
-            'buildSrc/**/Dependencies.kt'
+            'buildSrc/**/Dependencies.kt',
+            'gradle/*.versions.toml'
         ]
     },
     {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -35,7 +35,8 @@ const supportedPackageManager: PackageManager[] = [
       '**/*.gradle*',
       '**/gradle-wrapper.properties',
       'buildSrc/**/Versions.kt',
-      'buildSrc/**/Dependencies.kt'
+      'buildSrc/**/Dependencies.kt',
+      'gradle/*.versions.toml'
     ]
   },
   {


### PR DESCRIPTION
Thanks for keeping this action supported and updated! 🙌 

Recently I introduced the [version catalog provided by Gradle](https://docs.gradle.org/7.5.1/userguide/platforms.html#sub:version-catalog) to my project, so here I want to resolve #237 by adding several changes.

**Description:**

This PR adds the [version catalog provided by Gradle](https://docs.gradle.org/7.5.1/userguide/platforms.html#sub:version-catalog) into the target of dependency cache.

This file is usually named as `gradle/libs.versions.toml`, but in the official document there is [a case that uses `gradle/test-libs.versions.toml`](https://docs.gradle.org/7.5.1/userguide/platforms.html#sec:importing-catalog-from-file) so this PR considers `gradle/*.versions.toml` as path of version catalog.

**Related issue:**

#237

**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.