### PR TITLE
Make the Adoptopenjdk package type look at the Temurin repo first for latest assets

### DIFF
--- a/__tests__/distributors/adopt-installer.test.ts
+++ b/__tests__/distributors/adopt-installer.test.ts
@@ -4,6 +4,7 @@ import {
   AdoptDistribution,
   AdoptImplementation
 } from '../../src/distributions/adopt/installer';
+import {TemurinDistribution} from '../../src/distributions/temurin/installer';
 import {JavaInstallerOptions} from '../../src/distributions/base-models';
 
 import os from 'os';
@@ -256,6 +257,38 @@ describe('getAvailableVersions', () => {
 });
 
 describe('findPackageForDownload', () => {
+  it('returns Temurin result and does not query Adopt API when Temurin succeeds', async () => {
+    const temurinRelease = {
+      version: '11.0.31+11',
+      url: 'https://example.test/temurin-11.tar.gz'
+    };
+    const temurinFindPackageForDownload = jest
+      .fn()
+      .mockResolvedValue(temurinRelease);
+    const temurinDistribution = {
+      findPackageForDownload: temurinFindPackageForDownload
+    } as unknown as TemurinDistribution;
+
+    const distribution = new AdoptDistribution(
+      {
+        version: '11',
+        architecture: 'x64',
+        packageType: 'jdk',
+        checkLatest: false
+      },
+      AdoptImplementation.Hotspot,
+      temurinDistribution
+    );
+    const adoptLookupSpy = jest.fn();
+    distribution['getAvailableVersions'] = adoptLookupSpy;
+
+    const resolvedVersion = await distribution['findPackageForDownload']('11');
+
+    expect(resolvedVersion).toEqual(temurinRelease);
+    expect(temurinFindPackageForDownload).toHaveBeenCalledWith('11');
+    expect(adoptLookupSpy).not.toHaveBeenCalled();
+  });
+
   it.each([
     ['9', '9.0.7+10'],
     ['15', '15.0.2+7'],
@@ -279,9 +312,10 @@ describe('findPackageForDownload', () => {
       AdoptImplementation.Hotspot
     );
     // Mock Temurin to fail so fallback to AdoptOpenJDK is tested
-    distribution['temurinDistribution']!['findPackageForDownload'] = async () => {
-      throw new Error('No matching version found for SemVer');
-    };
+    distribution['temurinDistribution']!['findPackageForDownload'] =
+      async () => {
+        throw new Error('No matching version found for SemVer');
+      };
     distribution['getAvailableVersions'] = async () => manifestData as any;
     const resolvedVersion = await distribution['findPackageForDownload'](input);
     expect(resolvedVersion.version).toBe(expected);
@@ -298,9 +332,10 @@ describe('findPackageForDownload', () => {
       AdoptImplementation.Hotspot
     );
     // Mock Temurin to fail so fallback to AdoptOpenJDK is tested
-    distribution['temurinDistribution']!['findPackageForDownload'] = async () => {
-      throw new Error('No matching version found for SemVer');
-    };
+    distribution['temurinDistribution']!['findPackageForDownload'] =
+      async () => {
+        throw new Error('No matching version found for SemVer');
+      };
     distribution['getAvailableVersions'] = async () => manifestData as any;
     await expect(
       distribution['findPackageForDownload']('9.0.8')
@@ -318,9 +353,10 @@ describe('findPackageForDownload', () => {
       AdoptImplementation.Hotspot
     );
     // Mock Temurin to fail so fallback to AdoptOpenJDK is tested
-    distribution['temurinDistribution']!['findPackageForDownload'] = async () => {
-      throw new Error('No matching version found for SemVer');
-    };
+    distribution['temurinDistribution']!['findPackageForDownload'] =
+      async () => {
+        throw new Error('No matching version found for SemVer');
+      };
     distribution['getAvailableVersions'] = async () => manifestData as any;
     await expect(distribution['findPackageForDownload']('7.x')).rejects.toThrow(
       /No matching version found for SemVer */
@@ -338,9 +374,10 @@ describe('findPackageForDownload', () => {
       AdoptImplementation.Hotspot
     );
     // Mock Temurin to fail so fallback to AdoptOpenJDK is tested
-    distribution['temurinDistribution']!['findPackageForDownload'] = async () => {
-      throw new Error('No matching version found for SemVer');
-    };
+    distribution['temurinDistribution']!['findPackageForDownload'] =
+      async () => {
+        throw new Error('No matching version found for SemVer');
+      };
     distribution['getAvailableVersions'] = async () => [];
     await expect(distribution['findPackageForDownload']('11')).rejects.toThrow(
       /No matching version found for SemVer */

--- a/__tests__/distributors/adopt-installer.test.ts
+++ b/__tests__/distributors/adopt-installer.test.ts
@@ -278,6 +278,10 @@ describe('findPackageForDownload', () => {
       },
       AdoptImplementation.Hotspot
     );
+    // Mock Temurin to fail so fallback to AdoptOpenJDK is tested
+    distribution['temurinDistribution']!['findPackageForDownload'] = async () => {
+      throw new Error('No matching version found for SemVer');
+    };
     distribution['getAvailableVersions'] = async () => manifestData as any;
     const resolvedVersion = await distribution['findPackageForDownload'](input);
     expect(resolvedVersion.version).toBe(expected);
@@ -293,6 +297,10 @@ describe('findPackageForDownload', () => {
       },
       AdoptImplementation.Hotspot
     );
+    // Mock Temurin to fail so fallback to AdoptOpenJDK is tested
+    distribution['temurinDistribution']!['findPackageForDownload'] = async () => {
+      throw new Error('No matching version found for SemVer');
+    };
     distribution['getAvailableVersions'] = async () => manifestData as any;
     await expect(
       distribution['findPackageForDownload']('9.0.8')
@@ -309,6 +317,10 @@ describe('findPackageForDownload', () => {
       },
       AdoptImplementation.Hotspot
     );
+    // Mock Temurin to fail so fallback to AdoptOpenJDK is tested
+    distribution['temurinDistribution']!['findPackageForDownload'] = async () => {
+      throw new Error('No matching version found for SemVer');
+    };
     distribution['getAvailableVersions'] = async () => manifestData as any;
     await expect(distribution['findPackageForDownload']('7.x')).rejects.toThrow(
       /No matching version found for SemVer */
@@ -325,6 +337,10 @@ describe('findPackageForDownload', () => {
       },
       AdoptImplementation.Hotspot
     );
+    // Mock Temurin to fail so fallback to AdoptOpenJDK is tested
+    distribution['temurinDistribution']!['findPackageForDownload'] = async () => {
+      throw new Error('No matching version found for SemVer');
+    };
     distribution['getAvailableVersions'] = async () => [];
     await expect(distribution['findPackageForDownload']('11')).rejects.toThrow(
       /No matching version found for SemVer */

--- a/package-lock.json
+++ b/package-lock.json
@@ -6470,21 +6470,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/xml-naming": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/xmlbuilder2": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-4.0.3.tgz",

--- a/src/distributions/adopt/installer.ts
+++ b/src/distributions/adopt/installer.ts
@@ -21,6 +21,7 @@ import {
   MAX_PAGINATION_PAGES,
   validatePaginationUrl
 } from '../../util';
+import {TemurinDistribution, TemurinImplementation} from '../temurin/installer';
 
 export enum AdoptImplementation {
   Hotspot = 'Hotspot',
@@ -30,12 +31,60 @@ export enum AdoptImplementation {
 export class AdoptDistribution extends JavaBase {
   constructor(
     installerOptions: JavaInstallerOptions,
-    private readonly jvmImpl: AdoptImplementation
+    private readonly jvmImpl: AdoptImplementation,
+    private readonly temurinDistribution: TemurinDistribution | null = null
   ) {
     super(`Adopt-${jvmImpl}`, installerOptions);
+
+    if (temurinDistribution != null && jvmImpl != AdoptImplementation.Hotspot) {
+      throw new Error('Only Hotspot JVM is supported by Temurin.');
+    }
+
+    // Only use the temurin repo for Hotspot JVMs
+    if (temurinDistribution == null && jvmImpl == AdoptImplementation.Hotspot) {
+      this.temurinDistribution = new TemurinDistribution(
+        installerOptions,
+        TemurinImplementation.Hotspot
+      );
+    }
   }
 
   protected async findPackageForDownload(
+    version: string
+  ): Promise<JavaDownloadRelease> {
+    if (this.jvmImpl == AdoptImplementation.Hotspot) {
+      core.notice(
+        "AdoptOpenJDK has moved to Eclipse Temurin https://github.com/actions/setup-java#supported-distributions please consider changing to the 'temurin' distribution type in your setup-java configuration."
+      );
+    }
+
+    if (
+      this.jvmImpl == AdoptImplementation.Hotspot &&
+      this.temurinDistribution != null
+    ) {
+      try {
+        const result = await this.temurinDistribution.findPackageForDownload(
+          version
+        );
+
+        if (result != undefined) {
+          return result;
+        }
+      } catch (error) {
+        if (error.message.includes('Could not find satisfied version')) {
+          core.notice(
+            'The JVM you are looking for could not be found in the Temurin repository, this likely indicates ' +
+              'that you are using an out of date version of Java, consider updating and moving to using the Temurin distribution type in setup-java.'
+          );
+        }
+      }
+    }
+
+    // failed to find a Temurin version, so fall back to AdoptOpenJDK
+    return this.findPackageForDownloadOldAdoptOpenJdk(version);
+  }
+
+  private async findPackageForDownloadOldAdoptOpenJdk(
     version: string
   ): Promise<JavaDownloadRelease> {
     const availableVersionsRaw = await this.getAvailableVersions();

--- a/src/distributions/adopt/installer.ts
+++ b/src/distributions/adopt/installer.ts
@@ -29,10 +29,12 @@ export enum AdoptImplementation {
 }
 
 export class AdoptDistribution extends JavaBase {
+  private readonly temurinDistribution: TemurinDistribution | null;
+
   constructor(
     installerOptions: JavaInstallerOptions,
     private readonly jvmImpl: AdoptImplementation,
-    private readonly temurinDistribution: TemurinDistribution | null = null
+    temurinDistribution: TemurinDistribution | null = null
   ) {
     super(`Adopt-${jvmImpl}`, installerOptions);
 
@@ -44,15 +46,14 @@ export class AdoptDistribution extends JavaBase {
     }
 
     // Only use the temurin repo for Hotspot JVMs
-    if (
-      temurinDistribution === null &&
-      jvmImpl === AdoptImplementation.Hotspot
-    ) {
-      this.temurinDistribution = new TemurinDistribution(
-        installerOptions,
-        TemurinImplementation.Hotspot
-      );
-    }
+    this.temurinDistribution =
+      temurinDistribution ??
+      (jvmImpl === AdoptImplementation.Hotspot
+        ? new TemurinDistribution(
+            installerOptions,
+            TemurinImplementation.Hotspot
+          )
+        : null);
   }
 
   protected async findPackageForDownload(

--- a/src/distributions/adopt/installer.ts
+++ b/src/distributions/adopt/installer.ts
@@ -73,8 +73,9 @@ export class AdoptDistribution extends JavaBase {
         return await this.temurinDistribution.findPackageForDownload(version);
       } catch (error) {
         // Log the failure but always fall back to legacy AdoptOpenJDK for resilience
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        if (errorMessage.includes('No matching version found')) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        if (error instanceof Error && error.name === 'VersionNotFoundError') {
           core.notice(
             'The JVM you are looking for could not be found in the Temurin repository, this likely indicates ' +
               'that you are using an out of date version of Java, consider updating and moving to using the Temurin distribution type in setup-java.'

--- a/src/distributions/adopt/installer.ts
+++ b/src/distributions/adopt/installer.ts
@@ -36,12 +36,18 @@ export class AdoptDistribution extends JavaBase {
   ) {
     super(`Adopt-${jvmImpl}`, installerOptions);
 
-    if (temurinDistribution != null && jvmImpl != AdoptImplementation.Hotspot) {
+    if (
+      temurinDistribution !== null &&
+      jvmImpl !== AdoptImplementation.Hotspot
+    ) {
       throw new Error('Only Hotspot JVM is supported by Temurin.');
     }
 
     // Only use the temurin repo for Hotspot JVMs
-    if (temurinDistribution == null && jvmImpl == AdoptImplementation.Hotspot) {
+    if (
+      temurinDistribution === null &&
+      jvmImpl === AdoptImplementation.Hotspot
+    ) {
       this.temurinDistribution = new TemurinDistribution(
         installerOptions,
         TemurinImplementation.Hotspot
@@ -52,30 +58,34 @@ export class AdoptDistribution extends JavaBase {
   protected async findPackageForDownload(
     version: string
   ): Promise<JavaDownloadRelease> {
-    if (this.jvmImpl == AdoptImplementation.Hotspot) {
+    if (this.jvmImpl === AdoptImplementation.Hotspot) {
       core.notice(
         "AdoptOpenJDK has moved to Eclipse Temurin https://github.com/actions/setup-java#supported-distributions please consider changing to the 'temurin' distribution type in your setup-java configuration."
       );
     }
 
     if (
-      this.jvmImpl == AdoptImplementation.Hotspot &&
-      this.temurinDistribution != null
+      this.jvmImpl === AdoptImplementation.Hotspot &&
+      this.temurinDistribution !== null
     ) {
       try {
-        const result = await this.temurinDistribution.findPackageForDownload(
-          version
-        );
-
-        if (result != undefined) {
-          return result;
-        }
+        return await this.temurinDistribution.findPackageForDownload(version);
       } catch (error) {
-        if (error.message.includes('Could not find satisfied version')) {
+        // Only fall back to legacy AdoptOpenJDK for version-not-found errors
+        if (
+          error instanceof Error &&
+          error.message.includes('No matching version found')
+        ) {
           core.notice(
             'The JVM you are looking for could not be found in the Temurin repository, this likely indicates ' +
               'that you are using an out of date version of Java, consider updating and moving to using the Temurin distribution type in setup-java.'
           );
+        } else {
+          // Rethrow unexpected errors to avoid masking real issues
+          core.debug(
+            `Unexpected error from Temurin lookup: ${error instanceof Error ? error.message : String(error)}`
+          );
+          throw error;
         }
       }
     }

--- a/src/distributions/adopt/installer.ts
+++ b/src/distributions/adopt/installer.ts
@@ -71,21 +71,18 @@ export class AdoptDistribution extends JavaBase {
       try {
         return await this.temurinDistribution.findPackageForDownload(version);
       } catch (error) {
-        // Only fall back to legacy AdoptOpenJDK for version-not-found errors
-        if (
-          error instanceof Error &&
-          error.message.includes('No matching version found')
-        ) {
+        // Log the failure but always fall back to legacy AdoptOpenJDK for resilience
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        if (errorMessage.includes('No matching version found')) {
           core.notice(
             'The JVM you are looking for could not be found in the Temurin repository, this likely indicates ' +
               'that you are using an out of date version of Java, consider updating and moving to using the Temurin distribution type in setup-java.'
           );
         } else {
-          // Rethrow unexpected errors to avoid masking real issues
+          // Log other errors for debugging but gracefully fall back
           core.debug(
-            `Unexpected error from Temurin lookup: ${error instanceof Error ? error.message : String(error)}`
+            `Temurin lookup failed: ${errorMessage}. Falling back to AdoptOpenJDK API.`
           );
-          throw error;
         }
       }
     }

--- a/src/distributions/base-installer.ts
+++ b/src/distributions/base-installer.ts
@@ -292,7 +292,9 @@ export abstract class JavaBase {
       }
     }
 
-    return new Error(parts.join('\n'));
+    const error = new Error(parts.join('\n'));
+    error.name = 'VersionNotFoundError';
+    return error;
   }
 
   protected setJavaDefault(version: string, toolPath: string) {

--- a/src/distributions/temurin/installer.ts
+++ b/src/distributions/temurin/installer.ts
@@ -34,7 +34,7 @@ export class TemurinDistribution extends JavaBase {
     super(`Temurin-${jvmImpl}`, installerOptions);
   }
 
-  protected async findPackageForDownload(
+  public async findPackageForDownload(
     version: string
   ): Promise<JavaDownloadRelease> {
     const availableVersionsRaw = await this.getAvailableVersions();

--- a/src/distributions/temurin/installer.ts
+++ b/src/distributions/temurin/installer.ts
@@ -34,6 +34,9 @@ export class TemurinDistribution extends JavaBase {
     super(`Temurin-${jvmImpl}`, installerOptions);
   }
 
+  /**
+   * @internal For cross-distribution reuse only. Not intended as a public API.
+   */
   public async findPackageForDownload(
     version: string
   ): Promise<JavaDownloadRelease> {


### PR DESCRIPTION
We are looking to move people off of the old deprecated Adoptopenjdk API to the Temurin API for Hotspot builds.

For the vast majority of binaries, the Temurin API will contain the one you want, the outlier cases are:
- User is using an older (<16) non-lts release
- User is requesting a very specific version from before Temurin

In both cases it means that they are using very old builds.

In order to move to the new API, this PR is proposing that requests to AdoptDistribution, are requested against TemurinDistribution first, if they cannot be satisfied by Temurin, then continue the existing unchanged AdoptOpenJDK logic. For the VAST majority of requests, they will be satisfied by Temurin, for the few remaining outliers described above, they will make a second request to the old AdoptOpenJDK API.

I am submitting this as a draft to ask if this approach is acceptable in principle.