### PR TITLE
Update README.md: no `java HelloWorldApp.java`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ steps:
   with:
     distribution: 'temurin' # See 'Supported distributions' for available options
     java-version: '21'
-- run: java HelloWorldApp.java
 ```
 
 #### Azul Zulu OpenJDK
@@ -85,7 +84,6 @@ steps:
   with:
     distribution: 'zulu' # See 'Supported distributions' for available options
     java-version: '21'
-- run: java HelloWorldApp.java
 ```
 
 #### Supported version syntax
@@ -206,7 +204,6 @@ steps:
     distribution: 'temurin'
     java-version: '21'
     check-latest: true
-- run: java HelloWorldApp.java
 ```
 
 ### Testing against different Java versions
@@ -225,7 +222,6 @@ jobs:
         with:
           distribution: '<distribution>'
           java-version: ${{ matrix.java }}
-      - run: java HelloWorldApp.java
 ```
 
 ### Install multiple JDKs


### PR DESCRIPTION
A confusion introduced by running `java HelloWorldApp.java`

I believe the file is not an artifact of `setup-java`, thus user should provide it. But there is no tips in the guide that user should prepare it in advance. 

Directly copy the code snippets will introduce a straightforward error, which should not happen in a guide.




