### PR TITLE
Added gradle.properties file to the cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Currently, the following distributions are supported:
 
 ### Caching packages dependencies
 The action has a built-in functionality for caching and restoring dependencies. It uses [actions/cache](https://github.com/actions/cache) under hood for caching dependencies but requires less configuration settings. Supported package managers are gradle, maven and sbt. The format of the used cache key is `setup-java-${{ platform }}-${{ packageManager }}-${{ fileHash }}`, where the hash is based on the following files:
-- gradle: `**/*.gradle*`, `**/gradle-wrapper.properties`, `buildSrc/**/Versions.kt`, `buildSrc/**/Dependencies.kt`, and `gradle/*.versions.toml`
+- gradle: `**/*.gradle*`, `**/gradle-wrapper.properties`, `buildSrc/**/Versions.kt`, `buildSrc/**/Dependencies.kt`, `gradle.properties` and `gradle/*.versions.toml`
 - maven: `**/pom.xml`
 - sbt: all sbt build definition files `**/*.sbt`, `**/project/build.properties`, `**/project/**.{scala,sbt}`
 

--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -98,7 +98,7 @@ describe('dependency cache', () => {
         await expect(restore('gradle')).rejects.toThrowError(
           `No file in ${projectRoot(
             workspace
-          )} matched to [**/*.gradle*,**/gradle-wrapper.properties,buildSrc/**/Versions.kt,buildSrc/**/Dependencies.kt,gradle/*.versions.toml], make sure you have checked out the target repository`
+          )} matched to [**/*.gradle*,**/gradle-wrapper.properties,buildSrc/**/Versions.kt,buildSrc/**/Dependencies.kt,gradle/*.versions.toml,gradle.properties], make sure you have checked out the target repository`
         );
       });
       it('downloads cache based on build.gradle', async () => {
@@ -120,6 +120,14 @@ describe('dependency cache', () => {
       it('downloads cache based on libs.versions.toml', async () => {
         createDirectory(join(workspace, 'gradle'));
         createFile(join(workspace, 'gradle', 'libs.versions.toml'));
+
+        await restore('gradle');
+        expect(spyCacheRestore).toBeCalled();
+        expect(spyWarning).not.toBeCalled();
+        expect(spyInfo).toBeCalledWith('gradle cache is not found');
+      });
+      it('downloads cache based on gradle.properties', async () => {
+        createFile(join(workspace, 'gradle.properties'));
 
         await restore('gradle');
         expect(spyCacheRestore).toBeCalled();

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -68249,7 +68249,8 @@ const supportedPackageManager = [
             '**/gradle-wrapper.properties',
             'buildSrc/**/Versions.kt',
             'buildSrc/**/Dependencies.kt',
-            'gradle/*.versions.toml'
+            'gradle/*.versions.toml',
+            'gradle.properties'
         ]
     },
     {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -36,7 +36,8 @@ const supportedPackageManager: PackageManager[] = [
       '**/gradle-wrapper.properties',
       'buildSrc/**/Versions.kt',
       'buildSrc/**/Dependencies.kt',
-      'gradle/*.versions.toml'
+      'gradle/*.versions.toml',
+      'gradle.properties'
     ]
   },
   {


### PR DESCRIPTION
Part of project configuration may be in the `gradle.properties` file and changing it should invalidate cache

See: https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties

**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.