### PR TITLE
fix: add arch to cache key

### DIFF
--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -88116,7 +88116,7 @@ function computeCacheKey(packageManager, cacheDependencyPath) {
         if (!fileHash) {
             throw new Error(`No file in ${process.cwd()} matched to [${pattern}], make sure you have checked out the target repository`);
         }
-        return `${CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${packageManager.id}-${fileHash}`;
+        return `${CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${process.arch}-${packageManager.id}-${fileHash}`;
     });
 }
 /**

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -98,7 +98,7 @@ async function computeCacheKey(
       `No file in ${process.cwd()} matched to [${pattern}], make sure you have checked out the target repository`
     );
   }
-  return `${CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${packageManager.id}-${fileHash}`;
+  return `${CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${process.arch}-${packageManager.id}-${fileHash}`;
 }
 
 /**


### PR DESCRIPTION
**Description:**

GitHub has added the arm64 runner, so arch should be used as part of the cache key. Otherwise, if there are `macos-13` `macos-14` running at the same time, the late executor will get the wrong cache.

**Related issue:**

https://github.com/actions/setup-python/pull/896

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.