### PR TITLE
Add support for Oracle JDK

### DIFF
--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -25,6 +25,16 @@ jobs:
         exclude:
         - distribution: microsoft
           version: 8
+        include:
+        - distribution: oracle
+          os: macos-latest
+          version: 17
+        - distribution: oracle
+          os: windows-latest
+          version: 19
+        - distribution: oracle
+          os: ubuntu-latest
+          version: 19
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -51,6 +61,10 @@ jobs:
         - '11.0'
         - '8.0.302'
         - '16.0.2+7'
+        include:
+        - distribution: oracle
+          os: ubuntu-latest
+          version: '19.0.1'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Currently, the following distributions are supported:
 | `liberica` | Liberica JDK | [Link](https://bell-sw.com/) | [Link](https://bell-sw.com/liberica_eula/) |
 | `microsoft` | Microsoft Build of OpenJDK | [Link](https://www.microsoft.com/openjdk) | [Link](https://docs.microsoft.com/java/openjdk/faq)
 | `corretto` | Amazon Corretto Build of OpenJDK | [Link](https://aws.amazon.com/corretto/) | [Link](https://aws.amazon.com/corretto/faqs/)
+| `oracle` | Oracle JDK | [Link](https://www.oracle.com/java/technologies/downloads/) | [Link](https://java.com/freeuselicense)
 
 **NOTE:** The different distributors can provide discrepant list of available versions / supported configurations. Please refer to the official documentation to see the list of supported versions.
 

--- a/__tests__/distributors/oracle-installer.test.ts
+++ b/__tests__/distributors/oracle-installer.test.ts
@@ -1,0 +1,105 @@
+import { OracleDistribution } from '../../src/distributions/oracle/installer';
+import os from 'os';
+import * as core from '@actions/core';
+
+describe('findPackageForDownload', () => {
+  let distribution: OracleDistribution;
+  let spyDebug: jest.SpyInstance;
+
+  beforeEach(() => {
+    distribution = new OracleDistribution({
+      version: '',
+      architecture: 'x64',
+      packageType: 'jdk',
+      checkLatest: false
+    });
+
+    spyDebug = jest.spyOn(core, 'debug');
+    spyDebug.mockImplementation(() => {});
+  });
+
+  it.each([
+    [
+      '19',
+      '19',
+      'https://download.oracle.com/java/19/latest/jdk-19_{{OS_TYPE}}-x64_bin.{{ARCHIVE_TYPE}}'
+    ],
+    [
+      '19.0.1',
+      '19.0.1',
+      'https://download.oracle.com/java/19/archive/jdk-19.0.1_{{OS_TYPE}}-x64_bin.{{ARCHIVE_TYPE}}'
+    ],
+    [
+      '18.0.2.1',
+      '18.0.2.1',
+      'https://download.oracle.com/java/18/archive/jdk-18.0.2.1_{{OS_TYPE}}-x64_bin.{{ARCHIVE_TYPE}}'
+    ],
+    [
+      '17',
+      '17',
+      'https://download.oracle.com/java/17/latest/jdk-17_{{OS_TYPE}}-x64_bin.{{ARCHIVE_TYPE}}'
+    ],
+    [
+      '17.0.1',
+      '17.0.1',
+      'https://download.oracle.com/java/17/archive/jdk-17.0.1_{{OS_TYPE}}-x64_bin.{{ARCHIVE_TYPE}}'
+    ]
+  ])('version is %s -> %s', async (input, expectedVersion, expectedUrl) => {
+    const result = await distribution['findPackageForDownload'](input);
+    expect(result.version).toBe(expectedVersion);
+    let os: string;
+    let archive: string;
+    switch (process.platform) {
+      case 'darwin':
+        os = 'macos';
+        archive = 'tar.gz';
+        break;
+      case 'win32':
+        os = 'windows';
+        archive = 'zip';
+        break;
+      default:
+        os = process.platform.toString();
+        archive = 'tar.gz';
+        break;
+    }
+    const url = expectedUrl.replace('{{OS_TYPE}}', os).replace('{{ARCHIVE_TYPE}}', archive);
+    expect(result.url).toBe(url);
+  });
+
+  it.each([
+    ['amd64', 'x64'],
+    ['arm64', 'aarch64']
+  ])(
+    'defaults to os.arch(): %s mapped to distro arch: %s',
+    async (osArch: string, distroArch: string) => {
+      jest.spyOn(os, 'arch').mockReturnValue(osArch);
+      jest.spyOn(os, 'platform').mockReturnValue('linux');
+
+      const version = '17';
+      const distro = new OracleDistribution({
+        version,
+        architecture: '', // to get default value
+        packageType: 'jdk',
+        checkLatest: false
+      });
+
+      const result = await distro['findPackageForDownload'](version);
+      const expectedUrl = `https://download.oracle.com/java/17/latest/jdk-17_linux-${distroArch}_bin.tar.gz`;
+
+      expect(result.url).toBe(expectedUrl);
+    }
+  );
+
+  it('should throw an error', async () => {
+    await expect(distribution['findPackageForDownload']('8')).rejects.toThrow(
+      /Oracle JDK is only supported for JDK 17 and later/
+    );
+    await expect(distribution['findPackageForDownload']('11')).rejects.toThrow(
+      /Oracle JDK is only supported for JDK 17 and later/
+    );
+    await expect(distribution['findPackageForDownload']('18')).rejects.toThrow(
+      /Could not find Oracle JDK for SemVer */
+    );
+  });
+});

--- a/__tests__/verify-java.sh
+++ b/__tests__/verify-java.sh
@@ -24,7 +24,7 @@ fi
 ACTUAL_JAVA_VERSION="$(java -version 2>&1)"
 echo "Found java version: $ACTUAL_JAVA_VERSION"
 
-GREP_RESULT=$(echo $ACTUAL_JAVA_VERSION | grep "^openjdk version \"$EXPECTED_JAVA_VERSION")
+GREP_RESULT=$(echo $ACTUAL_JAVA_VERSION | grep -E "^(openjdk|java) version \"$EXPECTED_JAVA_VERSION")
 if [ -z "$GREP_RESULT" ]; then
   echo "::error::Unexpected version"
   echo "Expected version: $EXPECTED_JAVA_VERSION"

--- a/src/distributions/distribution-factory.ts
+++ b/src/distributions/distribution-factory.ts
@@ -7,6 +7,7 @@ import { TemurinDistribution, TemurinImplementation } from './temurin/installer'
 import { LibericaDistributions } from './liberica/installer';
 import { MicrosoftDistributions } from './microsoft/installer';
 import { CorrettoDistribution } from './corretto/installer';
+import { OracleDistribution } from './oracle/installer';
 
 enum JavaDistribution {
   Adopt = 'adopt',
@@ -17,7 +18,8 @@ enum JavaDistribution {
   Liberica = 'liberica',
   JdkFile = 'jdkfile',
   Microsoft = 'microsoft',
-  Corretto = 'corretto'
+  Corretto = 'corretto',
+  Oracle = 'oracle'
 }
 
 export function getJavaDistribution(
@@ -43,6 +45,8 @@ export function getJavaDistribution(
       return new MicrosoftDistributions(installerOptions);
     case JavaDistribution.Corretto:
       return new CorrettoDistribution(installerOptions);
+    case JavaDistribution.Oracle:
+      return new OracleDistribution(installerOptions);
     default:
       return null;
   }

--- a/src/distributions/oracle/installer.ts
+++ b/src/distributions/oracle/installer.ts
@@ -1,0 +1,102 @@
+import * as core from '@actions/core';
+import * as tc from '@actions/tool-cache';
+
+import fs from 'fs';
+import path from 'path';
+
+import { JavaBase } from '../base-installer';
+import { JavaDownloadRelease, JavaInstallerOptions, JavaInstallerResults } from '../base-models';
+import { extractJdkFile, getDownloadArchiveExtension } from '../../util';
+import { HttpCodes } from '@actions/http-client';
+
+const ORACLE_DL_BASE = 'https://download.oracle.com/java'
+
+export class OracleDistribution extends JavaBase {
+  constructor(installerOptions: JavaInstallerOptions) {
+    super('Oracle', installerOptions);
+  }
+
+  protected async downloadTool(javaRelease: JavaDownloadRelease): Promise<JavaInstallerResults> {
+    core.info(
+      `Downloading Java ${javaRelease.version} (${this.distribution}) from ${javaRelease.url} ...`
+    );
+    const javaArchivePath = await tc.downloadTool(javaRelease.url);
+
+    core.info(`Extracting Java archive...`);
+    let extension = getDownloadArchiveExtension();
+
+    let extractedJavaPath = await extractJdkFile(javaArchivePath, extension);
+
+    const archiveName = fs.readdirSync(extractedJavaPath)[0];
+    const archivePath = path.join(extractedJavaPath, archiveName);
+    const version = this.getToolcacheVersionName(javaRelease.version);
+
+    let javaPath = await tc.cacheDir(
+      archivePath,
+      this.toolcacheFolderName,
+      version,
+      this.architecture
+    );
+
+    return { version: javaRelease.version, path: javaPath };
+  }
+
+  protected async findPackageForDownload(range: string): Promise<JavaDownloadRelease> {
+    const arch = this.distributionArchitecture();
+    if (arch !== 'x64' && arch !== 'aarch64') {
+      throw new Error(`Unsupported architecture: ${this.architecture}`);
+    }
+
+    if (!this.stable) {
+      throw new Error('Early access versions are not supported');
+    }
+
+    if (this.packageType !== 'jdk') {
+      throw new Error('Oracle JDK provides only the `jdk` package type');
+    }
+
+    const platform = this.getPlatform()
+    const extension = getDownloadArchiveExtension();
+    let major;
+    let fileUrl;
+    if (range.includes('.')) {
+      major = range.split('.')[0]
+      fileUrl = `${ORACLE_DL_BASE}/${major}/archive/jdk-${range}_${platform}-${arch}_bin.${extension}`
+    } else {
+      major = range
+      fileUrl = `${ORACLE_DL_BASE}/${range}/latest/jdk-${range}_${platform}-${arch}_bin.${extension}`
+    }
+
+    if (parseInt(major) < 17) {
+      throw new Error('Oracle JDK is only supported for JDK 17 and later')
+    }
+
+    const response = await this.http.head(fileUrl)
+
+    if (response.message.statusCode === HttpCodes.NotFound) {
+        throw new Error(`Could not find Oracle JDK for SemVer ${range}`);
+    }
+
+    if (response.message.statusCode !== HttpCodes.OK) {
+        throw new Error(`Http request for Oracle JDK failed with status code: ${response.message.statusCode}`);
+    }
+
+    return { url: fileUrl, version: range }
+  }
+
+  private getPlatform(platform: NodeJS.Platform = process.platform): OsVersions {
+    switch (platform) {
+      case 'darwin':
+        return 'macos';
+      case 'win32':
+      case 'cygwin':
+        return 'windows';
+      case 'linux':
+        return 'linux';
+      default:
+        throw new Error(
+          `Platform '${platform}' is not supported. Supported platforms: 'linux', 'macos', 'windows'`
+        );
+    }
+  }
+}

--- a/src/distributions/oracle/models.ts
+++ b/src/distributions/oracle/models.ts
@@ -1,0 +1,1 @@
+export type OsVersions = 'linux' | 'macos' | 'windows';


### PR DESCRIPTION
**Description:**
This PR adds Oracle JDK to the list of supported distributions.

**Related issue:** https://github.com/actions/setup-java/issues/69

**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.