### PR TITLE
Add Support for JetBrains Runtime

### DIFF
--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -71,11 +71,11 @@ jobs:
         with:
           java-version: ${{ matrix.version }}
           distribution: ${{ matrix.distribution }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify Java
         run: bash __tests__/verify-java.sh "${{ matrix.version }}" "${{ steps.setup-java.outputs.path }}"
         shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   setup-java-major-minor-versions:
     name: ${{ matrix.distribution }} ${{ matrix.version }} (jdk-x64) - ${{ matrix.os }}
@@ -283,7 +283,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-13, windows-latest, ubuntu-latest]
-        distribution: ['temurin', 'zulu', 'liberica', 'semeru', 'sapmachine']
+        distribution:
+          ['temurin', 'zulu', 'liberica', 'semeru', 'sapmachine', 'jetbrains']
         java-package: ['jre']
         version: ['17.0']
         include:
@@ -307,6 +308,55 @@ jobs:
             java-package: jre
             version: '8'
             os: windows-latest
+          - distribution: 'jetbrains'
+            java-package: jdk+jcef
+            version: '11'
+            os: ubuntu-latest
+          - distribution: 'jetbrains'
+            java-package: jdk+jcef
+            version: '17'
+            os: ubuntu-latest
+          - distribution: 'jetbrains'
+            java-package: jdk+jcef
+            version: '21'
+            os: ubuntu-latest
+          - distribution: 'jetbrains'
+            java-package: jre+jcef
+            version: '11'
+            os: ubuntu-latest
+          - distribution: 'jetbrains'
+            java-package: jre+jcef
+            version: '17'
+            os: ubuntu-latest
+          - distribution: 'jetbrains'
+            java-package: jre+jcef
+            version: '21'
+            os: ubuntu-latest
+          - distribution: 'jetbrains'
+            java-package: jdk+ft
+            version: '11'
+            os: ubuntu-latest
+          - distribution: 'jetbrains'
+            java-package: jdk+ft
+            version: '17'
+            os: ubuntu-latest
+          - distribution: 'jetbrains'
+            java-package: jdk+ft
+            version: '21'
+            os: ubuntu-latest
+          - distribution: 'jetbrains'
+            java-package: jre+ft
+            version: '11'
+            os: ubuntu-latest
+          - distribution: 'jetbrains'
+            java-package: jre+ft
+            version: '17'
+            os: ubuntu-latest
+          - distribution: 'jetbrains'
+            java-package: jre+ft
+            version: '21'
+            os: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -74,6 +74,8 @@ jobs:
       - name: Verify Java
         run: bash __tests__/verify-java.sh "${{ matrix.version }}" "${{ steps.setup-java.outputs.path }}"
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   setup-java-major-minor-versions:
     name: ${{ matrix.distribution }} ${{ matrix.version }} (jdk-x64) - ${{ matrix.os }}
@@ -104,6 +106,12 @@ jobs:
           - distribution: sapmachine
             os: ubuntu-latest
             version: '17.0.7'
+          - distribution: jetbrains
+            os: ubuntu-latest
+            version: '11.0.11'
+          - distribution: jetbrains
+            os: ubuntu-latest
+            version: '17.0.7'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -116,6 +124,8 @@ jobs:
       - name: Verify Java
         run: bash __tests__/verify-java.sh "${{ matrix.version }}" "${{ steps.setup-java.outputs.path }}"
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   setup-java-check-latest:
     name: ${{ matrix.distribution }} ${{ matrix.version }} - check-latest flag - ${{ matrix.os }}
@@ -126,7 +136,7 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         distribution:
-          ['temurin', 'zulu', 'liberica', 'dragonwell', 'sapmachine']
+          ['temurin', 'zulu', 'liberica', 'dragonwell', 'sapmachine', 'jetbrains']
         exclude:
           - distribution: dragonwell
             os: macos-latest
@@ -153,7 +163,7 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         distribution:
-          ['temurin', 'zulu', 'liberica', 'dragonwell', 'sapmachine']
+          ['temurin', 'zulu', 'liberica', 'dragonwell', 'sapmachine', 'jetbrains']
         exclude:
           - distribution: dragonwell
             os: macos-latest

--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -30,7 +30,8 @@ jobs:
             'microsoft',
             'semeru',
             'corretto',
-            'dragonwell'
+            'dragonwell',
+            'jetbrains'
           ] # internally 'adopt-hotspot' is the same as 'adopt'
         version: ['21', '11', '17']
         exclude:

--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -157,6 +157,8 @@ jobs:
           distribution: ${{ matrix.distribution }}
           java-version: 11
           check-latest: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify Java
         run: bash __tests__/verify-java.sh "11" "${{ steps.setup-java.outputs.path }}"
         shell: bash
@@ -192,6 +194,8 @@ jobs:
           java-version: |
             11
             17
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify Java env variables
         run: |
           $versionsArr = "11","17"
@@ -334,19 +338,11 @@ jobs:
             os: ubuntu-latest
           - distribution: 'jetbrains'
             java-package: jdk+ft
-            version: '11'
-            os: ubuntu-latest
-          - distribution: 'jetbrains'
-            java-package: jdk+ft
             version: '17'
             os: ubuntu-latest
           - distribution: 'jetbrains'
             java-package: jdk+ft
             version: '21'
-            os: ubuntu-latest
-          - distribution: 'jetbrains'
-            java-package: jre+ft
-            version: '11'
             os: ubuntu-latest
           - distribution: 'jetbrains'
             java-package: jre+ft
@@ -367,6 +363,8 @@ jobs:
           java-version: ${{ matrix.version }}
           java-package: ${{ matrix.java-package }}
           distribution: ${{ matrix.distribution }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify Java
         run: bash __tests__/verify-java.sh "${{ matrix.version }}" "${{ steps.setup-java.outputs.path }}"
         shell: bash

--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -136,7 +136,14 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         distribution:
-          ['temurin', 'zulu', 'liberica', 'dragonwell', 'sapmachine', 'jetbrains']
+          [
+            'temurin',
+            'zulu',
+            'liberica',
+            'dragonwell',
+            'sapmachine',
+            'jetbrains'
+          ]
         exclude:
           - distribution: dragonwell
             os: macos-latest
@@ -163,7 +170,14 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         distribution:
-          ['temurin', 'zulu', 'liberica', 'dragonwell', 'sapmachine', 'jetbrains']
+          [
+            'temurin',
+            'zulu',
+            'liberica',
+            'dragonwell',
+            'sapmachine',
+            'jetbrains'
+          ]
         exclude:
           - distribution: dragonwell
             os: macos-latest

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Currently, the following distributions are supported:
 | `semeru` | IBM Semeru Runtime Open Edition | [Link](https://developer.ibm.com/languages/java/semeru-runtimes/downloads/) | [Link](https://openjdk.java.net/legal/gplv2+ce.html) |
 | `oracle` | Oracle JDK | [Link](https://www.oracle.com/java/technologies/downloads/) | [Link](https://java.com/freeuselicense)
 | `dragonwell` | Alibaba Dragonwell JDK | [Link](https://dragonwell-jdk.io/) | [Link](https://www.aliyun.com/product/dragonwell/)
+| `jetbrains` | JetBrains Runtime | [Link](https://github.com/JetBrains/JetBrainsRuntime/) | [Link](https://github.com/JetBrains/JetBrainsRuntime/blob/main/LICENSE)
 
 **NOTE:** The different distributors can provide discrepant list of available versions / supported configurations. Please refer to the official documentation to see the list of supported versions.
 

--- a/__tests__/data/jetbrains.json
+++ b/__tests__/data/jetbrains.json
@@ -1,0 +1,794 @@
+[
+    {
+      "tag_name": "jbr-release-21.0.3b465.3",
+      "semver": "21.0.3",
+      "build": 465.3,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-21.0.3-windows-x64-b465.3.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-21.0.3b458.1",
+      "semver": "21.0.3",
+      "build": 458.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-21.0.3-windows-x64-b458.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-21.0.3b453.2",
+      "semver": "21.0.3",
+      "build": 453.2,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-21.0.3-windows-x64-b453.2.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.11b1207.24",
+      "semver": "17.0.11",
+      "build": 1207.24,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.11-windows-x64-b1207.24.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.11b1207.23",
+      "semver": "17.0.11",
+      "build": 1207.23,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.11-windows-x64-b1207.23.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-21.0.3b446.1",
+      "semver": "21.0.3",
+      "build": 446.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-21.0.3-windows-x64-b446.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.11b1207.20",
+      "semver": "17.0.11",
+      "build": 1207.2,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.11-windows-x64-b1207.2.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b1207.14",
+      "semver": "17.0.10",
+      "build": 1207.14,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b1207.14.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b829.27",
+      "semver": "17.0.10",
+      "build": 829.27,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b829.27.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b1087.23",
+      "semver": "17.0.10",
+      "build": 1087.23,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b1087.23.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b1000.50",
+      "semver": "17.0.10",
+      "build": 1000.5,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b1000.5.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b1207.12",
+      "semver": "17.0.10",
+      "build": 1207.12,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b1207.12.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b1087.21",
+      "semver": "17.0.10",
+      "build": 1087.21,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b1087.21.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b1207.6",
+      "semver": "17.0.10",
+      "build": 1207.6,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b1207.6.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-21.0.2b375.1",
+      "semver": "21.0.2",
+      "build": 375.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-21.0.2-windows-x64-b375.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b1207.1",
+      "semver": "17.0.10",
+      "build": 1207.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b1207.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b1186.1",
+      "semver": "17.0.10",
+      "build": 1186.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b1186.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b1171.14",
+      "semver": "17.0.10",
+      "build": 1171.14,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b1171.14.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b829.26",
+      "semver": "17.0.10",
+      "build": 829.26,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b829.26.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-21.0.2b346.3",
+      "semver": "21.0.2",
+      "build": 346.3,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-21.0.2-windows-x64-b346.3.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b1000.48",
+      "semver": "17.0.10",
+      "build": 1000.48,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b1000.48.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-21.0.2b341.4",
+      "semver": "21.0.2",
+      "build": 341.4,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-21.0.2-windows-x64-b341.4.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b1087.17",
+      "semver": "17.0.10",
+      "build": 1087.17,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b1087.17.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.9b1166.2",
+      "semver": "17.0.9",
+      "build": 1166.2,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.9-windows-x64-b1166.2.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.9b1162.7",
+      "semver": "17.0.9",
+      "build": 1162.7,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.9-windows-x64-b1162.7.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.9b1087.11",
+      "semver": "17.0.9",
+      "build": 1087.11,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.9-windows-x64-b1087.11.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.9b1087.9",
+      "semver": "17.0.9",
+      "build": 1087.9,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.9-windows-x64-b1087.9.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.9b1087.7",
+      "semver": "17.0.9",
+      "build": 1087.7,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.9-windows-x64-b1087.7.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.9b1000.47",
+      "semver": "17.0.9",
+      "build": 1000.47,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.9-windows-x64-b1000.47.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.9b1000.46",
+      "semver": "17.0.9",
+      "build": 1000.46,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.9-windows-x64-b1000.46.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.9b1087.3",
+      "semver": "17.0.9",
+      "build": 1087.3,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.9-windows-x64-b1087.3.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.8.1b1080.1",
+      "semver": "17.0.8.1",
+      "build": 1080.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.8.1-windows-x64-b1080.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.8.1b1072.1",
+      "semver": "17.0.8.1",
+      "build": 1072.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.8.1-windows-x64-b1072.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.8.1b1070.2",
+      "semver": "17.0.8.1",
+      "build": 1070.2,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.8.1-windows-x64-b1070.2.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.8.1b1063.1",
+      "semver": "17.0.8.1",
+      "build": 1063.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.8.1-windows-x64-b1063.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.8.1b1000.32",
+      "semver": "17.0.8.1",
+      "build": 1000.32,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.8.1-windows-x64-b1000.32.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.8.1b1059.3",
+      "semver": "17.0.8.1",
+      "build": 1059.3,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.8.1-windows-x64-b1059.3.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.8b1000.22",
+      "semver": "17.0.8",
+      "build": 1000.22,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.8-windows-x64-b1000.22.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-21b212.1",
+      "semver": "21",
+      "build": 212.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-21-windows-x64-b212.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.8b1000.8",
+      "semver": "17.0.8",
+      "build": 1000.8,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.8-windows-x64-b1000.8.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.7b1000.6",
+      "semver": "17.0.7",
+      "build": 1000.6,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.7-windows-x64-b1000.6.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.7b1000.5",
+      "semver": "17.0.7",
+      "build": 1000.5,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.7-windows-x64-b1000.5.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.7b1000.2",
+      "semver": "17.0.7",
+      "build": 1000.2,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.7-windows-x64-b1000.2.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.7b985.2",
+      "semver": "17.0.7",
+      "build": 985.2,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.7-windows-x64-b985.2.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.7b979.4",
+      "semver": "17.0.7",
+      "build": 979.4,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.7-windows-x64-b979.4.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.7b829.16",
+      "semver": "17.0.7",
+      "build": 829.16,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.7-windows-x64-b829.16.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.7b966.2",
+      "semver": "17.0.7",
+      "build": 966.2,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.7-windows-x64-b966.2.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.7b964.1",
+      "semver": "17.0.7",
+      "build": 964.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.7-windows-x64-b964.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-21b126.4",
+      "semver": "21",
+      "build": 126.4,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-21-windows-x64-b126.4.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.7b829.14",
+      "semver": "17.0.7",
+      "build": 829.14,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.7-windows-x64-b829.14.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.7b953.1",
+      "semver": "17.0.7",
+      "build": 953.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.7-windows-x64-b953.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-21b75.2",
+      "semver": "21",
+      "build": 75.2,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-21-windows-x64-b75.2.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.6b829.9",
+      "semver": "17.0.6",
+      "build": 829.9,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.6-windows-x64-b829.9.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.6b469.82",
+      "semver": "17.0.6",
+      "build": 469.82,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.6-windows-x64-b469.82.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.6b829.5",
+      "semver": "17.0.6",
+      "build": 829.5,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.6-windows-x64-b829.5.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.6b653.34",
+      "semver": "17.0.6",
+      "build": 653.34,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.6-windows-x64-b653.34.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.6b829.4",
+      "semver": "17.0.6",
+      "build": 829.4,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.6-windows-x64-b829.4.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.6b829.1",
+      "semver": "17.0.6",
+      "build": 829.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.6-windows-x64-b829.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.6b653.32",
+      "semver": "17.0.6",
+      "build": 653.32,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.6-windows-x64-b653.32.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.6b802.4",
+      "semver": "17.0.6",
+      "build": 802.4,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.6-windows-x64-b802.4.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.6b802.1",
+      "semver": "17.0.6",
+      "build": 802.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.6-windows-x64-b802.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.6b785.1",
+      "semver": "17.0.6",
+      "build": 785.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.6-windows-x64-b785.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.6b779.1",
+      "semver": "17.0.6",
+      "build": 779.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.6-windows-x64-b779.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.5b762.1",
+      "semver": "17.0.5",
+      "build": 762.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.5-windows-x64-b762.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.5b653.25",
+      "semver": "17.0.5",
+      "build": 653.25,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.5-windows-x64-b653.25.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.5b759.1",
+      "semver": "17.0.5",
+      "build": 759.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.5-windows-x64-b759.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.5b653.23",
+      "semver": "17.0.5",
+      "build": 653.23,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.5-windows-x64-b653.23.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.5b653.14",
+      "semver": "17.0.5",
+      "build": 653.14,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.5-windows-x64-b653.14.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.5b469.71",
+      "semver": "17.0.5",
+      "build": 469.71,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.5-windows-x64-b469.71.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_16b2043.64",
+      "semver": "11.0.16",
+      "build": 2043.64,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.16-windows-x64-b2043.64.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.5b653.6",
+      "semver": "17.0.5",
+      "build": 653.6,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.5-windows-x64-b653.6.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.5b469.67",
+      "semver": "17.0.5",
+      "build": 469.67,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.5-windows-x64-b469.67.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.4.1b653.1",
+      "semver": "17.0.4.1",
+      "build": 653.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.4.1-windows-x64-b653.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.4.1b646.8",
+      "semver": "17.0.4.1",
+      "build": 646.8,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.4.1-windows-x64-b646.8.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.4.1b629.2",
+      "semver": "17.0.4.1",
+      "build": 629.2,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.4.1-windows-x64-b629.2.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.4.1b617.2",
+      "semver": "17.0.4.1",
+      "build": 617.2,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.4.1-windows-x64-b617.2.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.4.1b469.62",
+      "semver": "17.0.4.1",
+      "build": 469.62,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.4.1-windows-x64-b469.62.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.4.1b597.1",
+      "semver": "17.0.4.1",
+      "build": 597.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.4.1-windows-x64-b597.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.4b469.53",
+      "semver": "17.0.4",
+      "build": 469.53,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.4-windows-x64-b469.53.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.4b469.44",
+      "semver": "17.0.4",
+      "build": 469.44,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.4-windows-x64-b469.44.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.3b469.37",
+      "semver": "17.0.3",
+      "build": 469.37,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.3-windows-x64-b469.37.tar.gz"
+    },
+    {
+      "tag_name": "jbr17.0.3b469.32",
+      "semver": "17.0.3",
+      "build": 469.32,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.3-windows-x64-b469.32.tar.gz"
+    },
+    {
+      "tag_name": "jbr17.0.3b469.30",
+      "semver": "17.0.3",
+      "build": 469.3,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.3-windows-x64-b469.3.tar.gz"
+    },
+    {
+      "tag_name": "jbr17.0.3b469.19",
+      "semver": "17.0.3",
+      "build": 469.19,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.3-windows-x64-b469.19.tar.gz"
+    },
+    {
+      "tag_name": "jbr17.0.3b498.3",
+      "semver": "17.0.3",
+      "build": 498.3,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.3-windows-x64-b498.3.tar.gz"
+    },
+    {
+      "tag_name": "jbr17.0.3b469.16",
+      "semver": "17.0.3",
+      "build": 469.16,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.3-windows-x64-b469.16.tar.gz"
+    },
+    {
+      "tag_name": "jbr17.0.3b469.12",
+      "semver": "17.0.3",
+      "build": 469.12,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.3-windows-x64-b469.12.tar.gz"
+    },
+    {
+      "tag_name": "jbr17.0.3b469.3",
+      "semver": "17.0.3",
+      "build": 469.3,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.3-windows-x64-b469.3.tar.gz"
+    },
+    {
+      "tag_name": "jbr17.0.3b463.3",
+      "semver": "17.0.3",
+      "build": 463.3,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.3-windows-x64-b463.3.tar.gz"
+    },
+    {
+      "tag_name": "jbr17.0.3b423.10",
+      "semver": "17.0.3",
+      "build": 423.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.3-windows-x64-b423.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_15b2043.56",
+      "semver": "11.0.15",
+      "build": 2043.56,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.15-windows-x64-b2043.56.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_14_1b2043.45",
+      "semver": "11.0.14.1",
+      "build": 2043.45,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.14.1-windows-x64-b2043.45.tar.gz"
+    },
+    {
+      "tag_name": "jbr17.0.2b396.4",
+      "semver": "17.0.2",
+      "build": 396.4,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.2-windows-x64-b396.4.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_14_1b2043.25",
+      "semver": "11.0.14.1",
+      "build": 2043.25,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.14.1-windows-x64-b2043.25.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_14_1b2043.22",
+      "semver": "11.0.14.1",
+      "build": 2043.22,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.14.1-windows-x64-b2043.22.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_14_1b2043.17",
+      "semver": "11.0.14.1",
+      "build": 2043.17,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.14.1-windows-x64-b2043.17.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_14_1b2043.14",
+      "semver": "11.0.14.1",
+      "build": 2043.14,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.14.1-windows-x64-b2043.14.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_14_1b2043.11",
+      "semver": "11.0.14.1",
+      "build": 2043.11,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.14.1-windows-x64-b2043.11.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_14b2043.2",
+      "semver": "11.0.14",
+      "build": 2043.2,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.14-windows-x64-b2043.2.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_14_1b1751.46",
+      "semver": "11.0.14.1",
+      "build": 1751.46,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.14.1-windows-x64-b1751.46.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_14b1993.2",
+      "semver": "11.0.14",
+      "build": 1993.2,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.14-windows-x64-b1993.2.tar.gz"
+    },
+    {
+      "tag_name": "jbr17_0_2b315.1",
+      "semver": "17.0.2",
+      "build": 315.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.2-windows-x64-b315.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_14b1982.1",
+      "semver": "11.0.14",
+      "build": 1982.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.14-windows-x64-b1982.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_13b1890.3",
+      "semver": "11.0.13",
+      "build": 1890.3,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.13-windows-x64-b1890.3.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_13b1751.25",
+      "semver": "11.0.13",
+      "build": 1751.25,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.13-windows-x64-b1751.25.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_13b1751.24",
+      "semver": "11.0.13",
+      "build": 1751.24,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.13-windows-x64-b1751.24.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_13b1751.21",
+      "semver": "11.0.13",
+      "build": 1751.21,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.13-windows-x64-b1751.21.tar.gz"
+    },
+    {
+      "tag_name": "jbr17_0_1b164.8",
+      "semver": "17.0.1",
+      "build": 164.8,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.1-windows-x64-b164.8.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_13b1751.19",
+      "semver": "11.0.13",
+      "build": 1751.19,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.13-windows-x64-b1751.19.tar.gz"
+    },
+    {
+      "tag_name": "jb11_0_13-b1504.49",
+      "semver": "11.0.13",
+      "build": 1504.49,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.13-windows-x64-b1504.49.tar.gz"
+    },
+    {
+      "tag_name": "jbr17_0_1b164.4",
+      "semver": "17.0.1",
+      "build": 164.4,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.1-windows-x64-b164.4.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_13b1751.16",
+      "semver": "11.0.13",
+      "build": 1751.16,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.13-windows-x64-b1751.16.tar.gz"
+    },
+    {
+      "tag_name": "jbr17b135.1",
+      "semver": "17",
+      "build": 135.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17-windows-x64-b135.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_12b1751.11",
+      "semver": "11.0.12",
+      "build": 1751.11,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.12-windows-x64-b1751.11.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_12b1729.1",
+      "semver": "11.0.12",
+      "build": 1729.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.12-windows-x64-b1729.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_12b1715.4",
+      "semver": "11.0.12",
+      "build": 1715.4,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.12-windows-x64-b1715.4.tar.gz"
+    },
+    {
+      "tag_name": "jbr17b106.1",
+      "semver": "17",
+      "build": 106.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17-windows-x64-b106.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_12b1692.9",
+      "semver": "11.0.12",
+      "build": 1692.9,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.12-windows-x64-b1692.9.tar.gz"
+    },
+    {
+      "tag_name": "jbr17-b87.7",
+      "semver": "r17",
+      "build": 87.7,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-r17-windows-x64-b87.7.tar.gz"
+    },
+    {
+      "tag_name": "jb11_0_12-b1504.40",
+      "semver": "11.0.12",
+      "build": 1504.4,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.12-windows-x64-b1504.4.tar.gz"
+    },
+    {
+      "tag_name": "jb11_0_12-b1504.37",
+      "semver": "11.0.12",
+      "build": 1504.37,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.12-windows-x64-b1504.37.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_12b1665.1",
+      "semver": "11.0.12",
+      "build": 1665.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.12-windows-x64-b1665.1.tar.gz"
+    },
+    {
+      "tag_name": "jb11_0_12-b11_0_12b1649.1",
+      "semver": "11.0.12",
+      "build": null,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.12-windows-x64-bNaN.tar.gz"
+    },
+    {
+      "tag_name": "jb11_0_12-b1504.28",
+      "semver": "11.0.12",
+      "build": 1504.28,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.12-windows-x64-b1504.28.tar.gz"
+    },
+    {
+      "tag_name": "jb11_0_12-b1504.27",
+      "semver": "11.0.12",
+      "build": 1504.27,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.12-windows-x64-b1504.27.tar.gz"
+    },
+    {
+      "tag_name": "jb11_0_11-b1504.16",
+      "semver": "11.0.11",
+      "build": 1504.16,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.11-windows-x64-b1504.16.tar.gz"
+    },
+    {
+      "tag_name": "jb11_0_11-b1504.13",
+      "semver": "11.0.11",
+      "build": 1504.13,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.11-windows-x64-b1504.13.tar.gz"
+    },
+    {
+      "tag_name": "jb11_0_11-b1504.12",
+      "semver": "11.0.11",
+      "build": 1504.12,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.11-windows-x64-b1504.12.tar.gz"
+    },
+    {
+      "tag_name": "jb11_0_11-b1542.1",
+      "semver": "11.0.11",
+      "build": 1542.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.11-windows-x64-b1542.1.tar.gz"
+    },
+    {
+      "tag_name": "jb11_0_11-b1504.8",
+      "semver": "11.0.11",
+      "build": 1504.8,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.11-windows-x64-b1504.8.tar.gz"
+    },
+    {
+      "tag_name": "11_0_11b1536.2",
+      "semver": "0.11",
+      "build": 1536.2,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-0.11-windows-x64-b1536.2.tar.gz"
+    },
+    {
+      "tag_name": "11_0_11-b1522",
+      "semver": ".0.11",
+      "build": 1522,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-.0.11-windows-x64-b1522.tar.gz"
+    }
+  ]

--- a/__tests__/data/jetbrains.json
+++ b/__tests__/data/jetbrains.json
@@ -3,792 +3,1452 @@
       "tag_name": "jbr-release-21.0.3b465.3",
       "semver": "21.0.3",
       "build": 465.3,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-21.0.3-windows-x64-b465.3.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-21.0.3-linux-x64-b465.3.tar.gz"
     },
     {
       "tag_name": "jbr-release-21.0.3b458.1",
       "semver": "21.0.3",
       "build": 458.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-21.0.3-windows-x64-b458.1.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-21.0.3-linux-x64-b458.1.tar.gz"
     },
     {
       "tag_name": "jbr-release-21.0.3b453.2",
       "semver": "21.0.3",
       "build": 453.2,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-21.0.3-windows-x64-b453.2.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-21.0.3-linux-x64-b453.2.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.11b1207.24",
       "semver": "17.0.11",
       "build": 1207.24,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.11-windows-x64-b1207.24.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.11-linux-x64-b1207.24.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.11b1207.23",
       "semver": "17.0.11",
       "build": 1207.23,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.11-windows-x64-b1207.23.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.11-linux-x64-b1207.23.tar.gz"
     },
     {
       "tag_name": "jbr-release-21.0.3b446.1",
       "semver": "21.0.3",
       "build": 446.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-21.0.3-windows-x64-b446.1.tar.gz"
-    },
-    {
-      "tag_name": "jbr-release-17.0.11b1207.20",
-      "semver": "17.0.11",
-      "build": 1207.2,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.11-windows-x64-b1207.2.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-21.0.3-linux-x64-b446.1.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.10b1207.14",
       "semver": "17.0.10",
       "build": 1207.14,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b1207.14.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.10-linux-x64-b1207.14.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.10b829.27",
       "semver": "17.0.10",
       "build": 829.27,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b829.27.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.10-linux-x64-b829.27.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.10b1087.23",
       "semver": "17.0.10",
       "build": 1087.23,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b1087.23.tar.gz"
-    },
-    {
-      "tag_name": "jbr-release-17.0.10b1000.50",
-      "semver": "17.0.10",
-      "build": 1000.5,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b1000.5.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.10-linux-x64-b1087.23.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.10b1207.12",
       "semver": "17.0.10",
       "build": 1207.12,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b1207.12.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.10-linux-x64-b1207.12.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.10b1087.21",
       "semver": "17.0.10",
       "build": 1087.21,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b1087.21.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.10-linux-x64-b1087.21.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.10b1207.6",
       "semver": "17.0.10",
       "build": 1207.6,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b1207.6.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.10-linux-x64-b1207.6.tar.gz"
     },
     {
       "tag_name": "jbr-release-21.0.2b375.1",
       "semver": "21.0.2",
       "build": 375.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-21.0.2-windows-x64-b375.1.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-21.0.2-linux-x64-b375.1.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.10b1207.1",
       "semver": "17.0.10",
       "build": 1207.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b1207.1.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.10-linux-x64-b1207.1.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.10b1186.1",
       "semver": "17.0.10",
       "build": 1186.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b1186.1.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.10-linux-x64-b1186.1.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.10b1171.14",
       "semver": "17.0.10",
       "build": 1171.14,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b1171.14.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.10-linux-x64-b1171.14.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.10b829.26",
       "semver": "17.0.10",
       "build": 829.26,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b829.26.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.10-linux-x64-b829.26.tar.gz"
     },
     {
       "tag_name": "jbr-release-21.0.2b346.3",
       "semver": "21.0.2",
       "build": 346.3,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-21.0.2-windows-x64-b346.3.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-21.0.2-linux-x64-b346.3.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.10b1000.48",
       "semver": "17.0.10",
       "build": 1000.48,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b1000.48.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.10-linux-x64-b1000.48.tar.gz"
     },
     {
       "tag_name": "jbr-release-21.0.2b341.4",
       "semver": "21.0.2",
       "build": 341.4,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-21.0.2-windows-x64-b341.4.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-21.0.2-linux-x64-b341.4.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.10b1087.17",
       "semver": "17.0.10",
       "build": 1087.17,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.10-windows-x64-b1087.17.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.10-linux-x64-b1087.17.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.9b1166.2",
       "semver": "17.0.9",
       "build": 1166.2,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.9-windows-x64-b1166.2.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.9-linux-x64-b1166.2.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.9b1162.7",
       "semver": "17.0.9",
       "build": 1162.7,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.9-windows-x64-b1162.7.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.9-linux-x64-b1162.7.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.9b1087.11",
       "semver": "17.0.9",
       "build": 1087.11,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.9-windows-x64-b1087.11.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.9-linux-x64-b1087.11.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.9b1087.9",
       "semver": "17.0.9",
       "build": 1087.9,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.9-windows-x64-b1087.9.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.9-linux-x64-b1087.9.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.9b1087.7",
       "semver": "17.0.9",
       "build": 1087.7,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.9-windows-x64-b1087.7.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.9-linux-x64-b1087.7.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.9b1000.47",
       "semver": "17.0.9",
       "build": 1000.47,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.9-windows-x64-b1000.47.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.9-linux-x64-b1000.47.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.9b1000.46",
       "semver": "17.0.9",
       "build": 1000.46,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.9-windows-x64-b1000.46.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.9-linux-x64-b1000.46.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.9b1087.3",
       "semver": "17.0.9",
       "build": 1087.3,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.9-windows-x64-b1087.3.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.9-linux-x64-b1087.3.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.8.1b1080.1",
       "semver": "17.0.8.1",
       "build": 1080.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.8.1-windows-x64-b1080.1.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.8.1-linux-x64-b1080.1.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.8.1b1072.1",
       "semver": "17.0.8.1",
       "build": 1072.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.8.1-windows-x64-b1072.1.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.8.1-linux-x64-b1072.1.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.8.1b1070.2",
       "semver": "17.0.8.1",
       "build": 1070.2,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.8.1-windows-x64-b1070.2.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.8.1-linux-x64-b1070.2.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.8.1b1063.1",
       "semver": "17.0.8.1",
       "build": 1063.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.8.1-windows-x64-b1063.1.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.8.1-linux-x64-b1063.1.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.8.1b1000.32",
       "semver": "17.0.8.1",
       "build": 1000.32,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.8.1-windows-x64-b1000.32.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.8.1-linux-x64-b1000.32.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.8.1b1059.3",
       "semver": "17.0.8.1",
       "build": 1059.3,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.8.1-windows-x64-b1059.3.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.8.1-linux-x64-b1059.3.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.8b1000.22",
       "semver": "17.0.8",
       "build": 1000.22,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.8-windows-x64-b1000.22.tar.gz"
-    },
-    {
-      "tag_name": "jbr-release-21b212.1",
-      "semver": "21",
-      "build": 212.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-21-windows-x64-b212.1.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.8-linux-x64-b1000.22.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.8b1000.8",
       "semver": "17.0.8",
       "build": 1000.8,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.8-windows-x64-b1000.8.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.8-linux-x64-b1000.8.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.7b1000.6",
       "semver": "17.0.7",
       "build": 1000.6,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.7-windows-x64-b1000.6.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.7-linux-x64-b1000.6.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.7b1000.5",
       "semver": "17.0.7",
       "build": 1000.5,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.7-windows-x64-b1000.5.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.7-linux-x64-b1000.5.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.7b1000.2",
       "semver": "17.0.7",
       "build": 1000.2,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.7-windows-x64-b1000.2.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.7-linux-x64-b1000.2.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.7b985.2",
       "semver": "17.0.7",
       "build": 985.2,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.7-windows-x64-b985.2.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.7-linux-x64-b985.2.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.7b979.4",
       "semver": "17.0.7",
       "build": 979.4,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.7-windows-x64-b979.4.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.7-linux-x64-b979.4.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.7b829.16",
       "semver": "17.0.7",
       "build": 829.16,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.7-windows-x64-b829.16.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.7-linux-x64-b829.16.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.7b966.2",
       "semver": "17.0.7",
       "build": 966.2,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.7-windows-x64-b966.2.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.7-linux-x64-b966.2.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.7b964.1",
       "semver": "17.0.7",
       "build": 964.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.7-windows-x64-b964.1.tar.gz"
-    },
-    {
-      "tag_name": "jbr-release-21b126.4",
-      "semver": "21",
-      "build": 126.4,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-21-windows-x64-b126.4.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.7-linux-x64-b964.1.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.7b829.14",
       "semver": "17.0.7",
       "build": 829.14,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.7-windows-x64-b829.14.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.7-linux-x64-b829.14.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.7b953.1",
       "semver": "17.0.7",
       "build": 953.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.7-windows-x64-b953.1.tar.gz"
-    },
-    {
-      "tag_name": "jbr-release-21b75.2",
-      "semver": "21",
-      "build": 75.2,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-21-windows-x64-b75.2.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.7-linux-x64-b953.1.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.6b829.9",
       "semver": "17.0.6",
       "build": 829.9,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.6-windows-x64-b829.9.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.6-linux-x64-b829.9.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.6b469.82",
       "semver": "17.0.6",
       "build": 469.82,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.6-windows-x64-b469.82.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.6-linux-x64-b469.82.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.6b829.5",
       "semver": "17.0.6",
       "build": 829.5,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.6-windows-x64-b829.5.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.6-linux-x64-b829.5.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.6b653.34",
       "semver": "17.0.6",
       "build": 653.34,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.6-windows-x64-b653.34.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.6-linux-x64-b653.34.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.6b829.4",
       "semver": "17.0.6",
       "build": 829.4,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.6-windows-x64-b829.4.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.6-linux-x64-b829.4.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.6b829.1",
       "semver": "17.0.6",
       "build": 829.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.6-windows-x64-b829.1.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.6-linux-x64-b829.1.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.6b653.32",
       "semver": "17.0.6",
       "build": 653.32,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.6-windows-x64-b653.32.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.6-linux-x64-b653.32.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.6b802.4",
       "semver": "17.0.6",
       "build": 802.4,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.6-windows-x64-b802.4.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.6-linux-x64-b802.4.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.6b802.1",
       "semver": "17.0.6",
       "build": 802.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.6-windows-x64-b802.1.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.6-linux-x64-b802.1.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.6b785.1",
       "semver": "17.0.6",
       "build": 785.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.6-windows-x64-b785.1.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.6-linux-x64-b785.1.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.6b779.1",
       "semver": "17.0.6",
       "build": 779.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.6-windows-x64-b779.1.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.6-linux-x64-b779.1.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.5b762.1",
       "semver": "17.0.5",
       "build": 762.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.5-windows-x64-b762.1.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.5-linux-x64-b762.1.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.5b653.25",
       "semver": "17.0.5",
       "build": 653.25,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.5-windows-x64-b653.25.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.5-linux-x64-b653.25.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.5b759.1",
       "semver": "17.0.5",
       "build": 759.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.5-windows-x64-b759.1.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.5-linux-x64-b759.1.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.5b653.23",
       "semver": "17.0.5",
       "build": 653.23,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.5-windows-x64-b653.23.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.5-linux-x64-b653.23.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.5b653.14",
       "semver": "17.0.5",
       "build": 653.14,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.5-windows-x64-b653.14.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.5-linux-x64-b653.14.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.5b469.71",
       "semver": "17.0.5",
       "build": 469.71,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.5-windows-x64-b469.71.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.5-linux-x64-b469.71.tar.gz"
     },
     {
       "tag_name": "jbr11_0_16b2043.64",
       "semver": "11.0.16",
       "build": 2043.64,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.16-windows-x64-b2043.64.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_nomod-11_0_16-linux-x64-b2043.64.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.5b653.6",
       "semver": "17.0.5",
       "build": 653.6,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.5-windows-x64-b653.6.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.5-linux-x64-b653.6.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.5b469.67",
       "semver": "17.0.5",
       "build": 469.67,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.5-windows-x64-b469.67.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.5-linux-x64-b469.67.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.4.1b653.1",
       "semver": "17.0.4.1",
       "build": 653.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.4.1-windows-x64-b653.1.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.4.1-linux-x64-b653.1.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.4.1b646.8",
       "semver": "17.0.4.1",
       "build": 646.8,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.4.1-windows-x64-b646.8.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.4.1-linux-x64-b646.8.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.4.1b629.2",
       "semver": "17.0.4.1",
       "build": 629.2,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.4.1-windows-x64-b629.2.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.4.1-linux-x64-b629.2.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.4.1b617.2",
       "semver": "17.0.4.1",
       "build": 617.2,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.4.1-windows-x64-b617.2.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.4.1-linux-x64-b617.2.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.4.1b469.62",
       "semver": "17.0.4.1",
       "build": 469.62,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.4.1-windows-x64-b469.62.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.4.1-linux-x64-b469.62.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.4.1b597.1",
       "semver": "17.0.4.1",
       "build": 597.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.4.1-windows-x64-b597.1.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.4.1-linux-x64-b597.1.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.4b469.53",
       "semver": "17.0.4",
       "build": 469.53,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.4-windows-x64-b469.53.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.4-linux-x64-b469.53.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.4b469.44",
       "semver": "17.0.4",
       "build": 469.44,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.4-windows-x64-b469.44.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.4-linux-x64-b469.44.tar.gz"
     },
     {
       "tag_name": "jbr-release-17.0.3b469.37",
       "semver": "17.0.3",
       "build": 469.37,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.3-windows-x64-b469.37.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.3-linux-x64-b469.37.tar.gz"
     },
     {
       "tag_name": "jbr17.0.3b469.32",
       "semver": "17.0.3",
       "build": 469.32,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.3-windows-x64-b469.32.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.3-linux-x64-b469.32.tar.gz"
     },
     {
       "tag_name": "jbr17.0.3b469.30",
       "semver": "17.0.3",
       "build": 469.3,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.3-windows-x64-b469.3.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.3-linux-x64-b469.3.tar.gz"
     },
     {
       "tag_name": "jbr17.0.3b469.19",
       "semver": "17.0.3",
       "build": 469.19,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.3-windows-x64-b469.19.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.3-linux-x64-b469.19.tar.gz"
     },
     {
       "tag_name": "jbr17.0.3b498.3",
       "semver": "17.0.3",
       "build": 498.3,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.3-windows-x64-b498.3.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.3-linux-x64-b498.3.tar.gz"
     },
     {
       "tag_name": "jbr17.0.3b469.16",
       "semver": "17.0.3",
       "build": 469.16,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.3-windows-x64-b469.16.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.3-linux-x64-b469.16.tar.gz"
     },
     {
       "tag_name": "jbr17.0.3b469.12",
       "semver": "17.0.3",
       "build": 469.12,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.3-windows-x64-b469.12.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.3-linux-x64-b469.12.tar.gz"
     },
     {
       "tag_name": "jbr17.0.3b469.3",
       "semver": "17.0.3",
       "build": 469.3,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.3-windows-x64-b469.3.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.3-linux-x64-b469.3.tar.gz"
     },
     {
       "tag_name": "jbr17.0.3b463.3",
       "semver": "17.0.3",
       "build": 463.3,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.3-windows-x64-b463.3.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.3-linux-x64-b463.3.tar.gz"
     },
     {
       "tag_name": "jbr17.0.3b423.10",
       "semver": "17.0.3",
       "build": 423.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.3-windows-x64-b423.1.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.3-linux-x64-b423.1.tar.gz"
     },
     {
       "tag_name": "jbr11_0_15b2043.56",
       "semver": "11.0.15",
       "build": 2043.56,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.15-windows-x64-b2043.56.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_nomod-11_0_15-linux-x64-b2043.56.tar.gz"
     },
     {
       "tag_name": "jbr11_0_14_1b2043.45",
       "semver": "11.0.14.1",
       "build": 2043.45,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.14.1-windows-x64-b2043.45.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_nomod-11_0_14_1-linux-x64-b2043.45.tar.gz"
     },
     {
       "tag_name": "jbr17.0.2b396.4",
       "semver": "17.0.2",
       "build": 396.4,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.2-windows-x64-b396.4.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.2-linux-x64-b396.4.tar.gz"
     },
     {
       "tag_name": "jbr11_0_14_1b2043.25",
       "semver": "11.0.14.1",
       "build": 2043.25,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.14.1-windows-x64-b2043.25.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_14_1-linux-x64-b2043.25.tar.gz"
     },
     {
       "tag_name": "jbr11_0_14_1b2043.22",
       "semver": "11.0.14.1",
       "build": 2043.22,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.14.1-windows-x64-b2043.22.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_14_1-linux-x64-b2043.22.tar.gz"
     },
     {
       "tag_name": "jbr11_0_14_1b2043.17",
       "semver": "11.0.14.1",
       "build": 2043.17,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.14.1-windows-x64-b2043.17.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_14_1-linux-x64-b2043.17.tar.gz"
     },
     {
       "tag_name": "jbr11_0_14_1b2043.14",
       "semver": "11.0.14.1",
       "build": 2043.14,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.14.1-windows-x64-b2043.14.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_14_1-linux-x64-b2043.14.tar.gz"
     },
     {
       "tag_name": "jbr11_0_14_1b2043.11",
       "semver": "11.0.14.1",
       "build": 2043.11,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.14.1-windows-x64-b2043.11.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_14_1-linux-x64-b2043.11.tar.gz"
     },
     {
       "tag_name": "jbr11_0_14b2043.2",
       "semver": "11.0.14",
       "build": 2043.2,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.14-windows-x64-b2043.2.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_14-linux-x64-b2043.2.tar.gz"
     },
     {
       "tag_name": "jbr11_0_14_1b1751.46",
       "semver": "11.0.14.1",
       "build": 1751.46,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.14.1-windows-x64-b1751.46.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_14_1-linux-x64-b1751.46.tar.gz"
     },
     {
       "tag_name": "jbr11_0_14b1993.2",
       "semver": "11.0.14",
       "build": 1993.2,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.14-windows-x64-b1993.2.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_14-linux-x64-b1993.2.tar.gz"
     },
     {
       "tag_name": "jbr17_0_2b315.1",
       "semver": "17.0.2",
       "build": 315.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.2-windows-x64-b315.1.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17_0_2-linux-x64-b315.1.tar.gz"
     },
     {
       "tag_name": "jbr11_0_14b1982.1",
       "semver": "11.0.14",
       "build": 1982.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.14-windows-x64-b1982.1.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_14-linux-x64-b1982.1.tar.gz"
     },
     {
       "tag_name": "jbr11_0_13b1890.3",
       "semver": "11.0.13",
       "build": 1890.3,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.13-windows-x64-b1890.3.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_13-linux-x64-b1890.3.tar.gz"
     },
     {
       "tag_name": "jbr11_0_13b1751.25",
       "semver": "11.0.13",
       "build": 1751.25,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.13-windows-x64-b1751.25.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_13-linux-x64-b1751.25.tar.gz"
     },
     {
       "tag_name": "jbr11_0_13b1751.24",
       "semver": "11.0.13",
       "build": 1751.24,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.13-windows-x64-b1751.24.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_13-linux-x64-b1751.24.tar.gz"
     },
     {
       "tag_name": "jbr11_0_13b1751.21",
       "semver": "11.0.13",
       "build": 1751.21,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.13-windows-x64-b1751.21.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_13-linux-x64-b1751.21.tar.gz"
     },
     {
       "tag_name": "jbr17_0_1b164.8",
       "semver": "17.0.1",
       "build": 164.8,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.1-windows-x64-b164.8.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17_0_1-linux-x64-b164.8.tar.gz"
     },
     {
       "tag_name": "jbr11_0_13b1751.19",
       "semver": "11.0.13",
       "build": 1751.19,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.13-windows-x64-b1751.19.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_13-linux-x64-b1751.19.tar.gz"
     },
     {
       "tag_name": "jb11_0_13-b1504.49",
       "semver": "11.0.13",
       "build": 1504.49,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.13-windows-x64-b1504.49.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_13-linux-x64-b1504.49.tar.gz"
     },
     {
       "tag_name": "jbr17_0_1b164.4",
       "semver": "17.0.1",
       "build": 164.4,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17.0.1-windows-x64-b164.4.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17_0_1-linux-x64-b164.4.tar.gz"
     },
     {
       "tag_name": "jbr11_0_13b1751.16",
       "semver": "11.0.13",
       "build": 1751.16,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.13-windows-x64-b1751.16.tar.gz"
-    },
-    {
-      "tag_name": "jbr17b135.1",
-      "semver": "17",
-      "build": 135.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17-windows-x64-b135.1.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_13-linux-x64-b1751.16.tar.gz"
     },
     {
       "tag_name": "jbr11_0_12b1751.11",
       "semver": "11.0.12",
       "build": 1751.11,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.12-windows-x64-b1751.11.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_12-linux-x64-b1751.11.tar.gz"
     },
     {
       "tag_name": "jbr11_0_12b1729.1",
       "semver": "11.0.12",
       "build": 1729.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.12-windows-x64-b1729.1.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_12-linux-x64-b1729.1.tar.gz"
     },
     {
       "tag_name": "jbr11_0_12b1715.4",
       "semver": "11.0.12",
       "build": 1715.4,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.12-windows-x64-b1715.4.tar.gz"
-    },
-    {
-      "tag_name": "jbr17b106.1",
-      "semver": "17",
-      "build": 106.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-17-windows-x64-b106.1.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_12-linux-x64-b1715.4.tar.gz"
     },
     {
       "tag_name": "jbr11_0_12b1692.9",
       "semver": "11.0.12",
       "build": 1692.9,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.12-windows-x64-b1692.9.tar.gz"
-    },
-    {
-      "tag_name": "jbr17-b87.7",
-      "semver": "r17",
-      "build": 87.7,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-r17-windows-x64-b87.7.tar.gz"
-    },
-    {
-      "tag_name": "jb11_0_12-b1504.40",
-      "semver": "11.0.12",
-      "build": 1504.4,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.12-windows-x64-b1504.4.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_12-linux-x64-b1692.9.tar.gz"
     },
     {
       "tag_name": "jb11_0_12-b1504.37",
       "semver": "11.0.12",
       "build": 1504.37,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.12-windows-x64-b1504.37.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_12-linux-x64-b1504.37.tar.gz"
     },
     {
       "tag_name": "jbr11_0_12b1665.1",
       "semver": "11.0.12",
       "build": 1665.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.12-windows-x64-b1665.1.tar.gz"
-    },
-    {
-      "tag_name": "jb11_0_12-b11_0_12b1649.1",
-      "semver": "11.0.12",
-      "build": null,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.12-windows-x64-bNaN.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_12-linux-x64-b1665.1.tar.gz"
     },
     {
       "tag_name": "jb11_0_12-b1504.28",
       "semver": "11.0.12",
       "build": 1504.28,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.12-windows-x64-b1504.28.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_12-linux-x64-b1504.28.tar.gz"
     },
     {
       "tag_name": "jb11_0_12-b1504.27",
       "semver": "11.0.12",
       "build": 1504.27,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.12-windows-x64-b1504.27.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_12-linux-x64-b1504.27.tar.gz"
     },
     {
       "tag_name": "jb11_0_11-b1504.16",
       "semver": "11.0.11",
       "build": 1504.16,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.11-windows-x64-b1504.16.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_11-linux-x64-b1504.16.tar.gz"
     },
     {
       "tag_name": "jb11_0_11-b1504.13",
       "semver": "11.0.11",
       "build": 1504.13,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.11-windows-x64-b1504.13.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_11-linux-x64-b1504.13.tar.gz"
     },
     {
       "tag_name": "jb11_0_11-b1504.12",
       "semver": "11.0.11",
       "build": 1504.12,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.11-windows-x64-b1504.12.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_11-linux-x64-b1504.12.tar.gz"
     },
     {
       "tag_name": "jb11_0_11-b1542.1",
       "semver": "11.0.11",
       "build": 1542.1,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.11-windows-x64-b1542.1.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_11-linux-x64-b1542.1.tar.gz"
     },
     {
       "tag_name": "jb11_0_11-b1504.8",
       "semver": "11.0.11",
       "build": 1504.8,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-11.0.11-windows-x64-b1504.8.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_11-linux-x64-b1504.8.tar.gz"
     },
     {
       "tag_name": "11_0_11b1536.2",
-      "semver": "0.11",
+      "semver": "11.0.11",
       "build": 1536.2,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-0.11-windows-x64-b1536.2.tar.gz"
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_11-linux-x64-b1536.2.tar.gz"
     },
     {
-      "tag_name": "11_0_11-b1522",
-      "semver": ".0.11",
-      "build": 1522,
-      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-.0.11-windows-x64-b1522.tar.gz"
+      "tag_name": "jbr-release-21.0.3b465.3",
+      "semver": "21.0.3",
+      "build": 465.3,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-21.0.3-linux-x64-b465.3.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-21.0.3b458.1",
+      "semver": "21.0.3",
+      "build": 458.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-21.0.3-linux-x64-b458.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-21.0.3b453.2",
+      "semver": "21.0.3",
+      "build": 453.2,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-21.0.3-linux-x64-b453.2.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.11b1207.24",
+      "semver": "17.0.11",
+      "build": 1207.24,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.11-linux-x64-b1207.24.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.11b1207.23",
+      "semver": "17.0.11",
+      "build": 1207.23,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.11-linux-x64-b1207.23.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-21.0.3b446.1",
+      "semver": "21.0.3",
+      "build": 446.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-21.0.3-linux-x64-b446.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b1207.14",
+      "semver": "17.0.10",
+      "build": 1207.14,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.10-linux-x64-b1207.14.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b829.27",
+      "semver": "17.0.10",
+      "build": 829.27,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.10-linux-x64-b829.27.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b1087.23",
+      "semver": "17.0.10",
+      "build": 1087.23,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.10-linux-x64-b1087.23.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b1207.12",
+      "semver": "17.0.10",
+      "build": 1207.12,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.10-linux-x64-b1207.12.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b1087.21",
+      "semver": "17.0.10",
+      "build": 1087.21,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.10-linux-x64-b1087.21.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b1207.6",
+      "semver": "17.0.10",
+      "build": 1207.6,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.10-linux-x64-b1207.6.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-21.0.2b375.1",
+      "semver": "21.0.2",
+      "build": 375.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-21.0.2-linux-x64-b375.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b1207.1",
+      "semver": "17.0.10",
+      "build": 1207.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.10-linux-x64-b1207.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b1186.1",
+      "semver": "17.0.10",
+      "build": 1186.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.10-linux-x64-b1186.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b1171.14",
+      "semver": "17.0.10",
+      "build": 1171.14,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.10-linux-x64-b1171.14.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b829.26",
+      "semver": "17.0.10",
+      "build": 829.26,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.10-linux-x64-b829.26.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-21.0.2b346.3",
+      "semver": "21.0.2",
+      "build": 346.3,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-21.0.2-linux-x64-b346.3.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b1000.48",
+      "semver": "17.0.10",
+      "build": 1000.48,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.10-linux-x64-b1000.48.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-21.0.2b341.4",
+      "semver": "21.0.2",
+      "build": 341.4,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-21.0.2-linux-x64-b341.4.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.10b1087.17",
+      "semver": "17.0.10",
+      "build": 1087.17,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.10-linux-x64-b1087.17.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.9b1166.2",
+      "semver": "17.0.9",
+      "build": 1166.2,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.9-linux-x64-b1166.2.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.9b1162.7",
+      "semver": "17.0.9",
+      "build": 1162.7,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.9-linux-x64-b1162.7.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.9b1087.11",
+      "semver": "17.0.9",
+      "build": 1087.11,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.9-linux-x64-b1087.11.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.9b1087.9",
+      "semver": "17.0.9",
+      "build": 1087.9,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.9-linux-x64-b1087.9.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.9b1087.7",
+      "semver": "17.0.9",
+      "build": 1087.7,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.9-linux-x64-b1087.7.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.9b1000.47",
+      "semver": "17.0.9",
+      "build": 1000.47,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.9-linux-x64-b1000.47.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.9b1000.46",
+      "semver": "17.0.9",
+      "build": 1000.46,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.9-linux-x64-b1000.46.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.9b1087.3",
+      "semver": "17.0.9",
+      "build": 1087.3,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.9-linux-x64-b1087.3.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.8.1b1080.1",
+      "semver": "17.0.8.1",
+      "build": 1080.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.8.1-linux-x64-b1080.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.8.1b1072.1",
+      "semver": "17.0.8.1",
+      "build": 1072.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.8.1-linux-x64-b1072.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.8.1b1070.2",
+      "semver": "17.0.8.1",
+      "build": 1070.2,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.8.1-linux-x64-b1070.2.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.8.1b1063.1",
+      "semver": "17.0.8.1",
+      "build": 1063.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.8.1-linux-x64-b1063.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.8.1b1000.32",
+      "semver": "17.0.8.1",
+      "build": 1000.32,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.8.1-linux-x64-b1000.32.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.8.1b1059.3",
+      "semver": "17.0.8.1",
+      "build": 1059.3,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.8.1-linux-x64-b1059.3.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.8b1000.22",
+      "semver": "17.0.8",
+      "build": 1000.22,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.8-linux-x64-b1000.22.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.8b1000.8",
+      "semver": "17.0.8",
+      "build": 1000.8,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.8-linux-x64-b1000.8.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.7b1000.6",
+      "semver": "17.0.7",
+      "build": 1000.6,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.7-linux-x64-b1000.6.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.7b1000.5",
+      "semver": "17.0.7",
+      "build": 1000.5,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.7-linux-x64-b1000.5.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.7b1000.2",
+      "semver": "17.0.7",
+      "build": 1000.2,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.7-linux-x64-b1000.2.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.7b985.2",
+      "semver": "17.0.7",
+      "build": 985.2,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.7-linux-x64-b985.2.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.7b979.4",
+      "semver": "17.0.7",
+      "build": 979.4,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.7-linux-x64-b979.4.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.7b829.16",
+      "semver": "17.0.7",
+      "build": 829.16,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.7-linux-x64-b829.16.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.7b966.2",
+      "semver": "17.0.7",
+      "build": 966.2,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.7-linux-x64-b966.2.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.7b964.1",
+      "semver": "17.0.7",
+      "build": 964.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.7-linux-x64-b964.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.7b829.14",
+      "semver": "17.0.7",
+      "build": 829.14,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.7-linux-x64-b829.14.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.7b953.1",
+      "semver": "17.0.7",
+      "build": 953.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.7-linux-x64-b953.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.6b829.9",
+      "semver": "17.0.6",
+      "build": 829.9,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.6-linux-x64-b829.9.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.6b469.82",
+      "semver": "17.0.6",
+      "build": 469.82,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.6-linux-x64-b469.82.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.6b829.5",
+      "semver": "17.0.6",
+      "build": 829.5,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.6-linux-x64-b829.5.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.6b653.34",
+      "semver": "17.0.6",
+      "build": 653.34,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.6-linux-x64-b653.34.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.6b829.4",
+      "semver": "17.0.6",
+      "build": 829.4,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.6-linux-x64-b829.4.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.6b829.1",
+      "semver": "17.0.6",
+      "build": 829.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.6-linux-x64-b829.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.6b653.32",
+      "semver": "17.0.6",
+      "build": 653.32,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.6-linux-x64-b653.32.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.6b802.4",
+      "semver": "17.0.6",
+      "build": 802.4,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.6-linux-x64-b802.4.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.6b802.1",
+      "semver": "17.0.6",
+      "build": 802.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.6-linux-x64-b802.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.6b785.1",
+      "semver": "17.0.6",
+      "build": 785.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.6-linux-x64-b785.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.6b779.1",
+      "semver": "17.0.6",
+      "build": 779.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.6-linux-x64-b779.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.5b762.1",
+      "semver": "17.0.5",
+      "build": 762.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.5-linux-x64-b762.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.5b653.25",
+      "semver": "17.0.5",
+      "build": 653.25,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.5-linux-x64-b653.25.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.5b759.1",
+      "semver": "17.0.5",
+      "build": 759.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.5-linux-x64-b759.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.5b653.23",
+      "semver": "17.0.5",
+      "build": 653.23,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.5-linux-x64-b653.23.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.5b653.14",
+      "semver": "17.0.5",
+      "build": 653.14,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.5-linux-x64-b653.14.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.5b469.71",
+      "semver": "17.0.5",
+      "build": 469.71,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.5-linux-x64-b469.71.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_16b2043.64",
+      "semver": "11.0.16",
+      "build": 2043.64,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_nomod-11_0_16-linux-x64-b2043.64.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.5b653.6",
+      "semver": "17.0.5",
+      "build": 653.6,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.5-linux-x64-b653.6.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.5b469.67",
+      "semver": "17.0.5",
+      "build": 469.67,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.5-linux-x64-b469.67.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.4.1b653.1",
+      "semver": "17.0.4.1",
+      "build": 653.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.4.1-linux-x64-b653.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.4.1b646.8",
+      "semver": "17.0.4.1",
+      "build": 646.8,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.4.1-linux-x64-b646.8.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.4.1b629.2",
+      "semver": "17.0.4.1",
+      "build": 629.2,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.4.1-linux-x64-b629.2.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.4.1b617.2",
+      "semver": "17.0.4.1",
+      "build": 617.2,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.4.1-linux-x64-b617.2.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.4.1b469.62",
+      "semver": "17.0.4.1",
+      "build": 469.62,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.4.1-linux-x64-b469.62.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.4.1b597.1",
+      "semver": "17.0.4.1",
+      "build": 597.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.4.1-linux-x64-b597.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.4b469.53",
+      "semver": "17.0.4",
+      "build": 469.53,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.4-linux-x64-b469.53.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.4b469.44",
+      "semver": "17.0.4",
+      "build": 469.44,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.4-linux-x64-b469.44.tar.gz"
+    },
+    {
+      "tag_name": "jbr-release-17.0.3b469.37",
+      "semver": "17.0.3",
+      "build": 469.37,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.3-linux-x64-b469.37.tar.gz"
+    },
+    {
+      "tag_name": "jbr17.0.3b469.32",
+      "semver": "17.0.3",
+      "build": 469.32,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.3-linux-x64-b469.32.tar.gz"
+    },
+    {
+      "tag_name": "jbr17.0.3b469.30",
+      "semver": "17.0.3",
+      "build": 469.3,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.3-linux-x64-b469.3.tar.gz"
+    },
+    {
+      "tag_name": "jbr17.0.3b469.19",
+      "semver": "17.0.3",
+      "build": 469.19,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.3-linux-x64-b469.19.tar.gz"
+    },
+    {
+      "tag_name": "jbr17.0.3b498.3",
+      "semver": "17.0.3",
+      "build": 498.3,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.3-linux-x64-b498.3.tar.gz"
+    },
+    {
+      "tag_name": "jbr17.0.3b469.16",
+      "semver": "17.0.3",
+      "build": 469.16,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.3-linux-x64-b469.16.tar.gz"
+    },
+    {
+      "tag_name": "jbr17.0.3b469.12",
+      "semver": "17.0.3",
+      "build": 469.12,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.3-linux-x64-b469.12.tar.gz"
+    },
+    {
+      "tag_name": "jbr17.0.3b469.3",
+      "semver": "17.0.3",
+      "build": 469.3,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.3-linux-x64-b469.3.tar.gz"
+    },
+    {
+      "tag_name": "jbr17.0.3b463.3",
+      "semver": "17.0.3",
+      "build": 463.3,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.3-linux-x64-b463.3.tar.gz"
+    },
+    {
+      "tag_name": "jbr17.0.3b423.10",
+      "semver": "17.0.3",
+      "build": 423.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.3-linux-x64-b423.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_15b2043.56",
+      "semver": "11.0.15",
+      "build": 2043.56,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_nomod-11_0_15-linux-x64-b2043.56.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_14_1b2043.45",
+      "semver": "11.0.14.1",
+      "build": 2043.45,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_nomod-11_0_14_1-linux-x64-b2043.45.tar.gz"
+    },
+    {
+      "tag_name": "jbr17.0.2b396.4",
+      "semver": "17.0.2",
+      "build": 396.4,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17.0.2-linux-x64-b396.4.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_14_1b2043.25",
+      "semver": "11.0.14.1",
+      "build": 2043.25,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_14_1-linux-x64-b2043.25.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_14_1b2043.22",
+      "semver": "11.0.14.1",
+      "build": 2043.22,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_14_1-linux-x64-b2043.22.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_14_1b2043.17",
+      "semver": "11.0.14.1",
+      "build": 2043.17,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_14_1-linux-x64-b2043.17.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_14_1b2043.14",
+      "semver": "11.0.14.1",
+      "build": 2043.14,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_14_1-linux-x64-b2043.14.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_14_1b2043.11",
+      "semver": "11.0.14.1",
+      "build": 2043.11,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_14_1-linux-x64-b2043.11.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_14b2043.2",
+      "semver": "11.0.14",
+      "build": 2043.2,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_14-linux-x64-b2043.2.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_14_1b1751.46",
+      "semver": "11.0.14.1",
+      "build": 1751.46,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_14_1-linux-x64-b1751.46.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_14b1993.2",
+      "semver": "11.0.14",
+      "build": 1993.2,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_14-linux-x64-b1993.2.tar.gz"
+    },
+    {
+      "tag_name": "jbr17_0_2b315.1",
+      "semver": "17.0.2",
+      "build": 315.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17_0_2-linux-x64-b315.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_14b1982.1",
+      "semver": "11.0.14",
+      "build": 1982.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_14-linux-x64-b1982.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_13b1890.3",
+      "semver": "11.0.13",
+      "build": 1890.3,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_13-linux-x64-b1890.3.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_13b1751.25",
+      "semver": "11.0.13",
+      "build": 1751.25,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_13-linux-x64-b1751.25.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_13b1751.24",
+      "semver": "11.0.13",
+      "build": 1751.24,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_13-linux-x64-b1751.24.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_13b1751.21",
+      "semver": "11.0.13",
+      "build": 1751.21,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_13-linux-x64-b1751.21.tar.gz"
+    },
+    {
+      "tag_name": "jbr17_0_1b164.8",
+      "semver": "17.0.1",
+      "build": 164.8,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17_0_1-linux-x64-b164.8.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_13b1751.19",
+      "semver": "11.0.13",
+      "build": 1751.19,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_13-linux-x64-b1751.19.tar.gz"
+    },
+    {
+      "tag_name": "jb11_0_13-b1504.49",
+      "semver": "11.0.13",
+      "build": 1504.49,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_13-linux-x64-b1504.49.tar.gz"
+    },
+    {
+      "tag_name": "jbr17_0_1b164.4",
+      "semver": "17.0.1",
+      "build": 164.4,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-17_0_1-linux-x64-b164.4.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_13b1751.16",
+      "semver": "11.0.13",
+      "build": 1751.16,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_13-linux-x64-b1751.16.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_12b1751.11",
+      "semver": "11.0.12",
+      "build": 1751.11,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_12-linux-x64-b1751.11.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_12b1729.1",
+      "semver": "11.0.12",
+      "build": 1729.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_12-linux-x64-b1729.1.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_12b1715.4",
+      "semver": "11.0.12",
+      "build": 1715.4,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_12-linux-x64-b1715.4.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_12b1692.9",
+      "semver": "11.0.12",
+      "build": 1692.9,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_12-linux-x64-b1692.9.tar.gz"
+    },
+    {
+      "tag_name": "jb11_0_12-b1504.37",
+      "semver": "11.0.12",
+      "build": 1504.37,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_12-linux-x64-b1504.37.tar.gz"
+    },
+    {
+      "tag_name": "jbr11_0_12b1665.1",
+      "semver": "11.0.12",
+      "build": 1665.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_12-linux-x64-b1665.1.tar.gz"
+    },
+    {
+      "tag_name": "jb11_0_12-b1504.28",
+      "semver": "11.0.12",
+      "build": 1504.28,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_12-linux-x64-b1504.28.tar.gz"
+    },
+    {
+      "tag_name": "jb11_0_12-b1504.27",
+      "semver": "11.0.12",
+      "build": 1504.27,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_12-linux-x64-b1504.27.tar.gz"
+    },
+    {
+      "tag_name": "jb11_0_11-b1504.16",
+      "semver": "11.0.11",
+      "build": 1504.16,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_11-linux-x64-b1504.16.tar.gz"
+    },
+    {
+      "tag_name": "jb11_0_11-b1504.13",
+      "semver": "11.0.11",
+      "build": 1504.13,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_11-linux-x64-b1504.13.tar.gz"
+    },
+    {
+      "tag_name": "jb11_0_11-b1504.12",
+      "semver": "11.0.11",
+      "build": 1504.12,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_11-linux-x64-b1504.12.tar.gz"
+    },
+    {
+      "tag_name": "jb11_0_11-b1542.1",
+      "semver": "11.0.11",
+      "build": 1542.1,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_11-linux-x64-b1542.1.tar.gz"
+    },
+    {
+      "tag_name": "jb11_0_11-b1504.8",
+      "semver": "11.0.11",
+      "build": 1504.8,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_11-linux-x64-b1504.8.tar.gz"
+    },
+    {
+      "tag_name": "11_0_11b1536.2",
+      "semver": "11.0.11",
+      "build": 1536.2,
+      "url": "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-11_0_11-linux-x64-b1536.2.tar.gz"
     }
   ]

--- a/__tests__/distributors/jetbrains-installer.test.ts
+++ b/__tests__/distributors/jetbrains-installer.test.ts
@@ -25,22 +25,11 @@ describe('getAvailableVersions', () => {
 
   it('load available versions', async () => {
     spyHttpClient = jest.spyOn(HttpClient.prototype, 'getJson');
-    spyHttpClient
-      .mockReturnValueOnce({
-        statusCode: 200,
-        headers: {},
-        result: manifestData as any
-      })
-      .mockReturnValueOnce({
-        statusCode: 200,
-        headers: {},
-        result: manifestData as any
-      })
-      .mockReturnValueOnce({
-        statusCode: 200,
-        headers: {},
-        result: []
-      });
+    spyHttpClient.mockReturnValueOnce({
+      statusCode: 200,
+      headers: {},
+      result: manifestData as any
+    });
 
     const distribution = new JetBrainsDistribution({
       version: '17',
@@ -53,8 +42,8 @@ describe('getAvailableVersions', () => {
 
     const length =
       os.platform() === 'win32'
-        ? manifestData.length * 2 - 4
-        : manifestData.length * 2;
+        ? manifestData.length - 2
+        : manifestData.length + 1;
     expect(availableVersions.length).toBe(length);
   }, 10_000);
 });

--- a/__tests__/distributors/jetbrains-installer.test.ts
+++ b/__tests__/distributors/jetbrains-installer.test.ts
@@ -1,0 +1,109 @@
+import {HttpClient} from '@actions/http-client';
+import os from 'os';
+import fs from 'fs';
+import {JetBrainsDistribution} from '../../src/distributions/jetbrains/installer';
+import {JavaInstallerOptions} from '../../src/distributions/base-models';
+
+import manifestData from '../data/jetbrains.json';
+
+describe('getAvailableVersions', () => {
+  let spyHttpClient: jest.SpyInstance;
+
+  beforeEach(() => {
+    spyHttpClient = jest.spyOn(HttpClient.prototype, 'getJson');
+    spyHttpClient.mockReturnValue({
+      statusCode: 200,
+      headers: {},
+      result: []
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it('load available versions', async () => {
+    spyHttpClient = jest.spyOn(HttpClient.prototype, 'getJson');
+    spyHttpClient
+      .mockReturnValueOnce({
+        statusCode: 200,
+        headers: {},
+        result: manifestData as any
+      })
+      .mockReturnValueOnce({
+        statusCode: 200,
+        headers: {},
+        result: manifestData as any
+      })
+      .mockReturnValueOnce({
+        statusCode: 200,
+        headers: {},
+        result: []
+      });
+
+    const distribution = new JetBrainsDistribution({
+      version: '17',
+      architecture: 'x64',
+      packageType: 'jdk',
+      checkLatest: false
+    });
+    const availableVersions = await distribution['getAvailableVersions']();
+    expect(availableVersions).not.toBeNull();
+    expect(availableVersions.length).toBe(manifestData.length * 2);
+  });
+});
+
+describe('findPackageForDownload', () => {
+  it.each([
+    ['17', '17.0.11+1207.24'],
+    ['11.0', '11.0.16+2043.64'],
+    ['11.0.11', '11.0.11+1542.1'],
+    ['21.0.2', '21.0.2+375.1'],
+    ['21', '21.0.3+465.3'],
+    ['x', '21.0.3+465.3']
+  ])('version is resolved correctly %s -> %s', async (input, expected) => {
+    const distribution = new JetBrainsDistribution(
+      {
+        version: input,
+        architecture: 'x64',
+        packageType: 'jdk',
+        checkLatest: false
+      },
+    );
+    distribution['getAvailableVersions'] = async () => manifestData as any;
+    const resolvedVersion = await distribution['findPackageForDownload'](input);
+    expect(resolvedVersion.version).toBe(expected);
+  });
+
+  it('version is not found', async () => {
+    const distribution = new JetBrainsDistribution(
+      {
+        version: '8.0.452',
+        architecture: 'x64',
+        packageType: 'jdk',
+        checkLatest: false
+      },
+    );
+    distribution['getAvailableVersions'] = async () => manifestData as any;
+    await expect(distribution['findPackageForDownload']('8.x')).rejects.toThrow(
+      /Could not find satisfied version for SemVer */
+    );
+  });
+
+  it('version list is empty', async () => {
+    const distribution = new JetBrainsDistribution(
+      {
+        version: '8',
+        architecture: 'x64',
+        packageType: 'jdk',
+        checkLatest: false
+      },
+    );
+    distribution['getAvailableVersions'] = async () => [];
+    await expect(distribution['findPackageForDownload']('8')).rejects.toThrow(
+      /Could not find satisfied version for SemVer */
+    );
+  });
+});

--- a/__tests__/distributors/jetbrains-installer.test.ts
+++ b/__tests__/distributors/jetbrains-installer.test.ts
@@ -42,7 +42,7 @@ describe('getAvailableVersions', () => {
 
     const length =
       os.platform() === 'win32'
-        ? manifestData.length - 2
+        ? manifestData.length - 1
         : manifestData.length + 1;
     expect(availableVersions.length).toBe(length);
   }, 10_000);

--- a/__tests__/distributors/jetbrains-installer.test.ts
+++ b/__tests__/distributors/jetbrains-installer.test.ts
@@ -3,6 +3,7 @@ import {HttpClient} from '@actions/http-client';
 import {JetBrainsDistribution} from '../../src/distributions/jetbrains/installer';
 
 import manifestData from '../data/jetbrains.json';
+import {fstat, writeFileSync} from 'fs';
 
 describe('getAvailableVersions', () => {
   let spyHttpClient: jest.SpyInstance;
@@ -50,7 +51,7 @@ describe('getAvailableVersions', () => {
     const availableVersions = await distribution['getAvailableVersions']();
     expect(availableVersions).not.toBeNull();
     expect(availableVersions.length).toBe(manifestData.length * 2);
-  });
+  }, 10_000);
 });
 
 describe('findPackageForDownload', () => {

--- a/__tests__/distributors/jetbrains-installer.test.ts
+++ b/__tests__/distributors/jetbrains-installer.test.ts
@@ -3,7 +3,7 @@ import {HttpClient} from '@actions/http-client';
 import {JetBrainsDistribution} from '../../src/distributions/jetbrains/installer';
 
 import manifestData from '../data/jetbrains.json';
-import {fstat, writeFileSync} from 'fs';
+import os from 'os';
 
 describe('getAvailableVersions', () => {
   let spyHttpClient: jest.SpyInstance;
@@ -50,7 +50,12 @@ describe('getAvailableVersions', () => {
     });
     const availableVersions = await distribution['getAvailableVersions']();
     expect(availableVersions).not.toBeNull();
-    expect(availableVersions.length).toBe(manifestData.length * 2);
+
+    const length =
+      os.platform() === 'win32'
+        ? manifestData.length * 2 - 4
+        : manifestData.length * 2;
+    expect(availableVersions.length).toBe(length);
   }, 10_000);
 });
 

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -66945,132 +66945,6 @@ module.exports = buildConnector
 
 /***/ }),
 
-/***/ 4462:
-/***/ ((module) => {
-
-"use strict";
-
-
-/** @type {Record<string, string | undefined>} */
-const headerNameLowerCasedRecord = {}
-
-// https://developer.mozilla.org/docs/Web/HTTP/Headers
-const wellknownHeaderNames = [
-  'Accept',
-  'Accept-Encoding',
-  'Accept-Language',
-  'Accept-Ranges',
-  'Access-Control-Allow-Credentials',
-  'Access-Control-Allow-Headers',
-  'Access-Control-Allow-Methods',
-  'Access-Control-Allow-Origin',
-  'Access-Control-Expose-Headers',
-  'Access-Control-Max-Age',
-  'Access-Control-Request-Headers',
-  'Access-Control-Request-Method',
-  'Age',
-  'Allow',
-  'Alt-Svc',
-  'Alt-Used',
-  'Authorization',
-  'Cache-Control',
-  'Clear-Site-Data',
-  'Connection',
-  'Content-Disposition',
-  'Content-Encoding',
-  'Content-Language',
-  'Content-Length',
-  'Content-Location',
-  'Content-Range',
-  'Content-Security-Policy',
-  'Content-Security-Policy-Report-Only',
-  'Content-Type',
-  'Cookie',
-  'Cross-Origin-Embedder-Policy',
-  'Cross-Origin-Opener-Policy',
-  'Cross-Origin-Resource-Policy',
-  'Date',
-  'Device-Memory',
-  'Downlink',
-  'ECT',
-  'ETag',
-  'Expect',
-  'Expect-CT',
-  'Expires',
-  'Forwarded',
-  'From',
-  'Host',
-  'If-Match',
-  'If-Modified-Since',
-  'If-None-Match',
-  'If-Range',
-  'If-Unmodified-Since',
-  'Keep-Alive',
-  'Last-Modified',
-  'Link',
-  'Location',
-  'Max-Forwards',
-  'Origin',
-  'Permissions-Policy',
-  'Pragma',
-  'Proxy-Authenticate',
-  'Proxy-Authorization',
-  'RTT',
-  'Range',
-  'Referer',
-  'Referrer-Policy',
-  'Refresh',
-  'Retry-After',
-  'Sec-WebSocket-Accept',
-  'Sec-WebSocket-Extensions',
-  'Sec-WebSocket-Key',
-  'Sec-WebSocket-Protocol',
-  'Sec-WebSocket-Version',
-  'Server',
-  'Server-Timing',
-  'Service-Worker-Allowed',
-  'Service-Worker-Navigation-Preload',
-  'Set-Cookie',
-  'SourceMap',
-  'Strict-Transport-Security',
-  'Supports-Loading-Mode',
-  'TE',
-  'Timing-Allow-Origin',
-  'Trailer',
-  'Transfer-Encoding',
-  'Upgrade',
-  'Upgrade-Insecure-Requests',
-  'User-Agent',
-  'Vary',
-  'Via',
-  'WWW-Authenticate',
-  'X-Content-Type-Options',
-  'X-DNS-Prefetch-Control',
-  'X-Frame-Options',
-  'X-Permitted-Cross-Domain-Policies',
-  'X-Powered-By',
-  'X-Requested-With',
-  'X-XSS-Protection'
-]
-
-for (let i = 0; i < wellknownHeaderNames.length; ++i) {
-  const key = wellknownHeaderNames[i]
-  const lowerCasedKey = key.toLowerCase()
-  headerNameLowerCasedRecord[key] = headerNameLowerCasedRecord[lowerCasedKey] =
-    lowerCasedKey
-}
-
-// Note: object prototypes should not be able to be referenced. e.g. `Object#hasOwnProperty`.
-Object.setPrototypeOf(headerNameLowerCasedRecord, null)
-
-module.exports = {
-  wellknownHeaderNames,
-  headerNameLowerCasedRecord
-}
-
-
-/***/ }),
-
 /***/ 8045:
 /***/ ((module) => {
 
@@ -67901,7 +67775,6 @@ const { InvalidArgumentError } = __nccwpck_require__(8045)
 const { Blob } = __nccwpck_require__(4300)
 const nodeUtil = __nccwpck_require__(3837)
 const { stringify } = __nccwpck_require__(3477)
-const { headerNameLowerCasedRecord } = __nccwpck_require__(4462)
 
 const [nodeMajor, nodeMinor] = process.versions.node.split('.').map(v => Number(v))
 
@@ -68109,15 +67982,6 @@ const KEEPALIVE_TIMEOUT_EXPR = /timeout=(\d+)/
 function parseKeepAliveTimeout (val) {
   const m = val.toString().match(KEEPALIVE_TIMEOUT_EXPR)
   return m ? parseInt(m[1], 10) * 1000 : null
-}
-
-/**
- * Retrieves a header name and returns its lowercase value.
- * @param {string | Buffer} value Header name
- * @returns {string}
- */
-function headerNameToString (value) {
-  return headerNameLowerCasedRecord[value] || value.toLowerCase()
 }
 
 function parseHeaders (headers, obj = {}) {
@@ -68391,7 +68255,6 @@ module.exports = {
   isIterable,
   isAsyncIterable,
   isDestroyed,
-  headerNameToString,
   parseRawHeaders,
   parseHeaders,
   parseKeepAliveTimeout,
@@ -75039,18 +74902,14 @@ const { isBlobLike, toUSVString, ReadableStreamFrom } = __nccwpck_require__(3983
 const assert = __nccwpck_require__(9491)
 const { isUint8Array } = __nccwpck_require__(9830)
 
-let supportedHashes = []
-
 // https://nodejs.org/api/crypto.html#determining-if-crypto-support-is-unavailable
 /** @type {import('crypto')|undefined} */
 let crypto
 
 try {
   crypto = __nccwpck_require__(6113)
-  const possibleRelevantHashes = ['sha256', 'sha384', 'sha512']
-  supportedHashes = crypto.getHashes().filter((hash) => possibleRelevantHashes.includes(hash))
-/* c8 ignore next 3 */
 } catch {
+
 }
 
 function responseURL (response) {
@@ -75578,56 +75437,66 @@ function bytesMatch (bytes, metadataList) {
     return true
   }
 
-  // 3. If response is not eligible for integrity validation, return false.
-  // TODO
-
-  // 4. If parsedMetadata is the empty set, return true.
+  // 3. If parsedMetadata is the empty set, return true.
   if (parsedMetadata.length === 0) {
     return true
   }
 
-  // 5. Let metadata be the result of getting the strongest
+  // 4. Let metadata be the result of getting the strongest
   //    metadata from parsedMetadata.
-  const strongest = getStrongestMetadata(parsedMetadata)
-  const metadata = filterMetadataListByAlgorithm(parsedMetadata, strongest)
+  const list = parsedMetadata.sort((c, d) => d.algo.localeCompare(c.algo))
+  // get the strongest algorithm
+  const strongest = list[0].algo
+  // get all entries that use the strongest algorithm; ignore weaker
+  const metadata = list.filter((item) => item.algo === strongest)
 
-  // 6. For each item in metadata:
+  // 5. For each item in metadata:
   for (const item of metadata) {
     // 1. Let algorithm be the alg component of item.
     const algorithm = item.algo
 
     // 2. Let expectedValue be the val component of item.
-    const expectedValue = item.hash
+    let expectedValue = item.hash
 
     // See https://github.com/web-platform-tests/wpt/commit/e4c5cc7a5e48093220528dfdd1c4012dc3837a0e
     // "be liberal with padding". This is annoying, and it's not even in the spec.
 
+    if (expectedValue.endsWith('==')) {
+      expectedValue = expectedValue.slice(0, -2)
+    }
+
     // 3. Let actualValue be the result of applying algorithm to bytes.
     let actualValue = crypto.createHash(algorithm).update(bytes).digest('base64')
 
-    if (actualValue[actualValue.length - 1] === '=') {
-      if (actualValue[actualValue.length - 2] === '=') {
-        actualValue = actualValue.slice(0, -2)
-      } else {
-        actualValue = actualValue.slice(0, -1)
-      }
+    if (actualValue.endsWith('==')) {
+      actualValue = actualValue.slice(0, -2)
     }
 
     // 4. If actualValue is a case-sensitive match for expectedValue,
     //    return true.
-    if (compareBase64Mixed(actualValue, expectedValue)) {
+    if (actualValue === expectedValue) {
+      return true
+    }
+
+    let actualBase64URL = crypto.createHash(algorithm).update(bytes).digest('base64url')
+
+    if (actualBase64URL.endsWith('==')) {
+      actualBase64URL = actualBase64URL.slice(0, -2)
+    }
+
+    if (actualBase64URL === expectedValue) {
       return true
     }
   }
 
-  // 7. Return false.
+  // 6. Return false.
   return false
 }
 
 // https://w3c.github.io/webappsec-subresource-integrity/#grammardef-hash-with-options
 // https://www.w3.org/TR/CSP2/#source-list-syntax
 // https://www.rfc-editor.org/rfc/rfc5234#appendix-B.1
-const parseHashWithOptions = /(?<algo>sha256|sha384|sha512)-((?<hash>[A-Za-z0-9+/]+|[A-Za-z0-9_-]+)={0,2}(?:\s|$)( +[!-~]*)?)?/i
+const parseHashWithOptions = /((?<algo>sha256|sha384|sha512)-(?<hash>[A-z0-9+/]{1}.*={0,2}))( +[\x21-\x7e]?)?/i
 
 /**
  * @see https://w3c.github.io/webappsec-subresource-integrity/#parse-metadata
@@ -75641,6 +75510,8 @@ function parseMetadata (metadata) {
   // 2. Let empty be equal to true.
   let empty = true
 
+  const supportedHashes = crypto.getHashes()
+
   // 3. For each token returned by splitting metadata on spaces:
   for (const token of metadata.split(' ')) {
     // 1. Set empty to false.
@@ -75650,11 +75521,7 @@ function parseMetadata (metadata) {
     const parsedToken = parseHashWithOptions.exec(token)
 
     // 3. If token does not parse, continue to the next token.
-    if (
-      parsedToken === null ||
-      parsedToken.groups === undefined ||
-      parsedToken.groups.algo === undefined
-    ) {
+    if (parsedToken === null || parsedToken.groups === undefined) {
       // Note: Chromium blocks the request at this point, but Firefox
       // gives a warning that an invalid integrity was given. The
       // correct behavior is to ignore these, and subsequently not
@@ -75663,11 +75530,11 @@ function parseMetadata (metadata) {
     }
 
     // 4. Let algorithm be the hash-algo component of token.
-    const algorithm = parsedToken.groups.algo.toLowerCase()
+    const algorithm = parsedToken.groups.algo
 
     // 5. If algorithm is a hash function recognized by the user
     //    agent, add the parsed token to result.
-    if (supportedHashes.includes(algorithm)) {
+    if (supportedHashes.includes(algorithm.toLowerCase())) {
       result.push(parsedToken.groups)
     }
   }
@@ -75678,82 +75545,6 @@ function parseMetadata (metadata) {
   }
 
   return result
-}
-
-/**
- * @param {{ algo: 'sha256' | 'sha384' | 'sha512' }[]} metadataList
- */
-function getStrongestMetadata (metadataList) {
-  // Let algorithm be the algo component of the first item in metadataList.
-  // Can be sha256
-  let algorithm = metadataList[0].algo
-  // If the algorithm is sha512, then it is the strongest
-  // and we can return immediately
-  if (algorithm[3] === '5') {
-    return algorithm
-  }
-
-  for (let i = 1; i < metadataList.length; ++i) {
-    const metadata = metadataList[i]
-    // If the algorithm is sha512, then it is the strongest
-    // and we can break the loop immediately
-    if (metadata.algo[3] === '5') {
-      algorithm = 'sha512'
-      break
-    // If the algorithm is sha384, then a potential sha256 or sha384 is ignored
-    } else if (algorithm[3] === '3') {
-      continue
-    // algorithm is sha256, check if algorithm is sha384 and if so, set it as
-    // the strongest
-    } else if (metadata.algo[3] === '3') {
-      algorithm = 'sha384'
-    }
-  }
-  return algorithm
-}
-
-function filterMetadataListByAlgorithm (metadataList, algorithm) {
-  if (metadataList.length === 1) {
-    return metadataList
-  }
-
-  let pos = 0
-  for (let i = 0; i < metadataList.length; ++i) {
-    if (metadataList[i].algo === algorithm) {
-      metadataList[pos++] = metadataList[i]
-    }
-  }
-
-  metadataList.length = pos
-
-  return metadataList
-}
-
-/**
- * Compares two base64 strings, allowing for base64url
- * in the second string.
- *
-* @param {string} actualValue always base64
- * @param {string} expectedValue base64 or base64url
- * @returns {boolean}
- */
-function compareBase64Mixed (actualValue, expectedValue) {
-  if (actualValue.length !== expectedValue.length) {
-    return false
-  }
-  for (let i = 0; i < actualValue.length; ++i) {
-    if (actualValue[i] !== expectedValue[i]) {
-      if (
-        (actualValue[i] === '+' && expectedValue[i] === '-') ||
-        (actualValue[i] === '/' && expectedValue[i] === '_')
-      ) {
-        continue
-      }
-      return false
-    }
-  }
-
-  return true
 }
 
 // https://w3c.github.io/webappsec-upgrade-insecure-requests/#upgrade-request
@@ -76171,8 +75962,7 @@ module.exports = {
   urlHasHttpsScheme,
   urlIsHttpHttpsScheme,
   readAllBytes,
-  normalizeMethodRecord,
-  parseMetadata
+  normalizeMethodRecord
 }
 
 
@@ -78259,17 +78049,12 @@ function parseLocation (statusCode, headers) {
 
 // https://tools.ietf.org/html/rfc7231#section-6.4.4
 function shouldRemoveHeader (header, removeContent, unknownOrigin) {
-  if (header.length === 4) {
-    return util.headerNameToString(header) === 'host'
-  }
-  if (removeContent && util.headerNameToString(header).startsWith('content-')) {
-    return true
-  }
-  if (unknownOrigin && (header.length === 13 || header.length === 6 || header.length === 19)) {
-    const name = util.headerNameToString(header)
-    return name === 'authorization' || name === 'cookie' || name === 'proxy-authorization'
-  }
-  return false
+  return (
+    (header.length === 4 && header.toString().toLowerCase() === 'host') ||
+    (removeContent && header.toString().toLowerCase().indexOf('content-') === 0) ||
+    (unknownOrigin && header.length === 13 && header.toString().toLowerCase() === 'authorization') ||
+    (unknownOrigin && header.length === 6 && header.toString().toLowerCase() === 'cookie')
+  )
 }
 
 // https://tools.ietf.org/html/rfc7231#section-6.4

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -156,6 +156,21 @@ steps:
 - run: java -cp java HelloWorldApp
 ```
 
+The JetBrains installer uses the GitHub API to fetch the latest version. If you believe your project is going to be running into rate limits, you can provide a
+GitHub token to the action to increase the rate limit. Set the `GITHUB_TOKEN` environment variable to the value of your GitHub token in the workflow file.
+
+```yaml
+steps:
+- uses: actions/checkout@v4
+- uses: actions/setup-java@v4
+  with:
+    distribution: 'jetbrains'
+    java-version: '11'
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+- run: java -cp java HelloWorldApp
+```
+
 ## Installing custom Java package type
 ```yaml
 steps:

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -8,6 +8,7 @@
   - [Amazon Corretto](#Amazon-Corretto)
   - [Oracle](#Oracle)
   - [Alibaba Dragonwell](#Alibaba-Dragonwell)
+  - [JetBrains](#JetBrains)
 - [Installing custom Java package type](#Installing-custom-Java-package-type)
 - [Installing custom Java architecture](#Installing-custom-Java-architecture)
 - [Installing custom Java distribution from local file](#Installing-Java-from-local-file)
@@ -139,6 +140,19 @@ steps:
   with:
     distribution: 'dragonwell'
     java-version: '8'
+- run: java -cp java HelloWorldApp
+```
+
+### JetBrains
+**NOTE:** JetBrains only provides jdk and is only available for LTS versions 11 or later.
+
+```yaml
+steps:
+- uses: actions/checkout@v4
+- uses: actions/setup-java@v4
+  with:
+    distribution: 'jetbrains'
+    java-version: '11'
 - run: java -cp java HelloWorldApp
 ```
 

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -173,7 +173,8 @@ steps:
 ```
 
 ### JetBrains
-**NOTE:** JetBrains only provides jdk and is only available for LTS versions 11 or later. JCEF is not bundled with this distribution.
+
+**NOTE:** JetBrains is only available for LTS versions on 11 or later.
 
 ```yaml
 steps:
@@ -194,11 +195,21 @@ steps:
 - uses: actions/setup-java@v4
   with:
     distribution: 'jetbrains'
-    java-version: '11'
+    java-version: '17'
+    package-type: 'jdk' # optional (jdk, jre, jdk+jcef, jre+jcef, jdk+ft, or jre+ft) - defaults to jdk
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 - run: java -cp java HelloWorldApp
 ```
+
+JetBrains Package Types (as shown in the [releases page](https://github.com/JetBrains/JetBrainsRuntime/releases/)):
+
+- `jdk` - JBRSDK
+- `jre` - JBR (Vanilla)
+- `jdk+jcef` - JBRSDK with JCEF
+- `jre+jcef` - JBR with JCEF
+- `jdk+ft` - JBRSDK (FreeType)
+- `jre+ft` - JBR (FreeType)
 
 ### GraalVM
 **NOTE:** Oracle GraalVM is only available for JDK 17 and later.

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -174,7 +174,14 @@ steps:
 
 ### JetBrains
 
-**NOTE:** JetBrains is only available for LTS versions on 11 or later.
+**NOTE:** JetBrains is only available for LTS versions on 11 or later (11, 17, 21, etc.).
+
+Not all minor LTS versions are guarenteed to be available, since JetBrains considers what to ship IntelliJ IDEA with, most commonly on JDK 11.
+For example, `11.0.24` is not available but `11.0.16` is.
+
+Versions are based on the GitHub tag on the [JetBrains Runtime releases page](https://github.com/JetBrains/JetBrainsRuntime/releases). As such, some tags may be formatted with
+underscores (`11_0_13`) and others with dots (`11.0.13`). Conversion is automatically applied to the dot version format, so `11.0.13` is equivalent to `11_0_13`. Dot format
+is more encouraged for consistency, but both are supported.
 
 ```yaml
 steps:
@@ -202,7 +209,8 @@ steps:
 - run: java -cp java HelloWorldApp
 ```
 
-JetBrains Package Types (as shown in the [releases page](https://github.com/JetBrains/JetBrainsRuntime/releases/)):
+You can specify your package type (as shown in the [releases page](https://github.com/JetBrains/JetBrainsRuntime/releases/)) in the `package-type` parameter. 
+The available package types are:
 
 - `jdk` - JBRSDK
 - `jre` - JBR (Vanilla)

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -173,7 +173,7 @@ steps:
 ```
 
 ### JetBrains
-**NOTE:** JetBrains only provides jdk and is only available for LTS versions 11 or later.
+**NOTE:** JetBrains only provides jdk and is only available for LTS versions 11 or later. JCEF is not bundled with this distribution.
 
 ```yaml
 steps:

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -179,10 +179,6 @@ steps:
 Not all minor LTS versions are guarenteed to be available, since JetBrains considers what to ship IntelliJ IDEA with, most commonly on JDK 11.
 For example, `11.0.24` is not available but `11.0.16` is.
 
-Versions are based on the GitHub tag on the [JetBrains Runtime releases page](https://github.com/JetBrains/JetBrainsRuntime/releases). As such, some tags may be formatted with
-underscores (`11_0_13`) and others with dots (`11.0.13`). Conversion is automatically applied to the dot version format, so `11.0.13` is equivalent to `11_0_13`. Dot format
-is more encouraged for consistency, but both are supported.
-
 ```yaml
 steps:
 - uses: actions/checkout@v4
@@ -203,13 +199,13 @@ steps:
   with:
     distribution: 'jetbrains'
     java-version: '17'
-    package-type: 'jdk' # optional (jdk, jre, jdk+jcef, jre+jcef, jdk+ft, or jre+ft) - defaults to jdk
+    java-package: 'jdk' # optional (jdk, jre, jdk+jcef, jre+jcef, jdk+ft, or jre+ft) - defaults to jdk
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 - run: java -cp java HelloWorldApp
 ```
 
-You can specify your package type (as shown in the [releases page](https://github.com/JetBrains/JetBrainsRuntime/releases/)) in the `package-type` parameter. 
+You can specify your package type (as shown in the [releases page](https://github.com/JetBrains/JetBrainsRuntime/releases/)) in the `java-package` parameter. 
 The available package types are:
 
 - `jdk` - JBRSDK

--- a/package-lock.json
+++ b/package-lock.json
@@ -2495,10 +2495,11 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4322,12 +4323,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {

--- a/src/distributions/distribution-factory.ts
+++ b/src/distributions/distribution-factory.ts
@@ -12,7 +12,7 @@ import {OracleDistribution} from './oracle/installer';
 import {DragonwellDistribution} from './dragonwell/installer';
 import {SapMachineDistribution} from './sapmachine/installer';
 import {GraalVMDistribution} from './graalvm/installer';
-import {JetBrainsDistribution} from "./jetbrains/installer";
+import {JetBrainsDistribution} from './jetbrains/installer';
 
 enum JavaDistribution {
   Adopt = 'adopt',

--- a/src/distributions/distribution-factory.ts
+++ b/src/distributions/distribution-factory.ts
@@ -10,6 +10,7 @@ import {SemeruDistribution} from './semeru/installer';
 import {CorrettoDistribution} from './corretto/installer';
 import {OracleDistribution} from './oracle/installer';
 import {DragonwellDistribution} from './dragonwell/installer';
+import {JetBrainsDistribution} from "./jetbrains/installer";
 
 enum JavaDistribution {
   Adopt = 'adopt',
@@ -65,6 +66,8 @@ export function getJavaDistribution(
       return new OracleDistribution(installerOptions);
     case JavaDistribution.Dragonwell:
       return new DragonwellDistribution(installerOptions);
+    case JavaDistribution.JetBrains:
+      return new JetBrainsDistribution(installerOptions);
     default:
       return null;
   }

--- a/src/distributions/distribution-factory.ts
+++ b/src/distributions/distribution-factory.ts
@@ -23,7 +23,8 @@ enum JavaDistribution {
   Semeru = 'semeru',
   Corretto = 'corretto',
   Oracle = 'oracle',
-  Dragonwell = 'dragonwell'
+  Dragonwell = 'dragonwell',
+  JetBrains = 'jetbrains',
 }
 
 export function getJavaDistribution(

--- a/src/distributions/jetbrains/installer.ts
+++ b/src/distributions/jetbrains/installer.ts
@@ -12,11 +12,8 @@ import {
   JavaInstallerOptions,
   JavaInstallerResults
 } from '../base-models';
-import {
-  extractJdkFile,
-  isVersionSatisfies
-} from '../../util';
-import {IncomingHttpHeaders, OutgoingHttpHeaders} from "http";
+import {extractJdkFile, isVersionSatisfies} from '../../util';
+import {OutgoingHttpHeaders} from 'http';
 
 export class JetBrainsDistribution extends JavaBase {
   constructor(installerOptions: JavaInstallerOptions) {
@@ -46,7 +43,9 @@ export class JetBrainsDistribution extends JavaBase {
     const resolvedFullVersion =
       satisfiedVersions.length > 0 ? satisfiedVersions[0] : null;
     if (!resolvedFullVersion) {
-      const availableOptions = versionsRaw.map(item => item.tag_name).join(', ');
+      const availableOptions = versionsRaw
+        .map(item => item.tag_name)
+        .join(', ');
       const availableOptionsMessage = availableOptions
         ? `\nAvailable versions: ${availableOptions}`
         : '';
@@ -68,7 +67,7 @@ export class JetBrainsDistribution extends JavaBase {
     const javaArchivePath = await tc.downloadTool(javaRelease.url);
 
     core.info(`Extracting Java archive...`);
-    const extractedJavaPath = await extractJdkFile(javaArchivePath, "tar.gz");
+    const extractedJavaPath = await extractJdkFile(javaArchivePath, 'tar.gz');
 
     const archiveName = fs.readdirSync(extractedJavaPath)[0];
     const archivePath = path.join(extractedJavaPath, archiveName);
@@ -98,7 +97,7 @@ export class JetBrainsDistribution extends JavaBase {
     const rawVersions: IJetBrainsRawVersion[] = [];
     while (true) {
       const requestArguments = `per_page=100&page=${page_index}`;
-      const requestHeaders: OutgoingHttpHeaders = {}
+      const requestHeaders: OutgoingHttpHeaders = {};
 
       if (process.env.GITHUB_TOKEN) {
         requestHeaders['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
@@ -108,15 +107,11 @@ export class JetBrainsDistribution extends JavaBase {
 
       if (core.isDebug() && page_index === 1) {
         // url is identical except page_index so print it once for debug
-        core.debug(
-          `Gathering available versions from '${rawUrl}'`
-        );
+        core.debug(`Gathering available versions from '${rawUrl}'`);
       }
 
       const paginationPage = (
-        await this.http.getJson<IJetBrainsRawVersion[]>(
-          rawUrl, requestHeaders
-        )
+        await this.http.getJson<IJetBrainsRawVersion[]>(rawUrl, requestHeaders)
       ).result;
       if (!paginationPage || paginationPage.length === 0) {
         // break infinity loop because we have reached end of pagination
@@ -145,14 +140,14 @@ export class JetBrainsDistribution extends JavaBase {
           vstring = tag.substring(2).replace(/-/g, '').replace(/_/g, '.');
           break;
         case undefined: // 0
-          vstring = tag.substring(3)
+          vstring = tag.substring(3);
           break;
         default:
-          throw new Error(`Unrecognized tag_name: ${tag}`)
+          throw new Error(`Unrecognized tag_name: ${tag}`);
       }
 
       const vsplit = vstring.split('b');
-      const semver = vsplit[0].replace(/_/g, '.');
+      const semver = vsplit[0];
       const build = +vsplit[1];
 
       // Construct URL

--- a/src/distributions/jetbrains/installer.ts
+++ b/src/distributions/jetbrains/installer.ts
@@ -98,10 +98,12 @@ export class JetBrainsDistribution extends JavaBase {
     const rawVersions: IJetBrainsRawVersion[] = [];
     while (true) {
       const requestArguments = `per_page=100&page=${page_index}`;
-      const requestHeaders: OutgoingHttpHeaders = {
-        "User-Agent": "jetbrains-jbr-installer",
-        "Authorization": `Token ${process.env.GITHUB_TOKEN}`,
+      const requestHeaders: OutgoingHttpHeaders = {}
+
+      if (process.env.GITHUB_TOKEN) {
+        requestHeaders['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
       }
+
       const rawUrl = `https://api.github.com/repos/JetBrains/JetBrainsRuntime/releases?${requestArguments}`;
 
       if (core.isDebug() && page_index === 1) {

--- a/src/distributions/jetbrains/installer.ts
+++ b/src/distributions/jetbrains/installer.ts
@@ -68,9 +68,7 @@ export class JetBrainsDistribution extends JavaBase {
     const javaArchivePath = await tc.downloadTool(javaRelease.url);
 
     core.info(`Extracting Java archive...`);
-    const extension = getDownloadArchiveExtension();
-
-    const extractedJavaPath = await extractJdkFile(javaArchivePath, extension);
+    const extractedJavaPath = await extractJdkFile(javaArchivePath);
 
     const archiveName = fs.readdirSync(extractedJavaPath)[0];
     const archivePath = path.join(extractedJavaPath, archiveName);

--- a/src/distributions/jetbrains/installer.ts
+++ b/src/distributions/jetbrains/installer.ts
@@ -1,0 +1,187 @@
+import * as core from '@actions/core';
+import * as tc from '@actions/tool-cache';
+
+import fs from 'fs';
+import path from 'path';
+import semver from 'semver';
+
+import {JavaBase} from '../base-installer';
+import {IJetBrainsRawVersion, IJetBrainsVersion} from './models';
+import {
+  JavaDownloadRelease,
+  JavaInstallerOptions,
+  JavaInstallerResults
+} from '../base-models';
+import {
+  extractJdkFile,
+  getDownloadArchiveExtension,
+  isVersionSatisfies
+} from '../../util';
+
+export class JetBrainsDistribution extends JavaBase {
+  constructor(installerOptions: JavaInstallerOptions) {
+    super('JetBrains', installerOptions);
+  }
+
+  protected async findPackageForDownload(
+    range: string
+  ): Promise<JavaDownloadRelease> {
+    const versionsRaw = await this.getAvailableVersions();
+
+    const versions = versionsRaw.map(v => {
+      const formattedVersion = `${v.semver}+${v.build}`;
+
+      return {
+        version: formattedVersion,
+        url: v.url
+      } as JavaDownloadRelease;
+    });
+
+    const satisfiedVersions = versions
+      .filter(item => isVersionSatisfies(range, item.version))
+      .sort((a, b) => {
+        return -semver.compareBuild(a.version, b.version);
+      });
+
+    const resolvedFullVersion =
+      satisfiedVersions.length > 0 ? satisfiedVersions[0] : null;
+    if (!resolvedFullVersion) {
+      const availableOptions = versionsRaw.map(item => item.tag_name).join(', ');
+      const availableOptionsMessage = availableOptions
+        ? `\nAvailable versions: ${availableOptions}`
+        : '';
+      throw new Error(
+        `Could not find satisfied version for SemVer '${range}'. ${availableOptionsMessage}`
+      );
+    }
+
+    return resolvedFullVersion;
+  }
+
+  protected async downloadTool(
+    javaRelease: JavaDownloadRelease
+  ): Promise<JavaInstallerResults> {
+    core.info(
+      `Downloading Java ${javaRelease.version} (${this.distribution}) from ${javaRelease.url} ...`
+    );
+
+    const javaArchivePath = await tc.downloadTool(javaRelease.url);
+
+    core.info(`Extracting Java archive...`);
+    const extension = getDownloadArchiveExtension();
+
+    const extractedJavaPath = await extractJdkFile(javaArchivePath, extension);
+
+    const archiveName = fs.readdirSync(extractedJavaPath)[0];
+    const archivePath = path.join(extractedJavaPath, archiveName);
+    const version = this.getToolcacheVersionName(javaRelease.version);
+
+    const javaPath = await tc.cacheDir(
+      archivePath,
+      this.toolcacheFolderName,
+      version,
+      this.architecture
+    );
+
+    return {version: javaRelease.version, path: javaPath};
+  }
+
+  private async getAvailableVersions(): Promise<IJetBrainsVersion[]> {
+    const platform = this.getPlatformOption();
+    const arch = this.distributionArchitecture();
+
+    if (core.isDebug()) {
+      console.time('Retrieving available versions for JBR took'); // eslint-disable-line no-console
+    }
+
+    // need to iterate through all pages to retrieve the list of all versions
+    // GitHub API doesn't provide way to retrieve the count of pages to iterate so infinity loop
+    let page_index = 1;
+    const rawVersions: IJetBrainsRawVersion[] = [];
+    while (true) {
+      const requestArguments = `per_page=100&page=${page_index}`;
+      const rawUrl = `https://api.github.com/repos/JetBrains/JetBrainsRuntime/releases?${requestArguments}`;
+
+      if (core.isDebug() && page_index === 1) {
+        // url is identical except page_index so print it once for debug
+        core.debug(
+          `Gathering available versions from '${rawUrl}'`
+        );
+      }
+
+      const paginationPage = (
+        await this.http.getJson<IJetBrainsRawVersion[]>(
+          rawUrl
+        )
+      ).result;
+      if (!paginationPage || paginationPage.length === 0) {
+        // break infinity loop because we have reached end of pagination
+        break;
+      }
+
+      rawVersions.push(...paginationPage);
+      page_index++;
+    }
+
+    const versions = rawVersions.map(v => {
+      // Release tags look like one of these:
+      // jbr-release-21.0.3b465.3
+      // jb11_0_11-b87.7
+      // jbr11_0_15b2043.56
+      const tag = v.tag_name;
+
+      // Extract version string
+      let vstring;
+
+      switch (tag.match(/-/g)?.length) {
+        case 2:
+          vstring = tag.substring(tag.lastIndexOf('-') + 1);
+          break;
+        case 1:
+          vstring = tag.substring(2).replace(/-/g, '').replace(/_/g, '.');
+          break;
+        case undefined: // 0
+          vstring = tag.substring(3)
+          break;
+        default:
+          throw new Error(`Unrecognized tag_name: ${tag}`)
+      }
+
+      const vsplit = vstring.split('b');
+      const semver = vsplit[0].replace(/_/g, '.');
+      const build = +vsplit[1];
+
+      // Construct URL
+      const url = `https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-${semver}-${platform}-${arch}-b${build}.tar.gz`;
+
+      return {
+        tag_name: tag,
+        semver: semver,
+        build: build,
+        url: url
+      } as IJetBrainsVersion;
+    });
+
+    if (core.isDebug()) {
+      core.startGroup('Print information about available versions');
+      console.timeEnd('Retrieving available versions for JBR took'); // eslint-disable-line no-console
+      core.debug(`Available versions: [${versions.length}]`);
+      core.debug(versions.map(item => item.tag_name).join(', '));
+      core.endGroup();
+    }
+
+    return versions;
+  }
+
+  private getPlatformOption(): string {
+    // Jetbrains has own platform names so need to map them
+    switch (process.platform) {
+      case 'darwin':
+        return 'osx';
+      case 'win32':
+        return 'windows';
+      default:
+        return process.platform;
+    }
+  }
+}

--- a/src/distributions/jetbrains/installer.ts
+++ b/src/distributions/jetbrains/installer.ts
@@ -68,7 +68,7 @@ export class JetBrainsDistribution extends JavaBase {
     const javaArchivePath = await tc.downloadTool(javaRelease.url);
 
     core.info(`Extracting Java archive...`);
-    const extractedJavaPath = await extractJdkFile(javaArchivePath);
+    const extractedJavaPath = await extractJdkFile(javaArchivePath, "tar.gz");
 
     const archiveName = fs.readdirSync(extractedJavaPath)[0];
     const archivePath = path.join(extractedJavaPath, archiveName);

--- a/src/distributions/jetbrains/installer.ts
+++ b/src/distributions/jetbrains/installer.ts
@@ -122,7 +122,7 @@ export class JetBrainsDistribution extends JavaBase {
       page_index++;
     }
 
-    const versions = rawVersions.map(v => {
+    const versions0 = rawVersions.map(v => {
       // Release tags look like one of these:
       // jbr-release-21.0.3b465.3
       // jb11_0_11-b87.7
@@ -159,6 +159,11 @@ export class JetBrainsDistribution extends JavaBase {
         build: build,
         url: url
       } as IJetBrainsVersion;
+    });
+
+    const versions = versions0.filter(async i => {
+      const res = await this.http.head(i.url);
+      return res.message.statusCode === 200;
     });
 
     if (core.isDebug()) {

--- a/src/distributions/jetbrains/installer.ts
+++ b/src/distributions/jetbrains/installer.ts
@@ -138,7 +138,7 @@ export class JetBrainsDistribution extends JavaBase {
           vstring = tag.substring(tag.lastIndexOf('-') + 1);
           break;
         case 1:
-          vstring = tag.substring(2).replace(/-/g, '').replace(/_/g, '.');
+          vstring = tag.substring(2).replace(/-/g, '');
           break;
         case undefined: // 0
           vstring = tag.substring(3);

--- a/src/distributions/jetbrains/installer.ts
+++ b/src/distributions/jetbrains/installer.ts
@@ -96,12 +96,14 @@ export class JetBrainsDistribution extends JavaBase {
     // GitHub API doesn't provide way to retrieve the count of pages to iterate so infinity loop
     let page_index = 1;
     const rawVersions: IJetBrainsRawVersion[] = [];
+    const bearerToken = process.env.GITHUB_TOKEN;
+
     while (true) {
       const requestArguments = `per_page=100&page=${page_index}`;
       const requestHeaders: OutgoingHttpHeaders = {};
 
-      if (process.env.GITHUB_TOKEN) {
-        requestHeaders['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
+      if (bearerToken) {
+        requestHeaders['Authorization'] = `Bearer ${bearerToken}`;
       }
 
       const rawUrl = `https://api.github.com/repos/JetBrains/JetBrainsRuntime/releases?${requestArguments}`;
@@ -122,6 +124,10 @@ export class JetBrainsDistribution extends JavaBase {
       rawVersions.push(...paginationPage);
       page_index++;
     }
+
+    // Add versions not available from the API but are downloadable
+    const hidden = ['11_0_10b1145.115', '11_0_11b1341.60'];
+    rawVersions.push(...hidden.map(tag => ({tag_name: tag, name: tag})));
 
     const versions0 = rawVersions.map(async v => {
       // Release tags look like one of these:

--- a/src/distributions/jetbrains/installer.ts
+++ b/src/distributions/jetbrains/installer.ts
@@ -2,9 +2,8 @@ import * as core from '@actions/core';
 import * as tc from '@actions/tool-cache';
 
 import fs from 'fs';
-import path, {resolve} from 'path';
+import path from 'path';
 import semver from 'semver';
-import https from 'https';
 
 import {JavaBase} from '../base-installer';
 import {IJetBrainsRawVersion, IJetBrainsVersion} from './models';
@@ -156,7 +155,7 @@ export class JetBrainsDistribution extends JavaBase {
 
       return {
         tag_name: tag,
-        semver: semver,
+        semver: semver.replace(/_/g, '.'),
         build: build,
         url: url
       } as IJetBrainsVersion;
@@ -166,7 +165,7 @@ export class JetBrainsDistribution extends JavaBase {
       core.startGroup('Print information about available versions');
       console.timeEnd('Retrieving available versions for JBR took'); // eslint-disable-line no-console
       core.debug(`Available versions: [${versions.length}]`);
-      core.debug(versions.map(item => item.tag_name).join(', '));
+      core.debug(versions.map(item => item.semver).join(', '));
       core.endGroup();
     }
 

--- a/src/distributions/jetbrains/installer.ts
+++ b/src/distributions/jetbrains/installer.ts
@@ -2,8 +2,9 @@ import * as core from '@actions/core';
 import * as tc from '@actions/tool-cache';
 
 import fs from 'fs';
-import path from 'path';
+import path, {resolve} from 'path';
 import semver from 'semver';
+import https from 'https';
 
 import {JavaBase} from '../base-installer';
 import {IJetBrainsRawVersion, IJetBrainsVersion} from './models';
@@ -151,7 +152,7 @@ export class JetBrainsDistribution extends JavaBase {
       const build = +vsplit[1];
 
       // Construct URL
-      const url = `https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_jcef-${semver}-${platform}-${arch}-b${build}.tar.gz`;
+      const url = `https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-${semver}-${platform}-${arch}-b${build}.tar.gz`;
 
       return {
         tag_name: tag,

--- a/src/distributions/jetbrains/installer.ts
+++ b/src/distributions/jetbrains/installer.ts
@@ -14,9 +14,9 @@ import {
 } from '../base-models';
 import {
   extractJdkFile,
-  getDownloadArchiveExtension,
   isVersionSatisfies
 } from '../../util';
+import {IncomingHttpHeaders, OutgoingHttpHeaders} from "http";
 
 export class JetBrainsDistribution extends JavaBase {
   constructor(installerOptions: JavaInstallerOptions) {
@@ -98,6 +98,10 @@ export class JetBrainsDistribution extends JavaBase {
     const rawVersions: IJetBrainsRawVersion[] = [];
     while (true) {
       const requestArguments = `per_page=100&page=${page_index}`;
+      const requestHeaders: OutgoingHttpHeaders = {
+        "User-Agent": "jetbrains-jbr-installer",
+        "Authorization": `Token ${process.env.GITHUB_TOKEN}`,
+      }
       const rawUrl = `https://api.github.com/repos/JetBrains/JetBrainsRuntime/releases?${requestArguments}`;
 
       if (core.isDebug() && page_index === 1) {
@@ -109,7 +113,7 @@ export class JetBrainsDistribution extends JavaBase {
 
       const paginationPage = (
         await this.http.getJson<IJetBrainsRawVersion[]>(
-          rawUrl
+          rawUrl, requestHeaders
         )
       ).result;
       if (!paginationPage || paginationPage.length === 0) {

--- a/src/distributions/jetbrains/installer.ts
+++ b/src/distributions/jetbrains/installer.ts
@@ -152,7 +152,7 @@ export class JetBrainsDistribution extends JavaBase {
       const build = +vsplit[1];
 
       // Construct URL
-      const url = `https://cache-redirector.jetbrains.com/intellij-jbr/jbr-${semver}-${platform}-${arch}-b${build}.tar.gz`;
+      const url = `https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk_jcef-${semver}-${platform}-${arch}-b${build}.tar.gz`;
 
       return {
         tag_name: tag,

--- a/src/distributions/jetbrains/installer.ts
+++ b/src/distributions/jetbrains/installer.ts
@@ -152,7 +152,7 @@ export class JetBrainsDistribution extends JavaBase {
       const build = +vsplit[1];
 
       // Construct URL
-      const url = `https://cache-redirector.jetbrains.com/intellij-jbr/jbr_jcef-${semver}-${platform}-${arch}-b${build}.tar.gz`;
+      const url = `https://cache-redirector.jetbrains.com/intellij-jbr/jbr-${semver}-${platform}-${arch}-b${build}.tar.gz`;
 
       return {
         tag_name: tag,

--- a/src/distributions/jetbrains/models.ts
+++ b/src/distributions/jetbrains/models.ts
@@ -1,0 +1,13 @@
+// Raw Model from https://api.github.com/repos/JetBrains/JetBrainsRuntime/releases
+
+export interface IJetBrainsRawVersion {
+  tag_name: string;
+  name: string;
+}
+
+export interface IJetBrainsVersion {
+  tag_name: string;
+  semver: string;
+  build: number;
+  url: string;
+}


### PR DESCRIPTION
**Current Workaround**
```yml
- name: Setup JBR 21
  uses: gmitch215/setup-java@4e56c31b28053b7081e102121153633227d6dd8e
  with:
    distribution: 'jetbrains'
    java-version: 21
    cache: 'gradle'
  # For GitHub API (use if you believe you'd run into rate limits)
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
````

**Description:**
This PR adds support for the [JetBrains Runtime](https://github.com/JetBrains/JetBrainsRuntime), which is required in dependencies like [jewel](https://github.com/JetBrains/jewel) and useful for [Compose Multiplatform](https://www.jetbrains.com/lp/compose-multiplatform/).

The PR uses the binaries listed in `Binaries for Developers` , using the `JBRSDK` flavor as shown in the [releases page](https://github.com/JetBrains/JetBrainsRuntime/releases) for the default flavor `jdk`. Alternative flavors include `jdk+jcef` and `jdk+ft` with `jre` counterparts. 

It uses the GitHub API to find and parse versions, then calculates the URL using `cache-redirector.jetbrains.com` with the parsed SemVer, OS, Arch, and build number, which all output a `.tar.gz` file. Left a few comments in there for maintainability. Some tags have inconsistent naming conventions, or have been removed from public view for various reasons, so it will filter out those versions.

Since this uses the GitHub API, you can optionally specify a `GITHUB_TOKEN` environmental variable to increase your rate limit.

**Related issue:**
- Closes #399
- Closes #585 (Duplicate)

**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.

**Notes**
Tested using `jetbrains-installer.test.ts`. Most of the tests were copied from other installers, but some I couldn't figure out how to bring over, so additional work may be required. I also copied `downloadTool` from the Temurin installer.

I also executed `npm run build` for `dist/setup/index.js`. I think something else was also thrown because I was on TypeScript 5.3, so I'm not sure how that will affect `ncc`.