### PR TITLE
Update action to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,6 @@ outputs:
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/setup/index.js'
   post: 'dist/cleanup/index.js'


### PR DESCRIPTION
**Description:**
Node 16 has reached end-of-life on 11 Sep 202.
This PR updates the default runtime to node20, rather then node16.

This is supported on all Actions Runners [v2.308.0](https://github.com/actions/runner/releases/tag/v2.308.0) or later.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.