### PR TITLE
HTTP errors when the token is undefined

### DIFF
--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -90213,9 +90213,11 @@ function getGitHubHttpHeaders() {
     const token = core.getInput('token');
     const auth = !token ? undefined : `token ${token}`;
     const headers = {
-        authorization: auth,
         accept: 'application/vnd.github.VERSION.raw'
     };
+    if (auth) {
+        headers.authorization = auth;
+    }
     return headers;
 }
 exports.getGitHubHttpHeaders = getGitHubHttpHeaders;

--- a/src/util.ts
+++ b/src/util.ts
@@ -166,9 +166,13 @@ export function convertVersionToSemver(version: number[] | string) {
 export function getGitHubHttpHeaders(): OutgoingHttpHeaders {
   const token = core.getInput('token');
   const auth = !token ? undefined : `token ${token}`;
+
   const headers: OutgoingHttpHeaders = {
-    authorization: auth,
     accept: 'application/vnd.github.VERSION.raw'
   };
+
+  if (auth) {
+    headers.authorization = auth;
+  }
   return headers;
 }


### PR DESCRIPTION
**Description:**
When the token is undefined (as the use of the action is not on dotcom), the http library is generating an error as the `authorization` header is set to `undefined`.

This change only populates the `authorization` header if there is a value present which makes this action work correctly for Microsoft variants of Java when not on dotcom.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.