### PR TITLE
Add support for Oracle GraalVM

### DIFF
--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -58,6 +58,9 @@ jobs:
           - distribution: graalvm
             os: ubuntu-latest
             version: 21
+          - distribution: graalvm
+            os: ubuntu-latest
+            version: '24-ea'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -45,11 +45,19 @@ jobs:
             version: 17
           - distribution: oracle
             os: windows-latest
-            version: 20
+            version: 21
           - distribution: oracle
             os: ubuntu-latest
-            version: 20
-
+            version: 21
+          - distribution: graalvm
+            os: macos-latest
+            version: 17
+          - distribution: graalvm
+            os: windows-latest
+            version: 21
+          - distribution: graalvm
+            os: ubuntu-latest
+            version: 21
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -79,7 +87,10 @@ jobs:
         include:
           - distribution: oracle
             os: ubuntu-latest
-            version: '20.0.1'
+            version: '21.0.4'
+          - distribution: graalvm
+            os: ubuntu-latest
+            version: '21.0.4'
           - distribution: dragonwell
             os: ubuntu-latest
             version: '11.0'

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Currently, the following distributions are supported:
 | `oracle` | Oracle JDK | [Link](https://www.oracle.com/java/technologies/downloads/) | [Link](https://java.com/freeuselicense)
 | `dragonwell` | Alibaba Dragonwell JDK | [Link](https://dragonwell-jdk.io/) | [Link](https://www.aliyun.com/product/dragonwell/)
 | `sapmachine` | SAP SapMachine JDK/JRE | [Link](https://sapmachine.io/) | [Link](https://github.com/SAP/SapMachine/blob/sapmachine/LICENSE)
+| `graalvm` | Oracle GraalVM | [Link](https://www.graalvm.org/) | [Link](https://www.oracle.com/downloads/licenses/graal-free-license.html)
 
 **NOTE:** The different distributors can provide discrepant list of available versions / supported configurations. Please refer to the official documentation to see the list of supported versions.
 
@@ -259,6 +260,7 @@ In the example above multiple JDKs are installed for the same job. The result af
   - [Oracle](docs/advanced-usage.md#Oracle)
   - [Alibaba Dragonwell](docs/advanced-usage.md#Alibaba-Dragonwell)
   - [SapMachine](docs/advanced-usage.md#SapMachine)
+  - [GraalVM](docs/advanced-usage.md#GraalVM)
 - [Installing custom Java package type](docs/advanced-usage.md#Installing-custom-Java-package-type)
 - [Installing custom Java architecture](docs/advanced-usage.md#Installing-custom-Java-architecture)
 - [Installing custom Java distribution from local file](docs/advanced-usage.md#Installing-Java-from-local-file)

--- a/__tests__/distributors/graalvm-installer.test.ts
+++ b/__tests__/distributors/graalvm-installer.test.ts
@@ -1,0 +1,109 @@
+import {GraalVMDistribution} from '../../src/distributions/graalvm/installer';
+import os from 'os';
+import * as core from '@actions/core';
+import {getDownloadArchiveExtension} from '../../src/util';
+import {HttpClient} from '@actions/http-client';
+
+describe('findPackageForDownload', () => {
+  let distribution: GraalVMDistribution;
+  let spyDebug: jest.SpyInstance;
+  let spyHttpClient: jest.SpyInstance;
+
+  beforeEach(() => {
+    distribution = new GraalVMDistribution({
+      version: '',
+      architecture: 'x64',
+      packageType: 'jdk',
+      checkLatest: false
+    });
+
+    spyDebug = jest.spyOn(core, 'debug');
+    spyDebug.mockImplementation(() => {});
+  });
+
+  it.each([
+    [
+      '21',
+      '21',
+      'https://download.oracle.com/graalvm/21/latest/graalvm-jdk-21_{{OS_TYPE}}-x64_bin.{{ARCHIVE_TYPE}}'
+    ],
+    [
+      '21.0.4',
+      '21.0.4',
+      'https://download.oracle.com/graalvm/21/archive/graalvm-jdk-21.0.4_{{OS_TYPE}}-x64_bin.{{ARCHIVE_TYPE}}'
+    ],
+    [
+      '17',
+      '17',
+      'https://download.oracle.com/graalvm/17/latest/graalvm-jdk-17_{{OS_TYPE}}-x64_bin.{{ARCHIVE_TYPE}}'
+    ],
+    [
+      '17.0.12',
+      '17.0.12',
+      'https://download.oracle.com/graalvm/17/archive/graalvm-jdk-17.0.12_{{OS_TYPE}}-x64_bin.{{ARCHIVE_TYPE}}'
+    ]
+  ])('version is %s -> %s', async (input, expectedVersion, expectedUrl) => {
+    /* Needed only for this particular test because /latest/ urls tend to change */
+    spyHttpClient = jest.spyOn(HttpClient.prototype, 'head');
+    spyHttpClient.mockReturnValue(
+      Promise.resolve({
+        message: {
+          statusCode: 200
+        }
+      })
+    );
+
+    const result = await distribution['findPackageForDownload'](input);
+
+    jest.restoreAllMocks();
+
+    expect(result.version).toBe(expectedVersion);
+    const osType = distribution.getPlatform();
+    const archiveType = getDownloadArchiveExtension();
+    const url = expectedUrl
+      .replace('{{OS_TYPE}}', osType)
+      .replace('{{ARCHIVE_TYPE}}', archiveType);
+    expect(result.url).toBe(url);
+  });
+
+  it.each([
+    ['amd64', 'x64'],
+    ['arm64', 'aarch64']
+  ])(
+    'defaults to os.arch(): %s mapped to distro arch: %s',
+    async (osArch: string, distroArch: string) => {
+      jest.spyOn(os, 'arch').mockReturnValue(osArch);
+      jest.spyOn(os, 'platform').mockReturnValue('linux');
+
+      const version = '17';
+      const distro = new GraalVMDistribution({
+        version,
+        architecture: '', // to get default value
+        packageType: 'jdk',
+        checkLatest: false
+      });
+
+      const osType = distribution.getPlatform();
+      if (osType === 'windows' && distroArch == 'aarch64') {
+        return; // skip, aarch64 is not available for Windows
+      }
+      const archiveType = getDownloadArchiveExtension();
+      const result = await distro['findPackageForDownload'](version);
+      const expectedUrl = `https://download.oracle.com/graalvm/17/latest/graalvm-jdk-17_${osType}-${distroArch}_bin.${archiveType}`;
+
+      expect(result.url).toBe(expectedUrl);
+    }
+  );
+
+  it('should throw an error', async () => {
+    await expect(distribution['findPackageForDownload']('8')).rejects.toThrow(
+      /GraalVM JDK is only supported for JDK 17 and later/
+    );
+    await expect(distribution['findPackageForDownload']('11')).rejects.toThrow(
+      /GraalVM JDK is only supported for JDK 17 and later/
+    );
+    await expect(distribution['findPackageForDownload']('18')).rejects.toThrow(
+      /Could not find GraalVM JDK for SemVer */
+    );
+  });
+});

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -9,6 +9,7 @@
   - [Oracle](#Oracle)
   - [Alibaba Dragonwell](#Alibaba-Dragonwell)
   - [SapMachine](#SapMachine)
+  - [GraalVM](#GraalVM)
 - [Installing custom Java package type](#Installing-custom-Java-package-type)
 - [Installing custom Java architecture](#Installing-custom-Java-architecture)
 - [Installing custom Java distribution from local file](#Installing-Java-from-local-file)
@@ -153,6 +154,21 @@ steps:
     distribution: 'sapmachine'
     java-version: '21'
 - run: java -cp java HelloWorldApp
+```
+
+### GraalVM
+**NOTE:** Oracle GraalVM is only available for JDK 17 and later.
+
+```yaml
+steps:
+- uses: actions/checkout@v4
+- uses: actions/setup-java@v4
+  with:
+    distribution: 'graalvm'
+    java-version: '21'
+- run: |
+    java -cp java HelloWorldApp
+    native-image -cp java HelloWorldApp
 ```
 
 ## Installing custom Java package type

--- a/src/distributions/distribution-factory.ts
+++ b/src/distributions/distribution-factory.ts
@@ -11,6 +11,7 @@ import {CorrettoDistribution} from './corretto/installer';
 import {OracleDistribution} from './oracle/installer';
 import {DragonwellDistribution} from './dragonwell/installer';
 import {SapMachineDistribution} from './sapmachine/installer';
+import {GraalVMDistribution} from './graalvm/installer';
 
 enum JavaDistribution {
   Adopt = 'adopt',
@@ -25,7 +26,8 @@ enum JavaDistribution {
   Corretto = 'corretto',
   Oracle = 'oracle',
   Dragonwell = 'dragonwell',
-  SapMachine = 'sapmachine'
+  SapMachine = 'sapmachine',
+  GraalVM = 'graalvm'
 }
 
 export function getJavaDistribution(
@@ -68,6 +70,8 @@ export function getJavaDistribution(
       return new DragonwellDistribution(installerOptions);
     case JavaDistribution.SapMachine:
       return new SapMachineDistribution(installerOptions);
+    case JavaDistribution.GraalVM:
+      return new GraalVMDistribution(installerOptions);
     default:
       return null;
   }

--- a/src/distributions/graalvm/installer.ts
+++ b/src/distributions/graalvm/installer.ts
@@ -1,0 +1,111 @@
+import * as core from '@actions/core';
+import * as tc from '@actions/tool-cache';
+
+import fs from 'fs';
+import path from 'path';
+
+import {JavaBase} from '../base-installer';
+import {
+  JavaDownloadRelease,
+  JavaInstallerOptions,
+  JavaInstallerResults
+} from '../base-models';
+import {extractJdkFile, getDownloadArchiveExtension} from '../../util';
+import {HttpCodes} from '@actions/http-client';
+
+const GRAALVM_DL_BASE = 'https://download.oracle.com/graalvm';
+
+export class GraalVMDistribution extends JavaBase {
+  constructor(installerOptions: JavaInstallerOptions) {
+    super('GraalVM', installerOptions);
+  }
+
+  protected async downloadTool(
+    javaRelease: JavaDownloadRelease
+  ): Promise<JavaInstallerResults> {
+    core.info(
+      `Downloading Java ${javaRelease.version} (${this.distribution}) from ${javaRelease.url} ...`
+    );
+    const javaArchivePath = await tc.downloadTool(javaRelease.url);
+
+    core.info(`Extracting Java archive...`);
+    const extension = getDownloadArchiveExtension();
+
+    const extractedJavaPath = await extractJdkFile(javaArchivePath, extension);
+
+    const archiveName = fs.readdirSync(extractedJavaPath)[0];
+    const archivePath = path.join(extractedJavaPath, archiveName);
+    const version = this.getToolcacheVersionName(javaRelease.version);
+
+    const javaPath = await tc.cacheDir(
+      archivePath,
+      this.toolcacheFolderName,
+      version,
+      this.architecture
+    );
+
+    return {version: javaRelease.version, path: javaPath};
+  }
+
+  protected async findPackageForDownload(
+    range: string
+  ): Promise<JavaDownloadRelease> {
+    const arch = this.distributionArchitecture();
+    if (arch !== 'x64' && arch !== 'aarch64') {
+      throw new Error(`Unsupported architecture: ${this.architecture}`);
+    }
+
+    if (!this.stable) {
+      throw new Error('Early access versions are not supported');
+    }
+
+    if (this.packageType !== 'jdk') {
+      throw new Error('GraalVM JDK provides only the `jdk` package type');
+    }
+
+    const platform = this.getPlatform();
+    const extension = getDownloadArchiveExtension();
+    let major;
+    let fileUrl;
+    if (range.includes('.')) {
+      major = range.split('.')[0];
+      fileUrl = `${GRAALVM_DL_BASE}/${major}/archive/graalvm-jdk-${range}_${platform}-${arch}_bin.${extension}`;
+    } else {
+      major = range;
+      fileUrl = `${GRAALVM_DL_BASE}/${range}/latest/graalvm-jdk-${range}_${platform}-${arch}_bin.${extension}`;
+    }
+
+    if (parseInt(major) < 17) {
+      throw new Error('GraalVM JDK is only supported for JDK 17 and later');
+    }
+
+    const response = await this.http.head(fileUrl);
+
+    if (response.message.statusCode === HttpCodes.NotFound) {
+      throw new Error(`Could not find GraalVM JDK for SemVer ${range}`);
+    }
+
+    if (response.message.statusCode !== HttpCodes.OK) {
+      throw new Error(
+        `Http request for GraalVM JDK failed with status code: ${response.message.statusCode}`
+      );
+    }
+
+    return {url: fileUrl, version: range};
+  }
+
+  public getPlatform(platform: NodeJS.Platform = process.platform): OsVersions {
+    switch (platform) {
+      case 'darwin':
+        return 'macos';
+      case 'win32':
+        return 'windows';
+      case 'linux':
+        return 'linux';
+      default:
+        throw new Error(
+          `Platform '${platform}' is not supported. Supported platforms: 'linux', 'macos', 'windows'`
+        );
+    }
+  }
+}

--- a/src/distributions/graalvm/models.ts
+++ b/src/distributions/graalvm/models.ts
@@ -1,0 +1,1 @@
+export type OsVersions = 'linux' | 'macos' | 'windows';

--- a/src/distributions/graalvm/models.ts
+++ b/src/distributions/graalvm/models.ts
@@ -1,1 +1,14 @@
 export type OsVersions = 'linux' | 'macos' | 'windows';
+
+export interface GraalVMEAFile {
+  filename: string;
+  arch: 'aarch64' | 'x64';
+  platform: 'darwin' | 'linux' | 'windows';
+}
+
+export interface GraalVMEAVersion {
+  version: string;
+  latest?: boolean;
+  download_base_url: string;
+  files: GraalVMEAFile[];
+}


### PR DESCRIPTION
**Description:**
This PR adds Oracle GraalVM JDK to the list of supported distributions.

**Related issue:** https://github.com/actions/setup-java/pull/401

**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.