### PR TITLE
Corretto toolcache folder name fix

### DIFF
--- a/__tests__/distributors/corretto-installer.test.ts
+++ b/__tests__/distributors/corretto-installer.test.ts
@@ -247,7 +247,7 @@ describe('convertVersionToSemver', () => {
     ['12', '12'],
     ['12.0', '12.0'],
     ['12.0.2', '12.0.2'],
-    ['12.0.2+1', '12.0.2+1'],
+    ['12.0.2.1', '12.0.2+1'],
     ['12.0.2.1.0', '12.0.2+1.0']
   ])('%s -> %s', (input: string, expected: string) => {
     const distribution = new CorrettoDistribution({

--- a/__tests__/distributors/corretto-installer.test.ts
+++ b/__tests__/distributors/corretto-installer.test.ts
@@ -241,3 +241,22 @@ describe('getAvailableVersions', () => {
     spyGetDownloadArchiveExtension.mockReturnValue(mockedExtension);
   };
 });
+
+describe('convertVersionToSemver', () => {
+  it.each([
+    ['12', '12'],
+    ['12.0', '12.0'],
+    ['12.0.2', '12.0.2'],
+    ['12.0.2+1', '12.0.2+1'],
+    ['12.0.2.1.0', '12.0.2+1.0']
+  ])('%s -> %s', (input: string, expected: string) => {
+    const distribution = new CorrettoDistribution({
+      version: '12',
+      architecture: 'x86',
+      packageType: 'jdk',
+      checkLatest: false
+    });
+    const actual = distribution['convertVersionToSemver'](input);
+    expect(actual).toBe(expected);
+  });
+});

--- a/__tests__/distributors/corretto-installer.test.ts
+++ b/__tests__/distributors/corretto-installer.test.ts
@@ -241,22 +241,3 @@ describe('getAvailableVersions', () => {
     spyGetDownloadArchiveExtension.mockReturnValue(mockedExtension);
   };
 });
-
-describe('convertVersionToSemver', () => {
-  it.each([
-    ['12', '12'],
-    ['12.0', '12.0'],
-    ['12.0.2', '12.0.2'],
-    ['12.0.2.1', '12.0.2+1'],
-    ['12.0.2.1.0', '12.0.2+1.0']
-  ])('%s -> %s', (input: string, expected: string) => {
-    const distribution = new CorrettoDistribution({
-      version: '12',
-      architecture: 'x86',
-      packageType: 'jdk',
-      checkLatest: false
-    });
-    const actual = distribution['convertVersionToSemver'](input);
-    expect(actual).toBe(expected);
-  });
-});

--- a/__tests__/distributors/zulu-installer.test.ts
+++ b/__tests__/distributors/zulu-installer.test.ts
@@ -227,22 +227,3 @@ describe('findPackageForDownload', () => {
     ).rejects.toThrow(/Could not find satisfied version for semver */);
   });
 });
-
-describe('convertVersionToSemver', () => {
-  it.each([
-    [[12], '12'],
-    [[12, 0], '12.0'],
-    [[12, 0, 2], '12.0.2'],
-    [[12, 0, 2, 1], '12.0.2+1'],
-    [[12, 0, 2, 1, 3], '12.0.2+1']
-  ])('%s -> %s', (input: number[], expected: string) => {
-    const distribution = new ZuluDistribution({
-      version: '18',
-      architecture: 'x86',
-      packageType: 'jdk',
-      checkLatest: false
-    });
-    const actual = distribution['convertVersionToSemver'](input);
-    expect(actual).toBe(expected);
-  });
-});

--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -1,6 +1,10 @@
 import * as cache from '@actions/cache';
 import * as core from '@actions/core';
-import {isVersionSatisfies, isCacheFeatureAvailable} from '../src/util';
+import {
+  convertVersionToSemver,
+  isVersionSatisfies,
+  isCacheFeatureAvailable
+} from '../src/util';
 
 jest.mock('@actions/cache');
 jest.mock('@actions/core');
@@ -61,5 +65,18 @@ describe('isCacheFeatureAvailable', () => {
   it('isCacheFeatureAvailable is enabled', () => {
     jest.spyOn(cache, 'isFeatureAvailable').mockImplementation(() => true);
     expect(isCacheFeatureAvailable()).toBe(true);
+  });
+});
+
+describe('convertVersionToSemver', () => {
+  it.each([
+    ['12', '12'],
+    ['12.0', '12.0'],
+    ['12.0.2', '12.0.2'],
+    ['12.0.2.1', '12.0.2+1'],
+    ['12.0.2.1.0', '12.0.2+1.0']
+  ])('%s -> %s', (input: string, expected: string) => {
+    const actual = convertVersionToSemver(input);
+    expect(actual).toBe(expected);
   });
 });

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -68785,7 +68785,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getVersionFromFileContent = exports.isCacheFeatureAvailable = exports.isGhes = exports.isJobStatusSuccess = exports.getToolcachePath = exports.isVersionSatisfies = exports.getDownloadArchiveExtension = exports.extractJdkFile = exports.getVersionFromToolcachePath = exports.getBooleanInput = exports.getTempDir = void 0;
+exports.convertVersionToSemver = exports.getVersionFromFileContent = exports.isCacheFeatureAvailable = exports.isGhes = exports.isJobStatusSuccess = exports.getToolcachePath = exports.isVersionSatisfies = exports.getDownloadArchiveExtension = exports.extractJdkFile = exports.getVersionFromToolcachePath = exports.getBooleanInput = exports.getTempDir = void 0;
 const os_1 = __importDefault(__nccwpck_require__(2037));
 const path_1 = __importDefault(__nccwpck_require__(1017));
 const fs = __importStar(__nccwpck_require__(7147));
@@ -68912,6 +68912,16 @@ exports.getVersionFromFileContent = getVersionFromFileContent;
 function avoidOldNotation(content) {
     return content.startsWith('1.') ? content.substring(2) : content;
 }
+function convertVersionToSemver(version) {
+    // Some distributions may use semver-like notation (12.10.2.1, 12.10.2.1.1)
+    const versionArray = Array.isArray(version) ? version : version.split('.');
+    const mainVersion = versionArray.slice(0, 3).join('.');
+    if (versionArray.length > 3) {
+        return `${mainVersion}+${versionArray.slice(3).join('.')}`;
+    }
+    return mainVersion;
+}
+exports.convertVersionToSemver = convertVersionToSemver;
 
 
 /***/ }),

--- a/src/distributions/corretto/installer.ts
+++ b/src/distributions/corretto/installer.ts
@@ -2,7 +2,11 @@ import * as core from '@actions/core';
 import * as tc from '@actions/tool-cache';
 import fs from 'fs';
 import path from 'path';
-import {extractJdkFile, getDownloadArchiveExtension} from '../../util';
+import {
+  extractJdkFile,
+  getDownloadArchiveExtension,
+  convertVersionToSemver
+} from '../../util';
 import {JavaBase} from '../base-installer';
 import {
   JavaDownloadRelease,
@@ -62,7 +66,7 @@ export class CorrettoDistribution extends JavaBase {
       .filter(item => item.version == version)
       .map(item => {
         return {
-          version: this.convertVersionToSemver(item.correttoVersion),
+          version: convertVersionToSemver(item.correttoVersion),
           url: item.downloadLink
         } as JavaDownloadRelease;
       });
@@ -178,16 +182,5 @@ export class CorrettoDistribution extends JavaBase {
       throw Error(`Could not parse corretto version from ${resource}`);
     }
     return match[1];
-  }
-
-  private convertVersionToSemver(version: string) {
-    // corretto uses semver-like notation e.g. 17.0.6.10.1
-    const versionArray = version.split('.');
-    const mainVersion = versionArray.slice(0, 3).join('.');
-    if (versionArray.length > 3) {
-      return `${mainVersion}+${versionArray.slice(3).join('.')}`;
-    }
-
-    return mainVersion;
   }
 }

--- a/src/distributions/corretto/installer.ts
+++ b/src/distributions/corretto/installer.ts
@@ -181,7 +181,7 @@ export class CorrettoDistribution extends JavaBase {
   }
 
   private convertVersionToSemver(version: string) {
-    // corretto uses 5 digit semver-like notation e.g. 17.0.6.10.1
+    // corretto uses semver-like notation e.g. 17.0.6.10.1
     const versionArray = version.split('.');
     const mainVersion = versionArray.slice(0, 3).join('.');
     if (versionArray.length > 3) {

--- a/src/distributions/corretto/installer.ts
+++ b/src/distributions/corretto/installer.ts
@@ -181,10 +181,10 @@ export class CorrettoDistribution extends JavaBase {
   }
 
   private convertVersionToSemver(version: string) {
+    // corretto uses 5 digit semver-like notation e.g. 17.0.6.10.1
     const versionArray = version.split('.');
     const mainVersion = versionArray.slice(0, 3).join('.');
     if (versionArray.length > 3) {
-      // intentionally ignore more than 4 numbers because it is invalid semver
       return `${mainVersion}+${versionArray.slice(3).join('.')}`;
     }
 

--- a/src/distributions/corretto/installer.ts
+++ b/src/distributions/corretto/installer.ts
@@ -62,7 +62,7 @@ export class CorrettoDistribution extends JavaBase {
       .filter(item => item.version == version)
       .map(item => {
         return {
-          version: item.correttoVersion,
+          version: this.convertVersionToSemver(item.correttoVersion),
           url: item.downloadLink
         } as JavaDownloadRelease;
       });
@@ -178,5 +178,16 @@ export class CorrettoDistribution extends JavaBase {
       throw Error(`Could not parse corretto version from ${resource}`);
     }
     return match[1];
+  }
+
+  private convertVersionToSemver(version: string) {
+    const versionArray = version.split('.');
+    const mainVersion = versionArray.slice(0, 3).join('.');
+    if (versionArray.length > 3) {
+      // intentionally ignore more than 4 numbers because it is invalid semver
+      return `${mainVersion}+${versionArray.slice(3).join('.')}`;
+    }
+
+    return mainVersion;
   }
 }

--- a/src/distributions/zulu/installer.ts
+++ b/src/distributions/zulu/installer.ts
@@ -10,6 +10,7 @@ import {IZuluVersions} from './models';
 import {
   extractJdkFile,
   getDownloadArchiveExtension,
+  convertVersionToSemver,
   isVersionSatisfies
 } from '../../util';
 import {
@@ -29,9 +30,9 @@ export class ZuluDistribution extends JavaBase {
     const availableVersionsRaw = await this.getAvailableVersions();
     const availableVersions = availableVersionsRaw.map(item => {
       return {
-        version: this.convertVersionToSemver(item.jdk_version),
+        version: convertVersionToSemver(item.jdk_version),
         url: item.url,
-        zuluVersion: this.convertVersionToSemver(item.zulu_version)
+        zuluVersion: convertVersionToSemver(item.zulu_version)
       };
     });
 
@@ -171,16 +172,5 @@ export class ZuluDistribution extends JavaBase {
       default:
         return process.platform;
     }
-  }
-
-  // Azul API returns jdk_version as array of digits like [11, 0, 2, 1]
-  private convertVersionToSemver(version_array: number[]) {
-    const mainVersion = version_array.slice(0, 3).join('.');
-    if (version_array.length > 3) {
-      // intentionally ignore more than 4 numbers because it is invalid semver
-      return `${mainVersion}+${version_array[3]}`;
-    }
-
-    return mainVersion;
   }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -151,3 +151,13 @@ export function getVersionFromFileContent(
 function avoidOldNotation(content: string): string {
   return content.startsWith('1.') ? content.substring(2) : content;
 }
+
+export function convertVersionToSemver(version: number[] | string) {
+  // Some distributions may use semver-like notation (12.10.2.1, 12.10.2.1.1)
+  const versionArray = Array.isArray(version) ? version : version.split('.');
+  const mainVersion = versionArray.slice(0, 3).join('.');
+  if (versionArray.length > 3) {
+    return `${mainVersion}+${versionArray.slice(3).join('.')}`;
+  }
+  return mainVersion;
+}


### PR DESCRIPTION
**Description:**
Similarly to Zulu, Corretto uses semver-like notation for tagging it's versions instead of real semver, e.g. 12.0.6.3.10. Because of this fact, action couldn't find preinstalled version of the Corretto JDK in the toolcache. In scope of this PR the internal interpretation of the Corretto version notation is changed like that (12.0.6.3.10 -> 12.0.6+3.10) to be able to use the node-semver package.

**Related issue:**
[#474](https://github.com/actions/setup-java/issues/474)

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.