### PR TITLE
Fix XML namespaces wrongly using https

### DIFF
--- a/__tests__/toolchains.test.ts
+++ b/__tests__/toolchains.test.ts
@@ -77,9 +77,9 @@ describe('toolchains tests', () => {
     };
 
     const result = `<?xml version="1.0"?>
-<toolchains xmlns="https://maven.apache.org/TOOLCHAINS/1.1.0"
-  xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="https://maven.apache.org/TOOLCHAINS/1.1.0 https://maven.apache.org/xsd/toolchains-1.1.0.xsd">
+<toolchains xmlns="http://maven.apache.org/TOOLCHAINS/1.1.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/TOOLCHAINS/1.1.0 https://maven.apache.org/xsd/toolchains-1.1.0.xsd">
   <toolchain>
     <type>jdk</type>
     <provides>
@@ -248,9 +248,9 @@ describe('toolchains tests', () => {
     };
 
     const expectedToolchains = `<?xml version="1.0"?>
-<toolchains xmlns="https://maven.apache.org/TOOLCHAINS/1.1.0"
-  xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="https://maven.apache.org/TOOLCHAINS/1.1.0 https://maven.apache.org/xsd/toolchains-1.1.0.xsd">
+<toolchains xmlns="http://maven.apache.org/TOOLCHAINS/1.1.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/TOOLCHAINS/1.1.0 https://maven.apache.org/xsd/toolchains-1.1.0.xsd">
   <toolchain>
     <type>jdk</type>
     <provides>

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -103848,9 +103848,9 @@ function generateToolchainDefinition(original, version, vendor, id, jdkHome) {
     else
         xmlObj = xmlbuilder2_1.create({
             toolchains: {
-                '@xmlns': 'https://maven.apache.org/TOOLCHAINS/1.1.0',
-                '@xmlns:xsi': 'https://www.w3.org/2001/XMLSchema-instance',
-                '@xsi:schemaLocation': 'https://maven.apache.org/TOOLCHAINS/1.1.0 https://maven.apache.org/xsd/toolchains-1.1.0.xsd',
+                '@xmlns': 'http://maven.apache.org/TOOLCHAINS/1.1.0',
+                '@xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+                '@xsi:schemaLocation': 'http://maven.apache.org/TOOLCHAINS/1.1.0 https://maven.apache.org/xsd/toolchains-1.1.0.xsd',
                 toolchain: [
                     {
                         type: 'jdk',

--- a/src/toolchains.ts
+++ b/src/toolchains.ts
@@ -104,10 +104,10 @@ export function generateToolchainDefinition(
   } else
     xmlObj = xmlCreate({
       toolchains: {
-        '@xmlns': 'https://maven.apache.org/TOOLCHAINS/1.1.0',
-        '@xmlns:xsi': 'https://www.w3.org/2001/XMLSchema-instance',
+        '@xmlns': 'http://maven.apache.org/TOOLCHAINS/1.1.0',
+        '@xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
         '@xsi:schemaLocation':
-          'https://maven.apache.org/TOOLCHAINS/1.1.0 https://maven.apache.org/xsd/toolchains-1.1.0.xsd',
+          'http://maven.apache.org/TOOLCHAINS/1.1.0 https://maven.apache.org/xsd/toolchains-1.1.0.xsd',
         toolchain: [
           {
             type: 'jdk',


### PR DESCRIPTION
**Description:**
This PR fix the XML namespaces used when creating the maven toochains.xml file.
The namespaces are identifiers and do not start with 'https', but 'http'.
See https://www.w3.org/TR/xmlschema-1/#Instance_Document_Constructions and 
https://maven.apache.org/xsd/toolchains-1.1.0.xsd.
This is problematic and will break when Maven 4 uses a more conformant XML parser.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
