### PR TITLE
make it clear that Java 21 is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ steps:
 - uses: actions/setup-java@v4
   with:
     distribution: 'temurin' # See 'Supported distributions' for available options
-    java-version: '17'
+    java-version: '21'
 - run: java HelloWorldApp.java
 ```
 
@@ -84,13 +84,13 @@ steps:
 - uses: actions/setup-java@v4
   with:
     distribution: 'zulu' # See 'Supported distributions' for available options
-    java-version: '17'
+    java-version: '21'
 - run: java HelloWorldApp.java
 ```
 
 #### Supported version syntax
 The `java-version` input supports an exact version or a version range using [SemVer](https://semver.org/) notation:
-- major versions: `8`, `11`, `16`, `17`
+- major versions: `8`, `11`, `16`, `17`, `21`
 - more specific versions: `17.0`, `11.0`, `11.0.4`, `8.0.232`, `8.0.282+8`
 - early access (EA) versions: `15-ea`, `15.0.0-ea`, `15.0.0-ea.2`, `15.0.0+2-ea`
 
@@ -135,7 +135,7 @@ steps:
 - uses: actions/setup-java@v4
   with:
     distribution: 'temurin'
-    java-version: '17'
+    java-version: '21'
     cache: 'gradle'
     cache-dependency-path: | # optional
       sub-project/*.gradle*
@@ -150,7 +150,7 @@ steps:
 - uses: actions/setup-java@v4
   with:
     distribution: 'temurin'
-    java-version: '17'
+    java-version: '21'
     cache: 'maven'
     cache-dependency-path: 'sub-project/pom.xml' # optional
 - name: Build with Maven
@@ -164,7 +164,7 @@ steps:
 - uses: actions/setup-java@v4
   with:
     distribution: 'temurin'
-    java-version: '17'
+    java-version: '21'
     cache: 'sbt'
     cache-dependency-path: | # optional
       sub-project/build.sbt
@@ -184,7 +184,7 @@ steps:
 - uses: actions/setup-java@v4
   with:
     distribution: 'temurin'
-    java-version: '17'
+    java-version: '21'
     cache: 'gradle'
 - run: ./gradlew build --no-daemon
 ```
@@ -204,7 +204,7 @@ steps:
 - uses: actions/setup-java@v4
   with:
     distribution: 'temurin'
-    java-version: '17'
+    java-version: '21'
     check-latest: true
 - run: java HelloWorldApp.java
 ```
@@ -216,7 +216,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        java: [ '8', '11', '17' ]
+        java: [ '8', '11', '17', '21' ]
     name: Java ${{ matrix.Java }} sample
     steps:
       - uses: actions/checkout@v4

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -25,13 +25,14 @@ See [action.yml](../action.yml) for more details on task inputs.
 Inputs `java-version` and `distribution` are mandatory and needs to be provided. See [Supported distributions](../README.md#Supported-distributions) for a list of available options.
 
 ### Eclipse Temurin
+
 ```yaml
 steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-java@v4
   with:
     distribution: 'temurin'
-    java-version: '11'
+    java-version: '21'
 - run: java -cp java HelloWorldApp
 ```
 
@@ -49,37 +50,40 @@ steps:
 ```
 
 ### Zulu
+
 ```yaml
 steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-java@v4
   with:
     distribution: 'zulu'
-    java-version: '11'
+    java-version: '21'
     java-package: jdk # optional (jdk, jre, jdk+fx or jre+fx) - defaults to jdk
 - run: java -cp java HelloWorldApp
 ```
 
 ### Liberica
+
 ```yaml
 steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-java@v4
   with:
     distribution: 'liberica'
-    java-version: '11'
+    java-version: '21'
     java-package: jdk # optional (jdk, jre, jdk+fx or jre+fx) - defaults to jdk
 - run: java -cp java HelloWorldApp
 ```
 
 ### Microsoft
+
 ```yaml
 steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-java@v4
   with:
     distribution: 'microsoft'
-    java-version: '11'
+    java-version: '21'
 - run: java -cp java HelloWorldApp
 ```
 
@@ -94,7 +98,7 @@ uses: actions/setup-java@v4
 with:
   token: ${{ secrets.GH_DOTCOM_TOKEN }}
   distribution: 'microsoft'
-  java-version: '11'
+  java-version: '21'
 ```
 
 If the runner is not able to access github.com, any Java versions requested during a workflow run must come from the runner's tool cache. See "[Setting up the tool cache on self-hosted runners without internet access](https://docs.github.com/en/enterprise-server@3.2/admin/github-actions/managing-access-to-actions-from-githubcom/setting-up-the-tool-cache-on-self-hosted-runners-without-internet-access)" for more information.
@@ -108,7 +112,7 @@ steps:
 - uses: actions/setup-java@v4
   with:
     distribution: 'corretto'
-    java-version: '11'
+    java-version: '21'
 - run: java -cp java HelloWorldApp
 ```
 
@@ -121,12 +125,13 @@ steps:
 - uses: actions/setup-java@v4
   with:
     distribution: 'oracle'
-    java-version: '17'
+    java-version: '21'
 - run: java -cp java HelloWorldApp
 ```
 
 ### Alibaba Dragonwell
 **NOTE:** Alibaba Dragonwell only provides jdk.
+
 ```yaml
 steps:
 - uses: actions/checkout@v4
@@ -188,7 +193,7 @@ If your use-case requires a custom distribution (in the example, alpine-linux is
       - name: fetch latest temurin JDK
         id: fetch_latest_jdk
         run: |
-          major_version={{ env.JAVA_VERSION }} # Example 8 or 11 or 17
+          major_version={{ env.JAVA_VERSION }} # Example 16 or 21 or 22
           cd $RUNNER_TEMP
           response=$(curl -s "https://api.github.com/repos/adoptium/temurin${major_version}-binaries/releases")
           latest_jdk_download_url=$(echo "$response" | jq -r '.[0].assets[] | select(.name | contains("jdk_x64_alpine-linux") and endswith(".tar.gz")) | .browser_download_url')
@@ -439,7 +444,7 @@ steps:
 - uses: actions/setup-java@v4
   with:
     distribution: '<distribution>'
-    java-version: 15
+    java-version: '15'
 ```
 
 The result is a Toolchain with entries for JDKs 8, 11 and 15. You can even combine this with custom JDKs of arbitrary versions:
@@ -523,7 +528,7 @@ If the `java-version-file` input is specified, the action will try to extract th
 Action is able to recognize all variants of the version description according to [jenv](https://github.com/jenv/jenv). 
 Valid entry options:
 ```
-major versions: 8, 11, 16, 17
+major versions: 8, 11, 16, 17, 21
 more specific versions: 1.8.0.2, 17.0, 11.0, 11.0.4, 8.0.232, 8.0.282+8
 early access (EA) versions: 15-ea, 15.0.0-ea, 15.0.0-ea.2, 15.0.0+2-ea
 versions with specified distribution: openjdk64-11.0.2


### PR DESCRIPTION
**Description:**
Update examples and references to Java where older Java versions are used to highlight the support of Java 21.

Specific provider examples are only updated where they support Java 21.

**Related issue:**
Fixes #557

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.