### PR TITLE
Cache Maven Distributions downloaded by the Maven Wrapper

### DIFF
--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -100,7 +100,7 @@ describe('dependency cache', () => {
         await expect(restore('maven', '')).rejects.toThrow(
           `No file in ${projectRoot(
             workspace
-          )} matched to [**/pom.xml], make sure you have checked out the target repository`
+          )} matched to [**/pom.xml,.mvn/wrapper/maven-wrapper.properties], make sure you have checked out the target repository`
         );
       });
       it('downloads cache', async () => {
@@ -108,7 +108,9 @@ describe('dependency cache', () => {
 
         await restore('maven', '');
         expect(spyCacheRestore).toHaveBeenCalled();
-        expect(spyGlobHashFiles).toHaveBeenCalledWith('**/pom.xml');
+        expect(spyGlobHashFiles).toHaveBeenCalledWith(
+          '**/pom.xml\n.mvn/wrapper/maven-wrapper.properties'
+        );
         expect(spyWarning).not.toHaveBeenCalled();
         expect(spyInfo).toHaveBeenCalledWith('maven cache is not found');
       });

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -51467,9 +51467,12 @@ const CACHE_KEY_PREFIX = 'setup-java';
 const supportedPackageManager = [
     {
         id: 'maven',
-        path: [(0, path_1.join)(os_1.default.homedir(), '.m2', 'repository')],
+        path: [
+            (0, path_1.join)(os_1.default.homedir(), '.m2', 'repository'),
+            (0, path_1.join)(os_1.default.homedir(), '.m2', 'wrapper', 'dists')
+        ],
         // https://github.com/actions/cache/blob/0638051e9af2c23d10bb70fa9beffcad6cff9ce3/examples.md#java---maven
-        pattern: ['**/pom.xml']
+        pattern: ['**/pom.xml', '.mvn/wrapper/maven-wrapper.properties']
     },
     {
         id: 'gradle',

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -23,9 +23,12 @@ interface PackageManager {
 const supportedPackageManager: PackageManager[] = [
   {
     id: 'maven',
-    path: [join(os.homedir(), '.m2', 'repository')],
+    path: [
+      join(os.homedir(), '.m2', 'repository'),
+      join(os.homedir(), '.m2', 'wrapper', 'dists')
+    ],
     // https://github.com/actions/cache/blob/0638051e9af2c23d10bb70fa9beffcad6cff9ce3/examples.md#java---maven
-    pattern: ['**/pom.xml']
+    pattern: ['**/pom.xml', '.mvn/wrapper/maven-wrapper.properties']
   },
   {
     id: 'gradle',


### PR DESCRIPTION
Related issue : #448

With cache: https://github.com/yeikel/mvn-wrapper-caching-test/actions/runs/4158390216/jobs/7193735589

Without cache :  https://github.com/yeikel/mvn-wrapper-caching-test/actions/runs/4158489501/jobs/7193751281

> 2023-02-12 22:15:22 (4.06 MB/s) - ‘/home/runner/work/mvn-wrapper-caching-test/mvn-wrapper-caching-test/.mvn/wrapper/maven-wrapper.jar’ saved [59925/59925]
> [INFO] Apache Maven Wrapper 3.1.1
> [INFO] Installing Maven distribution /home/runner/.m2/wrapper/dists/apache-maven-3.8.5-bin/67203e94
> [INFO] Downloading https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.5/apache-maven-3.8.5-bin.zip
> [INFO] Unzipping /home/runner/.m2/wrapper/dists/apache-maven-3.8.5-bin/67203e94/apache-maven-3.8.5-bin.zip to /home/runner/.m2/wrapper/dists/apache-maven-3.8.5-bin/67203e94


Cache invalidation after a maven upgrade : https://github.com/yeikel/mvn-wrapper-caching-test/actions/runs/4158550035/jobs/7193847666 