### PR TITLE
Update workflow badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Setup Java
 
-[![Main workflow](https://github.com/actions/setup-java/actions/workflows/workflow.yml/badge.svg)](https://github.com/actions/setup-java/actions/workflows/workflow.yml)
+[![Basic validation](https://github.com/actions/setup-java/actions/workflows/basic-validation.yml/badge.svg?branch=main)](https://github.com/actions/setup-java/actions/workflows/basic-validation.yml)
+[![Validate Java e2e](https://github.com/actions/setup-java/actions/workflows/e2e-versions.yml/badge.svg?branch=main)](https://github.com/actions/setup-java/actions/workflows/e2e-versions.yml)
+[![Validate cache](https://github.com/actions/setup-java/actions/workflows/e2e-cache.yml/badge.svg?branch=main)](https://github.com/actions/setup-java/actions/workflows/e2e-cache.yml)
 
 The `setup-java` action provides the following functionality for GitHub Actions runners:
 - Downloading and setting up a requested version of Java. See [Usage](#Usage) for a list of supported distributions.


### PR DESCRIPTION
**Description:**
In the scope of this PR, [workflow badges](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge) were updated to represent the current status of the workflows which test the action. The badges were organized like that:
1. Badge for a workflow with unit tests
2. Badges for other workflows with several e2e tests

Use `display the rich diff` button to see the visual representation of the changes:
![image](https://user-images.githubusercontent.com/98037481/215442456-56bd363d-897b-4111-bd37-1dcdfcb2bbc0.png)

**Related issue:**
https://github.com/actions/runner-images-internal/issues/4709