### PR TITLE
Update versions of Oracle JDK and Microsoft Build of OpenJDK

### DIFF
--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -31,7 +31,7 @@ jobs:
             'semeru',
             'corretto'
           ] # internally 'adopt-hotspot' is the same as 'adopt'
-        version: ['8', '11', '16']
+        version: ['8', '11', '17']
         exclude:
           - distribution: microsoft
             version: 8
@@ -41,10 +41,10 @@ jobs:
             version: 17
           - distribution: oracle
             os: windows-latest
-            version: 19
+            version: 20
           - distribution: oracle
             os: ubuntu-latest
-            version: 19
+            version: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -70,11 +70,11 @@ jobs:
         version:
           - '11.0'
           - '8.0.302'
-          - '16.0.2+7'
+          - '17.0.7+7'
         include:
           - distribution: oracle
             os: ubuntu-latest
-            version: '19.0.1'
+            version: '20.0.1'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/__tests__/distributors/microsoft-installer.test.ts
+++ b/__tests__/distributors/microsoft-installer.test.ts
@@ -30,29 +30,14 @@ describe('findPackageForDownload', () => {
 
   it.each([
     [
-      '17.0.1',
-      '17.0.1+12.1',
-      'https://aka.ms/download-jdk/microsoft-jdk-17.0.1.12.1-{{OS_TYPE}}-x64.{{ARCHIVE_TYPE}}'
-    ],
-    [
       '17.x',
-      '17.0.3',
-      'https://aka.ms/download-jdk/microsoft-jdk-17.0.3-{{OS_TYPE}}-x64.{{ARCHIVE_TYPE}}'
+      '17.0.7',
+      'https://aka.ms/download-jdk/microsoft-jdk-17.0.7-{{OS_TYPE}}-x64.{{ARCHIVE_TYPE}}'
     ],
     [
-      '16.0.x',
-      '16.0.2+7.1',
-      'https://aka.ms/download-jdk/microsoft-jdk-16.0.2.7.1-{{OS_TYPE}}-x64.{{ARCHIVE_TYPE}}'
-    ],
-    [
-      '11.0.13',
-      '11.0.13+8.1',
-      'https://aka.ms/download-jdk/microsoft-jdk-11.0.13.8.1-{{OS_TYPE}}-x64.{{ARCHIVE_TYPE}}'
-    ],
-    [
-      '11.0.15',
-      '11.0.15',
-      'https://aka.ms/download-jdk/microsoft-jdk-11.0.15-{{OS_TYPE}}-x64.{{ARCHIVE_TYPE}}'
+      '11.x',
+      '11.0.19',
+      'https://aka.ms/download-jdk/microsoft-jdk-11.0.19-{{OS_TYPE}}-x64.{{ARCHIVE_TYPE}}'
     ]
   ])('version is %s -> %s', async (input, expectedVersion, expectedUrl) => {
     const result = await distribution['findPackageForDownload'](input);
@@ -97,7 +82,7 @@ describe('findPackageForDownload', () => {
       });
 
       const result = await distro['findPackageForDownload'](version);
-      const expectedUrl = `https://aka.ms/download-jdk/microsoft-jdk-17.0.3-linux-${distroArch}.tar.gz`;
+      const expectedUrl = `https://aka.ms/download-jdk/microsoft-jdk-17.0.7-linux-${distroArch}.tar.gz`;
 
       expect(result.url).toBe(expectedUrl);
     }

--- a/__tests__/distributors/oracle-installer.test.ts
+++ b/__tests__/distributors/oracle-installer.test.ts
@@ -21,19 +21,14 @@ describe('findPackageForDownload', () => {
 
   it.each([
     [
-      '19',
-      '19',
-      'https://download.oracle.com/java/19/latest/jdk-19_{{OS_TYPE}}-x64_bin.{{ARCHIVE_TYPE}}'
+      '20',
+      '20',
+      'https://download.oracle.com/java/20/latest/jdk-20_{{OS_TYPE}}-x64_bin.{{ARCHIVE_TYPE}}'
     ],
     [
-      '19.0.1',
-      '19.0.1',
-      'https://download.oracle.com/java/19/archive/jdk-19.0.1_{{OS_TYPE}}-x64_bin.{{ARCHIVE_TYPE}}'
-    ],
-    [
-      '18.0.2.1',
-      '18.0.2.1',
-      'https://download.oracle.com/java/18/archive/jdk-18.0.2.1_{{OS_TYPE}}-x64_bin.{{ARCHIVE_TYPE}}'
+      '20.0.1',
+      '20.0.1',
+      'https://download.oracle.com/java/20/archive/jdk-20.0.1_{{OS_TYPE}}-x64_bin.{{ARCHIVE_TYPE}}'
     ],
     [
       '17',

--- a/src/distributions/microsoft/microsoft-openjdk-versions.json
+++ b/src/distributions/microsoft/microsoft-openjdk-versions.json
@@ -1,76 +1,76 @@
 [
-    {
-        "version": "17.0.7",
-        "stable": true,
-        "release_url": "https://aka.ms/download-jdk",
-        "files": [
-          {
-            "filename": "microsoft-jdk-17.0.7-macos-x64.tar.gz",
-            "arch": "x64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-macos-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.7-linux-x64.tar.gz",
-            "arch": "x64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-linux-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.7-windows-x64.zip",
-            "arch": "x64",
-            "platform": "win32",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-windows-x64.zip"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.7-macos-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-macos-aarch64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.7-linux-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-linux-aarch64.tar.gz"
-          }
-        ]
-    }, 
-    {
-        "version": "11.0.19",
-        "stable": true,
-        "release_url": "https://aka.ms/download-jdk",
-        "files": [
-          {
-            "filename": "microsoft-jdk-11.0.19-macos-x64.tar.gz",
-            "arch": "x64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-macos-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.19-linux-x64.tar.gz",
-            "arch": "x64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-linux-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.19-windows-x64.zip",
-            "arch": "x64",
-            "platform": "win32",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-windows-x64.zip"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.19-macos-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-macos-aarch64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.19-linux-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-linux-aarch64.tar.gz"
-          }
-        ]
-    }
+  {
+    "version": "17.0.7",
+    "stable": true,
+    "release_url": "https://aka.ms/download-jdk",
+    "files": [
+      {
+        "filename": "microsoft-jdk-17.0.7-macos-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-macos-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.7-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-linux-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.7-windows-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-windows-x64.zip"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.7-macos-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-macos-aarch64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.7-linux-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-linux-aarch64.tar.gz"
+      }
+    ]
+  },
+  {
+    "version": "11.0.19",
+    "stable": true,
+    "release_url": "https://aka.ms/download-jdk",
+    "files": [
+      {
+        "filename": "microsoft-jdk-11.0.19-macos-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-macos-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.19-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-linux-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.19-windows-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-windows-x64.zip"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.19-macos-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-macos-aarch64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.19-linux-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-linux-aarch64.tar.gz"
+      }
+    ]
+  }
 ]

--- a/src/distributions/microsoft/microsoft-openjdk-versions.json
+++ b/src/distributions/microsoft/microsoft-openjdk-versions.json
@@ -1,180 +1,75 @@
 [
     {
-        "version": "17.0.3",
+        "version": "17.0.7",
         "stable": true,
         "release_url": "https://aka.ms/download-jdk",
         "files": [
           {
-            "filename": "microsoft-jdk-17.0.3-macos-x64.tar.gz",
+            "filename": "microsoft-jdk-17.0.7-macos-x64.tar.gz",
             "arch": "x64",
             "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.3-macos-x64.tar.gz"
+            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-macos-x64.tar.gz"
           },
           {
-            "filename": "microsoft-jdk-17.0.3-linux-x64.tar.gz",
+            "filename": "microsoft-jdk-17.0.7-linux-x64.tar.gz",
             "arch": "x64",
             "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.3-linux-x64.tar.gz"
+            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-linux-x64.tar.gz"
           },
           {
-            "filename": "microsoft-jdk-17.0.3-windows-x64.zip",
+            "filename": "microsoft-jdk-17.0.7-windows-x64.zip",
             "arch": "x64",
             "platform": "win32",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.3-windows-x64.zip"
+            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-windows-x64.zip"
           },
           {
-            "filename": "microsoft-jdk-17.0.3-macos-aarch64.tar.gz",
+            "filename": "microsoft-jdk-17.0.7-macos-aarch64.tar.gz",
             "arch": "aarch64",
             "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.3-macos-aarch64.tar.gz"
+            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-macos-aarch64.tar.gz"
           },
           {
-            "filename": "microsoft-jdk-17.0.3-linux-aarch64.tar.gz",
+            "filename": "microsoft-jdk-17.0.7-linux-aarch64.tar.gz",
             "arch": "aarch64",
             "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.3-linux-aarch64.tar.gz"
+            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-linux-aarch64.tar.gz"
           }
         ]
     }, 
     {
-        "version": "17.0.1+12.1",
+        "version": "11.0.19",
         "stable": true,
         "release_url": "https://aka.ms/download-jdk",
         "files": [
           {
-            "filename": "microsoft-jdk-17.0.1.12.1-macos-x64.tar.gz",
+            "filename": "microsoft-jdk-11.0.19-macos-x64.tar.gz",
             "arch": "x64",
             "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.1.12.1-macos-x64.tar.gz"
+            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-macos-x64.tar.gz"
           },
           {
-            "filename": "microsoft-jdk-17.0.1.12.1-linux-x64.tar.gz",
+            "filename": "microsoft-jdk-11.0.19-linux-x64.tar.gz",
             "arch": "x64",
             "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.1.12.1-linux-x64.tar.gz"
+            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-linux-x64.tar.gz"
           },
           {
-            "filename": "microsoft-jdk-17.0.1.12.1-windows-x64.zip",
+            "filename": "microsoft-jdk-11.0.19-windows-x64.zip",
             "arch": "x64",
             "platform": "win32",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.1.12.1-windows-x64.zip"
+            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-windows-x64.zip"
           },
           {
-            "filename": "microsoft-jdk-17.0.1.12.1-macos-aarch64.tar.gz",
+            "filename": "microsoft-jdk-11.0.19-macos-aarch64.tar.gz",
             "arch": "aarch64",
             "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.1.12.1-macos-aarch64.tar.gz"
+            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-macos-aarch64.tar.gz"
           },
           {
-            "filename": "microsoft-jdk-17.0.1.12.1-linux-aarch64.tar.gz",
+            "filename": "microsoft-jdk-11.0.19-linux-aarch64.tar.gz",
             "arch": "aarch64",
             "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.1.12.1-linux-aarch64.tar.gz"
-          }
-        ]
-    },
-    {
-        "version": "16.0.2+7.1",
-        "stable": true,
-        "release_url": "https://aka.ms/download-jdk",
-        "files": [
-          {
-            "filename": "microsoft-jdk-16.0.2.7.1-macos-x64.tar.gz",
-            "arch": "x64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-16.0.2.7.1-macos-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-16.0.2.7.1-linux-x64.tar.gz",
-            "arch": "x64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-16.0.2.7.1-linux-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-16.0.2.7.1-windows-x64.zip",
-            "arch": "x64",
-            "platform": "win32",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-16.0.2.7.1-windows-x64.zip"
-          },
-          {
-            "filename": "microsoft-jdk-16.0.2.7.1-macos-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-16.0.2.7.1-macos-aarch64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-16.0.2.7.1-linux-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-16.0.2.7.1-linux-aarch64.tar.gz"
-          }
-        ]
-    },
-    {
-        "version": "11.0.15",
-        "stable": true,
-        "release_url": "https://aka.ms/download-jdk",
-        "files": [
-          {
-            "filename": "microsoft-jdk-11.0.15-macos-x64.tar.gz",
-            "arch": "x64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.15-macos-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.15-linux-x64.tar.gz",
-            "arch": "x64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.15-linux-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.15-windows-x64.zip",
-            "arch": "x64",
-            "platform": "win32",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.15-windows-x64.zip"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.15-macos-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.15-macos-aarch64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.15-linux-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.15-linux-aarch64.tar.gz"
-          }
-        ]
-    },
-    {
-        "version": "11.0.13+8.1",
-        "stable": true,
-        "release_url": "https://aka.ms/download-jdk",
-        "files": [
-          {
-            "filename": "microsoft-jdk-11.0.13.8.1-macos-x64.tar.gz",
-            "arch": "x64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.13.8.1-macos-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.13.8.1-linux-x64.tar.gz",
-            "arch": "x64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.13.8.1-linux-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.13.8.1-windows-x64.zip",
-            "arch": "x64",
-            "platform": "win32",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.13.8.1-windows-x64.zip"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.13.8.1-linux-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.13.8.1-linux-aarch64.tar.gz"
+            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-linux-aarch64.tar.gz"
           }
         ]
     }

--- a/src/distributions/microsoft/microsoft-openjdk-versions.json
+++ b/src/distributions/microsoft/microsoft-openjdk-versions.json
@@ -1,76 +1,76 @@
 [
-  {
-    "version": "17.0.7",
-    "stable": true,
-    "release_url": "https://aka.ms/download-jdk",
-    "files": [
-      {
-        "filename": "microsoft-jdk-17.0.7-macos-x64.tar.gz",
-        "arch": "x64",
-        "platform": "darwin",
-        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-macos-x64.tar.gz"
-      },
-      {
-        "filename": "microsoft-jdk-17.0.7-linux-x64.tar.gz",
-        "arch": "x64",
-        "platform": "linux",
-        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-linux-x64.tar.gz"
-      },
-      {
-        "filename": "microsoft-jdk-17.0.7-windows-x64.zip",
-        "arch": "x64",
-        "platform": "win32",
-        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-windows-x64.zip"
-      },
-      {
-        "filename": "microsoft-jdk-17.0.7-macos-aarch64.tar.gz",
-        "arch": "aarch64",
-        "platform": "darwin",
-        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-macos-aarch64.tar.gz"
-      },
-      {
-        "filename": "microsoft-jdk-17.0.7-linux-aarch64.tar.gz",
-        "arch": "aarch64",
-        "platform": "linux",
-        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-linux-aarch64.tar.gz"
-      }
-    ]
-  },
-  {
-    "version": "11.0.19",
-    "stable": true,
-    "release_url": "https://aka.ms/download-jdk",
-    "files": [
-      {
-        "filename": "microsoft-jdk-11.0.19-macos-x64.tar.gz",
-        "arch": "x64",
-        "platform": "darwin",
-        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-macos-x64.tar.gz"
-      },
-      {
-        "filename": "microsoft-jdk-11.0.19-linux-x64.tar.gz",
-        "arch": "x64",
-        "platform": "linux",
-        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-linux-x64.tar.gz"
-      },
-      {
-        "filename": "microsoft-jdk-11.0.19-windows-x64.zip",
-        "arch": "x64",
-        "platform": "win32",
-        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-windows-x64.zip"
-      },
-      {
-        "filename": "microsoft-jdk-11.0.19-macos-aarch64.tar.gz",
-        "arch": "aarch64",
-        "platform": "darwin",
-        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-macos-aarch64.tar.gz"
-      },
-      {
-        "filename": "microsoft-jdk-11.0.19-linux-aarch64.tar.gz",
-        "arch": "aarch64",
-        "platform": "linux",
-        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-linux-aarch64.tar.gz"
-      }
-    ]
-  }
+    {
+        "version": "17.0.7",
+        "stable": true,
+        "release_url": "https://aka.ms/download-jdk",
+        "files": [
+          {
+            "filename": "microsoft-jdk-17.0.7-macos-x64.tar.gz",
+            "arch": "x64",
+            "platform": "darwin",
+            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-macos-x64.tar.gz"
+          },
+          {
+            "filename": "microsoft-jdk-17.0.7-linux-x64.tar.gz",
+            "arch": "x64",
+            "platform": "linux",
+            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-linux-x64.tar.gz"
+          },
+          {
+            "filename": "microsoft-jdk-17.0.7-windows-x64.zip",
+            "arch": "x64",
+            "platform": "win32",
+            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-windows-x64.zip"
+          },
+          {
+            "filename": "microsoft-jdk-17.0.7-macos-aarch64.tar.gz",
+            "arch": "aarch64",
+            "platform": "darwin",
+            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-macos-aarch64.tar.gz"
+          },
+          {
+            "filename": "microsoft-jdk-17.0.7-linux-aarch64.tar.gz",
+            "arch": "aarch64",
+            "platform": "linux",
+            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-linux-aarch64.tar.gz"
+          }
+        ]
+    }, 
+    {
+        "version": "11.0.19",
+        "stable": true,
+        "release_url": "https://aka.ms/download-jdk",
+        "files": [
+          {
+            "filename": "microsoft-jdk-11.0.19-macos-x64.tar.gz",
+            "arch": "x64",
+            "platform": "darwin",
+            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-macos-x64.tar.gz"
+          },
+          {
+            "filename": "microsoft-jdk-11.0.19-linux-x64.tar.gz",
+            "arch": "x64",
+            "platform": "linux",
+            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-linux-x64.tar.gz"
+          },
+          {
+            "filename": "microsoft-jdk-11.0.19-windows-x64.zip",
+            "arch": "x64",
+            "platform": "win32",
+            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-windows-x64.zip"
+          },
+          {
+            "filename": "microsoft-jdk-11.0.19-macos-aarch64.tar.gz",
+            "arch": "aarch64",
+            "platform": "darwin",
+            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-macos-aarch64.tar.gz"
+          },
+          {
+            "filename": "microsoft-jdk-11.0.19-linux-aarch64.tar.gz",
+            "arch": "aarch64",
+            "platform": "linux",
+            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-linux-aarch64.tar.gz"
+          }
+        ]
+    }
 ]


### PR DESCRIPTION
**Description:**
As the latest JDK of Microsoft Build of OpenJDK could not be downloaded with the current `setup-java` action, `microsoft-openjdk-versions.json` and `microsoft-installer.test.ts` were modified. Along with this modification, `oracle-installer.test.ts` was also changed since the latest JDK could not be also downloaded with the current action.

**Related issue:**
As of now no related issue exists.

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.