### PR TITLE
fix sbt/scala cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Currently, the following distributions are supported:
 The action has a built-in functionality for caching and restoring dependencies. It uses [actions/cache](https://github.com/actions/cache) under hood for caching dependencies but requires less configuration settings. Supported package managers are gradle, maven and sbt. The format of the used cache key is `setup-java-${{ platform }}-${{ packageManager }}-${{ fileHash }}`, where the hash is based on the following files:
 - gradle: `**/*.gradle*`, `**/gradle-wrapper.properties`, `buildSrc/**/Versions.kt`, `buildSrc/**/Dependencies.kt`, and `gradle/*.versions.toml`
 - maven: `**/pom.xml`
-- sbt: all sbt build definition files `**/*.sbt`, `**/project/build.properties`, `**/project/**.{scala,sbt}`
+- sbt: all sbt build definition files `**/*.sbt`, `**/project/build.properties`, `**/project/**.scala`, `**/project/**.sbt`
 
 The workflow output `cache-hit` is set to indicate if an exact match was found for the key [as actions/cache does](https://github.com/actions/cache/tree/main#outputs).
 

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -68416,7 +68416,8 @@ const supportedPackageManager = [
         pattern: [
             '**/*.sbt',
             '**/project/build.properties',
-            '**/project/**.{scala,sbt}'
+            '**/project/**.scala',
+            '**/project/**.sbt'
         ]
     }
 ];

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -56,7 +56,8 @@ const supportedPackageManager: PackageManager[] = [
     pattern: [
       '**/*.sbt',
       '**/project/build.properties',
-      '**/project/**.{scala,sbt}'
+      '**/project/**.scala',
+      '**/project/**.sbt'
     ]
   }
 ];


### PR DESCRIPTION
**Description:**
Change sbt cache key to be calculated properly.

Unfortunately `**/project/**.{scala,sbt}` glob pattern does not work. I have verified this by writing unit tests.

**Related issue:**
- #477 

**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.