### PR TITLE
Improve archive extraction on windows runners without powershell core and Update micromatch dependency

### DIFF
--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -88470,7 +88470,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getGitHubHttpHeaders = exports.convertVersionToSemver = exports.getVersionFromFileContent = exports.isCacheFeatureAvailable = exports.isGhes = exports.isJobStatusSuccess = exports.getToolcachePath = exports.isVersionSatisfies = exports.getDownloadArchiveExtension = exports.extractJdkFile = exports.getVersionFromToolcachePath = exports.getBooleanInput = exports.getTempDir = void 0;
+exports.renameWinArchive = exports.getGitHubHttpHeaders = exports.convertVersionToSemver = exports.getVersionFromFileContent = exports.isCacheFeatureAvailable = exports.isGhes = exports.isJobStatusSuccess = exports.getToolcachePath = exports.isVersionSatisfies = exports.getDownloadArchiveExtension = exports.extractJdkFile = exports.getVersionFromToolcachePath = exports.getBooleanInput = exports.getTempDir = void 0;
 const os_1 = __importDefault(__nccwpck_require__(2037));
 const path_1 = __importDefault(__nccwpck_require__(1017));
 const fs = __importStar(__nccwpck_require__(7147));
@@ -88630,6 +88630,17 @@ function getGitHubHttpHeaders() {
     return headers;
 }
 exports.getGitHubHttpHeaders = getGitHubHttpHeaders;
+// Rename archive to add extension because after downloading
+// archive does not contain extension type and it leads to some issues
+// on Windows runners without PowerShell Core.
+//
+// For default PowerShell Windows it should contain extension type to unpack it.
+function renameWinArchive(javaArchivePath) {
+    const javaArchivePathRenamed = `${javaArchivePath}.zip`;
+    fs.renameSync(javaArchivePath, javaArchivePathRenamed);
+    return javaArchivePathRenamed;
+}
+exports.renameWinArchive = renameWinArchive;
 
 
 /***/ }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -4322,12 +4322,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {

--- a/src/distributions/adopt/installer.ts
+++ b/src/distributions/adopt/installer.ts
@@ -15,7 +15,8 @@ import {
 import {
   extractJdkFile,
   getDownloadArchiveExtension,
-  isVersionSatisfies
+  isVersionSatisfies,
+  renameWinArchive
 } from '../../util';
 
 export enum AdoptImplementation {
@@ -73,11 +74,13 @@ export class AdoptDistribution extends JavaBase {
     core.info(
       `Downloading Java ${javaRelease.version} (${this.distribution}) from ${javaRelease.url} ...`
     );
-    const javaArchivePath = await tc.downloadTool(javaRelease.url);
+    let javaArchivePath = await tc.downloadTool(javaRelease.url);
 
     core.info(`Extracting Java archive...`);
     const extension = getDownloadArchiveExtension();
-
+    if (process.platform === 'win32') {
+      javaArchivePath = renameWinArchive(javaArchivePath);
+    }
     const extractedJavaPath = await extractJdkFile(javaArchivePath, extension);
 
     const archiveName = fs.readdirSync(extractedJavaPath)[0];

--- a/src/distributions/corretto/installer.ts
+++ b/src/distributions/corretto/installer.ts
@@ -5,7 +5,8 @@ import path from 'path';
 import {
   extractJdkFile,
   getDownloadArchiveExtension,
-  convertVersionToSemver
+  convertVersionToSemver,
+  renameWinArchive
 } from '../../util';
 import {JavaBase} from '../base-installer';
 import {
@@ -29,14 +30,14 @@ export class CorrettoDistribution extends JavaBase {
     core.info(
       `Downloading Java ${javaRelease.version} (${this.distribution}) from ${javaRelease.url} ...`
     );
-    const javaArchivePath = await tc.downloadTool(javaRelease.url);
+    let javaArchivePath = await tc.downloadTool(javaRelease.url);
 
     core.info(`Extracting Java archive...`);
-
-    const extractedJavaPath = await extractJdkFile(
-      javaArchivePath,
-      getDownloadArchiveExtension()
-    );
+    const extension = getDownloadArchiveExtension();
+    if (process.platform === 'win32') {
+      javaArchivePath = renameWinArchive(javaArchivePath);
+    }
+    const extractedJavaPath = await extractJdkFile(javaArchivePath, extension);
 
     const archiveName = fs.readdirSync(extractedJavaPath)[0];
     const archivePath = path.join(extractedJavaPath, archiveName);

--- a/src/distributions/dragonwell/installer.ts
+++ b/src/distributions/dragonwell/installer.ts
@@ -11,7 +11,8 @@ import {
   extractJdkFile,
   getDownloadArchiveExtension,
   getGitHubHttpHeaders,
-  isVersionSatisfies
+  isVersionSatisfies,
+  renameWinArchive
 } from '../../util';
 import {IDragonwellVersions, IDragonwellAllVersions} from './models';
 import {
@@ -100,14 +101,14 @@ export class DragonwellDistribution extends JavaBase {
     core.info(
       `Downloading Java ${javaRelease.version} (${this.distribution}) from ${javaRelease.url} ...`
     );
-    const javaArchivePath = await tc.downloadTool(javaRelease.url);
+    let javaArchivePath = await tc.downloadTool(javaRelease.url);
 
     core.info(`Extracting Java archive...`);
-
-    const extractedJavaPath = await extractJdkFile(
-      javaArchivePath,
-      getDownloadArchiveExtension()
-    );
+    const extension = getDownloadArchiveExtension();
+    if (process.platform === 'win32') {
+      javaArchivePath = renameWinArchive(javaArchivePath);
+    }
+    const extractedJavaPath = await extractJdkFile(javaArchivePath, extension);
 
     const archiveName = fs.readdirSync(extractedJavaPath)[0];
     const archivePath = path.join(extractedJavaPath, archiveName);

--- a/src/distributions/graalvm/installer.ts
+++ b/src/distributions/graalvm/installer.ts
@@ -13,7 +13,8 @@ import {
 import {
   extractJdkFile,
   getDownloadArchiveExtension,
-  getGitHubHttpHeaders
+  getGitHubHttpHeaders,
+  renameWinArchive
 } from '../../util';
 import {HttpCodes} from '@actions/http-client';
 import {GraalVMEAVersion} from './models';
@@ -33,11 +34,13 @@ export class GraalVMDistribution extends JavaBase {
     core.info(
       `Downloading Java ${javaRelease.version} (${this.distribution}) from ${javaRelease.url} ...`
     );
-    const javaArchivePath = await tc.downloadTool(javaRelease.url);
+    let javaArchivePath = await tc.downloadTool(javaRelease.url);
 
     core.info(`Extracting Java archive...`);
     const extension = getDownloadArchiveExtension();
-
+    if (process.platform === 'win32') {
+      javaArchivePath = renameWinArchive(javaArchivePath);
+    }
     const extractedJavaPath = await extractJdkFile(javaArchivePath, extension);
 
     const archiveName = fs.readdirSync(extractedJavaPath)[0];

--- a/src/distributions/liberica/installer.ts
+++ b/src/distributions/liberica/installer.ts
@@ -8,7 +8,8 @@ import semver from 'semver';
 import {
   extractJdkFile,
   getDownloadArchiveExtension,
-  isVersionSatisfies
+  isVersionSatisfies,
+  renameWinArchive
 } from '../../util';
 import * as core from '@actions/core';
 import {ArchitectureOptions, LibericaVersion, OsVersions} from './models';
@@ -35,13 +36,8 @@ export class LibericaDistributions extends JavaBase {
 
     core.info(`Extracting Java archive...`);
     const extension = getDownloadArchiveExtension();
-    if (
-      process.platform === 'win32' &&
-      (this.architecture === 'arm64' || this.architecture === 'aarch64')
-    ) {
-      const javaArchivePathRenamed = `${javaArchivePath}.zip`;
-      await fs.renameSync(javaArchivePath, javaArchivePathRenamed);
-      javaArchivePath = javaArchivePathRenamed;
+    if (process.platform === 'win32') {
+      javaArchivePath = renameWinArchive(javaArchivePath);
     }
     const extractedJavaPath = await extractJdkFile(javaArchivePath, extension);
 

--- a/src/distributions/microsoft/installer.ts
+++ b/src/distributions/microsoft/installer.ts
@@ -7,7 +7,8 @@ import {
 import {
   extractJdkFile,
   getDownloadArchiveExtension,
-  getGitHubHttpHeaders
+  getGitHubHttpHeaders,
+  renameWinArchive
 } from '../../util';
 import * as core from '@actions/core';
 import * as tc from '@actions/tool-cache';
@@ -27,22 +28,12 @@ export class MicrosoftDistributions extends JavaBase {
       `Downloading Java ${javaRelease.version} (${this.distribution}) from ${javaRelease.url} ...`
     );
     let javaArchivePath = await tc.downloadTool(javaRelease.url);
-    // Rename archive to add extension because after downloading
-    // archive does not contain extension type and it leads to some issues
-    // on Windows runners without PowerShell Core.
-    //
-    // For default PowerShell Windows it should contain extension type to unpack it.
-    if (
-      process.platform === 'win32' &&
-      (this.architecture === 'arm64' || this.architecture === 'aarch64')
-    ) {
-      const javaArchivePathRenamed = `${javaArchivePath}.zip`;
-      await fs.renameSync(javaArchivePath, javaArchivePathRenamed);
-      javaArchivePath = javaArchivePathRenamed;
-    }
 
     core.info(`Extracting Java archive...`);
     const extension = getDownloadArchiveExtension();
+    if (process.platform === 'win32') {
+      javaArchivePath = renameWinArchive(javaArchivePath);
+    }
     const extractedJavaPath = await extractJdkFile(javaArchivePath, extension);
 
     const archiveName = fs.readdirSync(extractedJavaPath)[0];

--- a/src/distributions/oracle/installer.ts
+++ b/src/distributions/oracle/installer.ts
@@ -10,7 +10,11 @@ import {
   JavaInstallerOptions,
   JavaInstallerResults
 } from '../base-models';
-import {extractJdkFile, getDownloadArchiveExtension} from '../../util';
+import {
+  extractJdkFile,
+  getDownloadArchiveExtension,
+  renameWinArchive
+} from '../../util';
 import {HttpCodes} from '@actions/http-client';
 
 const ORACLE_DL_BASE = 'https://download.oracle.com/java';
@@ -26,11 +30,13 @@ export class OracleDistribution extends JavaBase {
     core.info(
       `Downloading Java ${javaRelease.version} (${this.distribution}) from ${javaRelease.url} ...`
     );
-    const javaArchivePath = await tc.downloadTool(javaRelease.url);
+    let javaArchivePath = await tc.downloadTool(javaRelease.url);
 
     core.info(`Extracting Java archive...`);
     const extension = getDownloadArchiveExtension();
-
+    if (process.platform === 'win32') {
+      javaArchivePath = renameWinArchive(javaArchivePath);
+    }
     const extractedJavaPath = await extractJdkFile(javaArchivePath, extension);
 
     const archiveName = fs.readdirSync(extractedJavaPath)[0];

--- a/src/distributions/sapmachine/installer.ts
+++ b/src/distributions/sapmachine/installer.ts
@@ -9,7 +9,8 @@ import {
   extractJdkFile,
   getDownloadArchiveExtension,
   getGitHubHttpHeaders,
-  isVersionSatisfies
+  isVersionSatisfies,
+  renameWinArchive
 } from '../../util';
 import {JavaBase} from '../base-installer';
 import {
@@ -104,14 +105,14 @@ export class SapMachineDistribution extends JavaBase {
     core.info(
       `Downloading Java ${javaRelease.version} (${this.distribution}) from ${javaRelease.url} ...`
     );
-    const javaArchivePath = await tc.downloadTool(javaRelease.url);
+    let javaArchivePath = await tc.downloadTool(javaRelease.url);
 
     core.info(`Extracting Java archive...`);
-
-    const extractedJavaPath = await extractJdkFile(
-      javaArchivePath,
-      getDownloadArchiveExtension()
-    );
+    const extension = getDownloadArchiveExtension();
+    if (process.platform === 'win32') {
+      javaArchivePath = renameWinArchive(javaArchivePath);
+    }
+    const extractedJavaPath = await extractJdkFile(javaArchivePath, extension);
 
     const archiveName = fs.readdirSync(extractedJavaPath)[0];
     const archivePath = path.join(extractedJavaPath, archiveName);

--- a/src/distributions/semeru/installer.ts
+++ b/src/distributions/semeru/installer.ts
@@ -8,7 +8,8 @@ import semver from 'semver';
 import {
   extractJdkFile,
   getDownloadArchiveExtension,
-  isVersionSatisfies
+  isVersionSatisfies,
+  renameWinArchive
 } from '../../util';
 import * as core from '@actions/core';
 import * as tc from '@actions/tool-cache';
@@ -98,11 +99,13 @@ export class SemeruDistribution extends JavaBase {
     core.info(
       `Downloading Java ${javaRelease.version} (${this.distribution}) from ${javaRelease.url} ...`
     );
-    const javaArchivePath = await tc.downloadTool(javaRelease.url);
+    let javaArchivePath = await tc.downloadTool(javaRelease.url);
 
     core.info(`Extracting Java archive...`);
     const extension = getDownloadArchiveExtension();
-
+    if (process.platform === 'win32') {
+      javaArchivePath = renameWinArchive(javaArchivePath);
+    }
     const extractedJavaPath: string = await extractJdkFile(
       javaArchivePath,
       extension

--- a/src/distributions/temurin/installer.ts
+++ b/src/distributions/temurin/installer.ts
@@ -15,7 +15,8 @@ import {
 import {
   extractJdkFile,
   getDownloadArchiveExtension,
-  isVersionSatisfies
+  isVersionSatisfies,
+  renameWinArchive
 } from '../../util';
 
 export enum TemurinImplementation {
@@ -76,11 +77,13 @@ export class TemurinDistribution extends JavaBase {
     core.info(
       `Downloading Java ${javaRelease.version} (${this.distribution}) from ${javaRelease.url} ...`
     );
-    const javaArchivePath = await tc.downloadTool(javaRelease.url);
+    let javaArchivePath = await tc.downloadTool(javaRelease.url);
 
     core.info(`Extracting Java archive...`);
     const extension = getDownloadArchiveExtension();
-
+    if (process.platform === 'win32') {
+      javaArchivePath = renameWinArchive(javaArchivePath);
+    }
     const extractedJavaPath = await extractJdkFile(javaArchivePath, extension);
 
     const archiveName = fs.readdirSync(extractedJavaPath)[0];

--- a/src/distributions/zulu/installer.ts
+++ b/src/distributions/zulu/installer.ts
@@ -11,7 +11,8 @@ import {
   extractJdkFile,
   getDownloadArchiveExtension,
   convertVersionToSemver,
-  isVersionSatisfies
+  isVersionSatisfies,
+  renameWinArchive
 } from '../../util';
 import {
   JavaDownloadRelease,
@@ -80,13 +81,8 @@ export class ZuluDistribution extends JavaBase {
 
     core.info(`Extracting Java archive...`);
     const extension = getDownloadArchiveExtension();
-    if (
-      process.platform === 'win32' &&
-      (this.architecture === 'arm64' || this.architecture === 'aarch64')
-    ) {
-      const javaArchivePathRenamed = `${javaArchivePath}.zip`;
-      await fs.renameSync(javaArchivePath, javaArchivePathRenamed);
-      javaArchivePath = javaArchivePathRenamed;
+    if (process.platform === 'win32') {
+      javaArchivePath = renameWinArchive(javaArchivePath);
     }
     const extractedJavaPath = await extractJdkFile(javaArchivePath, extension);
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -190,3 +190,14 @@ export function getGitHubHttpHeaders(): OutgoingHttpHeaders {
   }
   return headers;
 }
+
+// Rename archive to add extension because after downloading
+// archive does not contain extension type and it leads to some issues
+// on Windows runners without PowerShell Core.
+//
+// For default PowerShell Windows it should contain extension type to unpack it.
+export function renameWinArchive(javaArchivePath: string): string {
+  const javaArchivePathRenamed = `${javaArchivePath}.zip`;
+  fs.renameSync(javaArchivePath, javaArchivePathRenamed);
+  return javaArchivePathRenamed;
+}


### PR DESCRIPTION
**Description:**

- This update ensures that downloaded filenames explicitly include the `.zip` extension to enable smooth execution of the `Expand-Archive` command on Windows runners that do not have PowerShell Core.

- Bumps [micromatch](https://github.com/micromatch/micromatch) from 4.0.5 to 4.0.8

**Related issue:**
#563 

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.