### PR TITLE
Pass the token input through on GHES for Microsoft Build of OpenJDK

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ inputs:
     description: 'Workaround to pass job status to post job step. This variable is not intended for manual setting'
     default: ${{ job.status }}
   token:
-    description: Used to pull java versions from setup-java. Since there is a default value, token is typically not supplied by the user. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.
+    description: The token used to authenticate when fetching version manifests hosted on github.com, such as for the Microsoft Build of OpenJDK. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.
     default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
   mvn-toolchain-id:
     description: 'Name of Maven Toolchain ID if the default name of "${distribution}_${java-version}" is not wanted. See examples of supported syntax in Advanced Usage file'

--- a/action.yml
+++ b/action.yml
@@ -59,8 +59,8 @@ inputs:
     description: 'Workaround to pass job status to post job step. This variable is not intended for manual setting'
     default: ${{ job.status }}
   token:
-    description: Used to pull java versions from setup-java. Since there is a default value, token is typically not supplied by the user.
-    default: ${{ github.token }}
+    description: Used to pull java versions from setup-java. Since there is a default value, token is typically not supplied by the user. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.
+    default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
   mvn-toolchain-id:
     description: 'Name of Maven Toolchain ID if the default name of "${distribution}_${java-version}" is not wanted. See examples of supported syntax in Advanced Usage file'
     required: false

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -80,6 +80,22 @@ steps:
 - run: java -cp java HelloWorldApp
 ```
 
+### Using Microsoft distribution on GHES
+
+`setup-java` comes pre-installed on the appliance with GHES if Actions is enabled. When dynamically downloading Microsoft Build of OpenJDK distribution, `setup-java` makes request to `actions/setup-java` to get available versions on github.com (outside of the appliance). These calls to `actions/setup-java` are made via unauthenticated requests, which are limited to [60 requests per hour per IP](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting). If more requests are made within the time frame, then you will start to see rate-limit errors during downloading that looks like: `##[error]API rate limit exceeded for...`.
+
+To get a higher rate limit, you can [generate a personal access token on github.com](https://github.com/settings/tokens/new) and pass it as the `token` input for the action:
+
+```yaml
+uses: actions/setup-java@v3
+with:
+  token: ${{ secrets.GH_DOTCOM_TOKEN }}
+  distribution: 'microsoft'
+  java-version: '11'
+```
+
+If the runner is not able to access github.com, any Go versions requested during a workflow run must come from the runner's tool cache. See "[Setting up the tool cache on self-hosted runners without internet access](https://docs.github.com/en/enterprise-server@3.2/admin/github-actions/managing-access-to-actions-from-githubcom/setting-up-the-tool-cache-on-self-hosted-runners-without-internet-access)" for more information.
+
 ### Amazon Corretto
 **NOTE:** Amazon Corretto only supports the major version specification.
 

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -82,7 +82,7 @@ steps:
 
 ### Using Microsoft distribution on GHES
 
-`setup-java` comes pre-installed on the appliance with GHES if Actions is enabled. When dynamically downloading Microsoft Build of OpenJDK distribution, `setup-java` makes request to `actions/setup-java` to get available versions on github.com (outside of the appliance). These calls to `actions/setup-java` are made via unauthenticated requests, which are limited to [60 requests per hour per IP](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting). If more requests are made within the time frame, then you will start to see rate-limit errors during downloading that looks like: `##[error]API rate limit exceeded for...`.
+`setup-java` comes pre-installed on the appliance with GHES if Actions is enabled. When dynamically downloading the Microsoft Build of OpenJDK distribution, `setup-java` makes a request to `actions/setup-java` to get available versions on github.com (outside of the appliance). These calls to `actions/setup-java` are made via unauthenticated requests, which are limited to [60 requests per hour per IP](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting). If more requests are made within the time frame, then you will start to see rate-limit errors during downloading that looks like: `##[error]API rate limit exceeded for...`.
 
 To get a higher rate limit, you can [generate a personal access token on github.com](https://github.com/settings/tokens/new) and pass it as the `token` input for the action:
 
@@ -94,7 +94,7 @@ with:
   java-version: '11'
 ```
 
-If the runner is not able to access github.com, any Go versions requested during a workflow run must come from the runner's tool cache. See "[Setting up the tool cache on self-hosted runners without internet access](https://docs.github.com/en/enterprise-server@3.2/admin/github-actions/managing-access-to-actions-from-githubcom/setting-up-the-tool-cache-on-self-hosted-runners-without-internet-access)" for more information.
+If the runner is not able to access github.com, any Java versions requested during a workflow run must come from the runner's tool cache. See "[Setting up the tool cache on self-hosted runners without internet access](https://docs.github.com/en/enterprise-server@3.2/admin/github-actions/managing-access-to-actions-from-githubcom/setting-up-the-tool-cache-on-self-hosted-runners-without-internet-access)" for more information.
 
 ### Amazon Corretto
 **NOTE:** Amazon Corretto only supports the major version specification.

--- a/src/distributions/microsoft/installer.ts
+++ b/src/distributions/microsoft/installer.ts
@@ -73,6 +73,7 @@ export class MicrosoftDistributions extends JavaBase {
     // TODO get these dynamically!
     // We will need Microsoft to add an endpoint where we can query for versions.
     const token = core.getInput('token');
+    const auth = !token ? undefined : `token ${token}`;
     const owner = 'actions';
     const repository = 'setup-java';
     const branch = 'main';
@@ -82,7 +83,7 @@ export class MicrosoftDistributions extends JavaBase {
     const fileUrl = `https://api.github.com/repos/${owner}/${repository}/contents/${filePath}?ref=${branch}`;
 
     const headers: OutgoingHttpHeaders = {
-      authorization: token,
+      authorization: auth,
       accept: 'application/vnd.github.VERSION.raw'
     };
 


### PR DESCRIPTION
**Description:**
In scope of this pull request we fix issue with passing token to download manifest.

**Related issue:**
https://github.com/actions/runner-images-internal/issues/4479

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.