### PR TITLE
add support for microsoft openjdk 21.0.0

### DIFF
--- a/__tests__/data/microsoft.json
+++ b/__tests__/data/microsoft.json
@@ -1,5 +1,42 @@
 [
     {
+      "version": "21.0.0",
+      "stable": true,
+      "release_url": "https://aka.ms/download-jdk",
+      "files": [
+        {
+          "filename": "microsoft-jdk-21.0.0-macos-x64.tar.gz",
+          "arch": "x64",
+          "platform": "darwin",
+          "download_url": "https://aka.ms/download-jdk/microsoft-jdk-21.0.0-macos-x64.tar.gz"
+        },
+        {
+          "filename": "microsoft-jdk-21.0.0-linux-x64.tar.gz",
+          "arch": "x64",
+          "platform": "linux",
+          "download_url": "https://aka.ms/download-jdk/microsoft-jdk-21.0.0-linux-x64.tar.gz"
+        },
+        {
+          "filename": "microsoft-jdk-21.0.0-windows-x64.zip",
+          "arch": "x64",
+          "platform": "win32",
+          "download_url": "https://aka.ms/download-jdk/microsoft-jdk-21.0.0-windows-x64.zip"
+        },
+        {
+          "filename": "microsoft-jdk-21.0.0-macos-aarch64.tar.gz",
+          "arch": "aarch64",
+          "platform": "darwin",
+          "download_url": "https://aka.ms/download-jdk/microsoft-jdk-21.0.0-macos-aarch64.tar.gz"
+        },
+        {
+          "filename": "microsoft-jdk-21.0.0-linux-aarch64.tar.gz",
+          "arch": "aarch64",
+          "platform": "linux",
+          "download_url": "https://aka.ms/download-jdk/microsoft-jdk-21.0.0-linux-aarch64.tar.gz"
+        }
+      ]
+    },
+    {
         "version": "17.0.7",
         "stable": true,
         "release_url": "https://aka.ms/download-jdk",

--- a/__tests__/distributors/microsoft-installer.test.ts
+++ b/__tests__/distributors/microsoft-installer.test.ts
@@ -30,6 +30,11 @@ describe('findPackageForDownload', () => {
 
   it.each([
     [
+      '21.x',
+      '21.0.0',
+      'https://aka.ms/download-jdk/microsoft-jdk-21.0.0-{{OS_TYPE}}-x64.{{ARCHIVE_TYPE}}'
+    ],
+    [
       '17.0.1',
       '17.0.1+12.1',
       'https://aka.ms/download-jdk/microsoft-jdk-17.0.1.12.1-{{OS_TYPE}}-x64.{{ARCHIVE_TYPE}}'

--- a/src/distributions/microsoft/microsoft-openjdk-versions.json
+++ b/src/distributions/microsoft/microsoft-openjdk-versions.json
@@ -1,477 +1,514 @@
 [
-    {
-        "version": "17.0.7",
-        "stable": true,
-        "release_url": "https://aka.ms/download-jdk",
-        "files": [
-          {
-            "filename": "microsoft-jdk-17.0.7-macos-x64.tar.gz",
-            "arch": "x64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-macos-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.7-linux-x64.tar.gz",
-            "arch": "x64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-linux-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.7-windows-x64.zip",
-            "arch": "x64",
-            "platform": "win32",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-windows-x64.zip"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.7-macos-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-macos-aarch64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.7-linux-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-linux-aarch64.tar.gz"
-          }
-        ]
-    }, 
-    {
-        "version": "17.0.6",
-        "stable": true,
-        "release_url": "https://aka.ms/download-jdk",
-        "files": [
-          {
-            "filename": "microsoft-jdk-17.0.6-macos-x64.tar.gz",
-            "arch": "x64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.6-macos-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.6-linux-x64.tar.gz",
-            "arch": "x64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.6-linux-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.6-windows-x64.zip",
-            "arch": "x64",
-            "platform": "win32",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.6-windows-x64.zip"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.6-macos-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.6-macos-aarch64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.6-linux-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.6-linux-aarch64.tar.gz"
-          }
-        ]
-    },
-    {
-        "version": "17.0.5",
-        "stable": true,
-        "release_url": "https://aka.ms/download-jdk",
-        "files": [
-          {
-            "filename": "microsoft-jdk-17.0.5-macos-x64.tar.gz",
-            "arch": "x64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.5-macos-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.5-linux-x64.tar.gz",
-            "arch": "x64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.5-linux-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.5-windows-x64.zip",
-            "arch": "x64",
-            "platform": "win32",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.5-windows-x64.zip"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.5-macos-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.5-macos-aarch64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.5-linux-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.5-linux-aarch64.tar.gz"
-          }
-        ]
-    },
-    {
-        "version": "17.0.4",
-        "stable": true,
-        "release_url": "https://aka.ms/download-jdk",
-        "files": [
-          {
-            "filename": "microsoft-jdk-17.0.4-macos-x64.tar.gz",
-            "arch": "x64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.4-macos-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.4-linux-x64.tar.gz",
-            "arch": "x64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.4-linux-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.4-windows-x64.zip",
-            "arch": "x64",
-            "platform": "win32",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.4-windows-x64.zip"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.4-macos-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.4-macos-aarch64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.4-linux-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.4-linux-aarch64.tar.gz"
-          }
-        ]
-    }, 
-    {
-        "version": "17.0.3",
-        "stable": true,
-        "release_url": "https://aka.ms/download-jdk",
-        "files": [
-          {
-            "filename": "microsoft-jdk-17.0.3-macos-x64.tar.gz",
-            "arch": "x64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.3-macos-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.3-linux-x64.tar.gz",
-            "arch": "x64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.3-linux-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.3-windows-x64.zip",
-            "arch": "x64",
-            "platform": "win32",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.3-windows-x64.zip"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.3-macos-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.3-macos-aarch64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.3-linux-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.3-linux-aarch64.tar.gz"
-          }
-        ]
-    }, 
-    {
-        "version": "17.0.1+12.1",
-        "stable": true,
-        "release_url": "https://aka.ms/download-jdk",
-        "files": [
-          {
-            "filename": "microsoft-jdk-17.0.1.12.1-macos-x64.tar.gz",
-            "arch": "x64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.1.12.1-macos-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.1.12.1-linux-x64.tar.gz",
-            "arch": "x64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.1.12.1-linux-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.1.12.1-windows-x64.zip",
-            "arch": "x64",
-            "platform": "win32",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.1.12.1-windows-x64.zip"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.1.12.1-macos-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.1.12.1-macos-aarch64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-17.0.1.12.1-linux-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.1.12.1-linux-aarch64.tar.gz"
-          }
-        ]
-    },
-    {
-        "version": "16.0.2+7.1",
-        "stable": true,
-        "release_url": "https://aka.ms/download-jdk",
-        "files": [
-          {
-            "filename": "microsoft-jdk-16.0.2.7.1-macos-x64.tar.gz",
-            "arch": "x64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-16.0.2.7.1-macos-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-16.0.2.7.1-linux-x64.tar.gz",
-            "arch": "x64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-16.0.2.7.1-linux-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-16.0.2.7.1-windows-x64.zip",
-            "arch": "x64",
-            "platform": "win32",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-16.0.2.7.1-windows-x64.zip"
-          },
-          {
-            "filename": "microsoft-jdk-16.0.2.7.1-macos-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-16.0.2.7.1-macos-aarch64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-16.0.2.7.1-linux-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-16.0.2.7.1-linux-aarch64.tar.gz"
-          }
-        ]
-    },
-    {
-        "version": "11.0.19",
-        "stable": true,
-        "release_url": "https://aka.ms/download-jdk",
-        "files": [
-          {
-            "filename": "microsoft-jdk-11.0.19-macos-x64.tar.gz",
-            "arch": "x64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-macos-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.19-linux-x64.tar.gz",
-            "arch": "x64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-linux-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.19-windows-x64.zip",
-            "arch": "x64",
-            "platform": "win32",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-windows-x64.zip"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.19-macos-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-macos-aarch64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.19-linux-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-linux-aarch64.tar.gz"
-          }
-        ]
-    },
-    {
-        "version": "11.0.18",
-        "stable": true,
-        "release_url": "https://aka.ms/download-jdk",
-        "files": [
-          {
-            "filename": "microsoft-jdk-11.0.18-macos-x64.tar.gz",
-            "arch": "x64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.18-macos-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.18-linux-x64.tar.gz",
-            "arch": "x64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.18-linux-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.18-windows-x64.zip",
-            "arch": "x64",
-            "platform": "win32",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.18-windows-x64.zip"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.18-macos-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.18-macos-aarch64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.18-linux-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.18-linux-aarch64.tar.gz"
-          }
-        ]
-    },
-    {
-        "version": "11.0.17",
-        "stable": true,
-        "release_url": "https://aka.ms/download-jdk",
-        "files": [
-          {
-            "filename": "microsoft-jdk-11.0.17-macos-x64.tar.gz",
-            "arch": "x64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.17-macos-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.17-linux-x64.tar.gz",
-            "arch": "x64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.17-linux-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.17-windows-x64.zip",
-            "arch": "x64",
-            "platform": "win32",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.17-windows-x64.zip"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.17-macos-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.17-macos-aarch64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.17-linux-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.17-linux-aarch64.tar.gz"
-          }
-        ]
-    },
-    {
-        "version": "11.0.16",
-        "stable": true,
-        "release_url": "https://aka.ms/download-jdk",
-        "files": [
-          {
-            "filename": "microsoft-jdk-11.0.16-macos-x64.tar.gz",
-            "arch": "x64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.16-macos-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.16-linux-x64.tar.gz",
-            "arch": "x64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.16-linux-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.16-windows-x64.zip",
-            "arch": "x64",
-            "platform": "win32",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.16-windows-x64.zip"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.16-macos-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.16-macos-aarch64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.16-linux-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.16-linux-aarch64.tar.gz"
-          }
-        ]
-    },
-    {
-        "version": "11.0.15",
-        "stable": true,
-        "release_url": "https://aka.ms/download-jdk",
-        "files": [
-          {
-            "filename": "microsoft-jdk-11.0.15-macos-x64.tar.gz",
-            "arch": "x64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.15-macos-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.15-linux-x64.tar.gz",
-            "arch": "x64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.15-linux-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.15-windows-x64.zip",
-            "arch": "x64",
-            "platform": "win32",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.15-windows-x64.zip"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.15-macos-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.15-macos-aarch64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.15-linux-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.15-linux-aarch64.tar.gz"
-          }
-        ]
-    },
-    {
-        "version": "11.0.13+8.1",
-        "stable": true,
-        "release_url": "https://aka.ms/download-jdk",
-        "files": [
-          {
-            "filename": "microsoft-jdk-11.0.13.8.1-macos-x64.tar.gz",
-            "arch": "x64",
-            "platform": "darwin",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.13.8.1-macos-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.13.8.1-linux-x64.tar.gz",
-            "arch": "x64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.13.8.1-linux-x64.tar.gz"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.13.8.1-windows-x64.zip",
-            "arch": "x64",
-            "platform": "win32",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.13.8.1-windows-x64.zip"
-          },
-          {
-            "filename": "microsoft-jdk-11.0.13.8.1-linux-aarch64.tar.gz",
-            "arch": "aarch64",
-            "platform": "linux",
-            "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.13.8.1-linux-aarch64.tar.gz"
-          }
-        ]
-    }
+  {
+    "version": "21.0.0",
+    "stable": true,
+    "release_url": "https://aka.ms/download-jdk",
+    "files": [
+      {
+        "filename": "microsoft-jdk-21.0.0-macos-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-21.0.0-macos-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-21.0.0-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-21.0.0-linux-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-21.0.0-windows-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-21.0.0-windows-x64.zip"
+      },
+      {
+        "filename": "microsoft-jdk-21.0.0-macos-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-21.0.0-macos-aarch64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-21.0.0-linux-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-21.0.0-linux-aarch64.tar.gz"
+      }
+    ]
+  },
+  {
+    "version": "17.0.7",
+    "stable": true,
+    "release_url": "https://aka.ms/download-jdk",
+    "files": [
+      {
+        "filename": "microsoft-jdk-17.0.7-macos-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-macos-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.7-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-linux-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.7-windows-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-windows-x64.zip"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.7-macos-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-macos-aarch64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.7-linux-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-linux-aarch64.tar.gz"
+      }
+    ]
+  },
+  {
+    "version": "17.0.6",
+    "stable": true,
+    "release_url": "https://aka.ms/download-jdk",
+    "files": [
+      {
+        "filename": "microsoft-jdk-17.0.6-macos-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.6-macos-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.6-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.6-linux-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.6-windows-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.6-windows-x64.zip"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.6-macos-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.6-macos-aarch64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.6-linux-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.6-linux-aarch64.tar.gz"
+      }
+    ]
+  },
+  {
+    "version": "17.0.5",
+    "stable": true,
+    "release_url": "https://aka.ms/download-jdk",
+    "files": [
+      {
+        "filename": "microsoft-jdk-17.0.5-macos-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.5-macos-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.5-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.5-linux-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.5-windows-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.5-windows-x64.zip"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.5-macos-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.5-macos-aarch64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.5-linux-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.5-linux-aarch64.tar.gz"
+      }
+    ]
+  },
+  {
+    "version": "17.0.4",
+    "stable": true,
+    "release_url": "https://aka.ms/download-jdk",
+    "files": [
+      {
+        "filename": "microsoft-jdk-17.0.4-macos-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.4-macos-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.4-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.4-linux-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.4-windows-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.4-windows-x64.zip"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.4-macos-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.4-macos-aarch64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.4-linux-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.4-linux-aarch64.tar.gz"
+      }
+    ]
+  },
+  {
+    "version": "17.0.3",
+    "stable": true,
+    "release_url": "https://aka.ms/download-jdk",
+    "files": [
+      {
+        "filename": "microsoft-jdk-17.0.3-macos-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.3-macos-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.3-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.3-linux-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.3-windows-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.3-windows-x64.zip"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.3-macos-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.3-macos-aarch64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.3-linux-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.3-linux-aarch64.tar.gz"
+      }
+    ]
+  },
+  {
+    "version": "17.0.1+12.1",
+    "stable": true,
+    "release_url": "https://aka.ms/download-jdk",
+    "files": [
+      {
+        "filename": "microsoft-jdk-17.0.1.12.1-macos-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.1.12.1-macos-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.1.12.1-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.1.12.1-linux-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.1.12.1-windows-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.1.12.1-windows-x64.zip"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.1.12.1-macos-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.1.12.1-macos-aarch64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.1.12.1-linux-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.1.12.1-linux-aarch64.tar.gz"
+      }
+    ]
+  },
+  {
+    "version": "16.0.2+7.1",
+    "stable": true,
+    "release_url": "https://aka.ms/download-jdk",
+    "files": [
+      {
+        "filename": "microsoft-jdk-16.0.2.7.1-macos-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-16.0.2.7.1-macos-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-16.0.2.7.1-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-16.0.2.7.1-linux-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-16.0.2.7.1-windows-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-16.0.2.7.1-windows-x64.zip"
+      },
+      {
+        "filename": "microsoft-jdk-16.0.2.7.1-macos-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-16.0.2.7.1-macos-aarch64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-16.0.2.7.1-linux-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-16.0.2.7.1-linux-aarch64.tar.gz"
+      }
+    ]
+  },
+  {
+    "version": "11.0.19",
+    "stable": true,
+    "release_url": "https://aka.ms/download-jdk",
+    "files": [
+      {
+        "filename": "microsoft-jdk-11.0.19-macos-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-macos-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.19-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-linux-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.19-windows-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-windows-x64.zip"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.19-macos-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-macos-aarch64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.19-linux-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.19-linux-aarch64.tar.gz"
+      }
+    ]
+  },
+  {
+    "version": "11.0.18",
+    "stable": true,
+    "release_url": "https://aka.ms/download-jdk",
+    "files": [
+      {
+        "filename": "microsoft-jdk-11.0.18-macos-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.18-macos-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.18-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.18-linux-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.18-windows-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.18-windows-x64.zip"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.18-macos-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.18-macos-aarch64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.18-linux-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.18-linux-aarch64.tar.gz"
+      }
+    ]
+  },
+  {
+    "version": "11.0.17",
+    "stable": true,
+    "release_url": "https://aka.ms/download-jdk",
+    "files": [
+      {
+        "filename": "microsoft-jdk-11.0.17-macos-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.17-macos-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.17-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.17-linux-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.17-windows-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.17-windows-x64.zip"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.17-macos-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.17-macos-aarch64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.17-linux-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.17-linux-aarch64.tar.gz"
+      }
+    ]
+  },
+  {
+    "version": "11.0.16",
+    "stable": true,
+    "release_url": "https://aka.ms/download-jdk",
+    "files": [
+      {
+        "filename": "microsoft-jdk-11.0.16-macos-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.16-macos-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.16-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.16-linux-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.16-windows-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.16-windows-x64.zip"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.16-macos-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.16-macos-aarch64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.16-linux-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.16-linux-aarch64.tar.gz"
+      }
+    ]
+  },
+  {
+    "version": "11.0.15",
+    "stable": true,
+    "release_url": "https://aka.ms/download-jdk",
+    "files": [
+      {
+        "filename": "microsoft-jdk-11.0.15-macos-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.15-macos-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.15-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.15-linux-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.15-windows-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.15-windows-x64.zip"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.15-macos-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.15-macos-aarch64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.15-linux-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.15-linux-aarch64.tar.gz"
+      }
+    ]
+  },
+  {
+    "version": "11.0.13+8.1",
+    "stable": true,
+    "release_url": "https://aka.ms/download-jdk",
+    "files": [
+      {
+        "filename": "microsoft-jdk-11.0.13.8.1-macos-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.13.8.1-macos-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.13.8.1-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.13.8.1-linux-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.13.8.1-windows-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.13.8.1-windows-x64.zip"
+      },
+      {
+        "filename": "microsoft-jdk-11.0.13.8.1-linux-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-11.0.13.8.1-linux-aarch64.tar.gz"
+      }
+    ]
+  }
 ]


### PR DESCRIPTION
**Description:**
Extended the microsoft-openjdk-versions.json by version 21.0.0

**Related issue:**
https://github.com/actions/setup-java/issues/545

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.