### PR TITLE
refactor: Use early return pattern to avoid nested conditions

### DIFF
--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -29,14 +29,13 @@ describe('isVersionSatisfies', () => {
 describe('isCacheFeatureAvailable', () => {
   it('isCacheFeatureAvailable disabled on GHES', () => {
     jest.spyOn(cache, 'isFeatureAvailable').mockImplementation(() => false);
+    const infoMock = jest.spyOn(core, 'warning');
+    const message =
+      'Caching is only supported on GHES version >= 3.5. If you are on a version >= 3.5, please check with your GHES admin if the Actions cache service is enabled or not.';
     try {
       process.env['GITHUB_SERVER_URL'] = 'http://example.com';
-      isCacheFeatureAvailable();
-    } catch (error) {
-      expect(error).toHaveProperty(
-        'message',
-        'Caching is only supported on GHES version >= 3.5. If you are on a version >= 3.5, please check with your GHES admin if the Actions cache service is enabled or not.'
-      );
+      expect(isCacheFeatureAvailable()).toBeFalsy();
+      expect(infoMock).toHaveBeenCalledWith(message);
     } finally {
       delete process.env['GITHUB_SERVER_URL'];
     }

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -68706,16 +68706,14 @@ function isGhes() {
 }
 exports.isGhes = isGhes;
 function isCacheFeatureAvailable() {
-    if (!cache.isFeatureAvailable()) {
-        if (isGhes()) {
-            throw new Error('Caching is only supported on GHES version >= 3.5. If you are on a version >= 3.5, please check with your GHES admin if the Actions cache service is enabled or not.');
-        }
-        else {
-            core.warning('The runner was not able to contact the cache service. Caching will be skipped');
-        }
-        return false;
+    if (cache.isFeatureAvailable()) {
+        return true;
     }
-    return true;
+    if (isGhes()) {
+        throw new Error('Caching is only supported on GHES version >= 3.5. If you are on a version >= 3.5, please check with your GHES admin if the Actions cache service is enabled or not.');
+    }
+    core.warning('The runner was not able to contact the cache service. Caching will be skipped');
+    return false;
 }
 exports.isCacheFeatureAvailable = isCacheFeatureAvailable;
 

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -68710,7 +68710,8 @@ function isCacheFeatureAvailable() {
         return true;
     }
     if (isGhes()) {
-        throw new Error('Caching is only supported on GHES version >= 3.5. If you are on a version >= 3.5, please check with your GHES admin if the Actions cache service is enabled or not.');
+        core.warning('Caching is only supported on GHES version >= 3.5. If you are on a version >= 3.5, please check with your GHES admin if the Actions cache service is enabled or not.');
+        return false;
     }
     core.warning('The runner was not able to contact the cache service. Caching will be skipped');
     return false;

--- a/src/util.ts
+++ b/src/util.ts
@@ -85,17 +85,16 @@ export function isGhes(): boolean {
 }
 
 export function isCacheFeatureAvailable(): boolean {
-  if (!cache.isFeatureAvailable()) {
-    if (isGhes()) {
-      throw new Error(
-        'Caching is only supported on GHES version >= 3.5. If you are on a version >= 3.5, please check with your GHES admin if the Actions cache service is enabled or not.'
-      );
-    } else {
-      core.warning('The runner was not able to contact the cache service. Caching will be skipped');
-    }
-
-    return false;
+  if (cache.isFeatureAvailable()) {
+    return true;
   }
 
-  return true;
+  if (isGhes()) {
+    throw new Error(
+      'Caching is only supported on GHES version >= 3.5. If you are on a version >= 3.5, please check with your GHES admin if the Actions cache service is enabled or not.'
+    );
+  }
+
+  core.warning('The runner was not able to contact the cache service. Caching will be skipped');
+  return false;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -90,9 +90,10 @@ export function isCacheFeatureAvailable(): boolean {
   }
 
   if (isGhes()) {
-    throw new Error(
+    core.warning(
       'Caching is only supported on GHES version >= 3.5. If you are on a version >= 3.5, please check with your GHES admin if the Actions cache service is enabled or not.'
     );
+    return false;
   }
 
   core.warning('The runner was not able to contact the cache service. Caching will be skipped');


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>
Issue #420 

## Description

Return early is the way of writing functions or methods so that the expected positive result is returned at the end of the function and the rest of the code terminates the execution (by returning or throwing an exception) when conditions are not met.

See [actions/cache#1012](https://github.com/actions/cache/issues/1012), [actions/setup-node#639](https://github.com/actions/setup-node/pull/639)

In `util.ts`:

**AS-IS**

```typescript
export function isCacheFeatureAvailable(): boolean {
  if (!cache.isFeatureAvailable()) {
    if (isGhes()) {
      throw new Error(
        'Caching is only supported on GHES version >= 3.5...'
      );
    } else {
      core.warning('The runner was not able to contact...');
    }

    return false;
  }

  return true;
}
```


**TO-BE**

```typescript
export function isCacheFeatureAvailable(): boolean {
  if (cache.isFeatureAvailable()) {
    return true;
  }

  if (isGhes()) {
    throw new Error(
        'Caching is only supported on GHES version >= 3.5...'
    );
  }

  core.warning('The runner was not able to contact...');
  return false;
}
```

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.