### PR TITLE
Refine `isGhes` logic

### DIFF
--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -3,7 +3,8 @@ import * as core from '@actions/core';
 import {
   convertVersionToSemver,
   isVersionSatisfies,
-  isCacheFeatureAvailable
+  isCacheFeatureAvailable,
+  isGhes
 } from '../src/util';
 
 jest.mock('@actions/cache');
@@ -80,3 +81,42 @@ describe('convertVersionToSemver', () => {
     expect(actual).toBe(expected);
   });
 });
+
+describe('isGhes', () => {
+  const pristineEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...pristineEnv };
+  });
+
+  afterAll(() => {
+    process.env = pristineEnv;
+  });  
+
+  it('returns false when the GITHUB_SERVER_URL environment variable is not defined', async () => {
+    process.env['GITHUB_SERVER_URL'] = undefined;
+    expect(isGhes()).toBeFalsy();
+  });
+
+  it('returns false when the GITHUB_SERVER_URL environment variable is set to github.com', async () => {
+    process.env['GITHUB_SERVER_URL'] = 'https://github.com';
+    expect(isGhes()).toBeFalsy();
+  });
+
+  it('returns false when the GITHUB_SERVER_URL environment variable is set to a GitHub Enterprise Cloud-style URL', async () => {
+    process.env['GITHUB_SERVER_URL'] = 'https://contoso.ghe.com';
+    expect(isGhes()).toBeFalsy();
+  });
+
+  it('returns false when the GITHUB_SERVER_URL environment variable has a .localhost suffix', async () => {
+    process.env['GITHUB_SERVER_URL'] = 'https://mock-github.localhost';
+    expect(isGhes()).toBeFalsy();
+  });
+
+  it('returns true when the GITHUB_SERVER_URL environment variable is set to some other URL', async () => {
+    process.env['GITHUB_SERVER_URL'] = 'https://src.onpremise.fabrikam.com';
+    expect(isGhes()).toBeTruthy();
+  });
+});
+

--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -87,12 +87,12 @@ describe('isGhes', () => {
 
   beforeEach(() => {
     jest.resetModules();
-    process.env = { ...pristineEnv };
+    process.env = {...pristineEnv};
   });
 
   afterAll(() => {
     process.env = pristineEnv;
-  });  
+  });
 
   it('returns false when the GITHUB_SERVER_URL environment variable is not defined', async () => {
     delete process.env['GITHUB_SERVER_URL'];

--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -95,7 +95,7 @@ describe('isGhes', () => {
   });  
 
   it('returns false when the GITHUB_SERVER_URL environment variable is not defined', async () => {
-    process.env['GITHUB_SERVER_URL'] = undefined;
+    delete process.env['GITHUB_SERVER_URL'];
     expect(isGhes()).toBeFalsy();
   });
 
@@ -119,4 +119,3 @@ describe('isGhes', () => {
     expect(isGhes()).toBeTruthy();
   });
 });
-

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -88552,7 +88552,11 @@ function isJobStatusSuccess() {
 exports.isJobStatusSuccess = isJobStatusSuccess;
 function isGhes() {
     const ghUrl = new URL(process.env['GITHUB_SERVER_URL'] || 'https://github.com');
-    return ghUrl.hostname.toUpperCase() !== 'GITHUB.COM';
+    const hostname = ghUrl.hostname.trimEnd().toUpperCase();
+    const isGitHubHost = hostname === 'GITHUB.COM';
+    const isGitHubEnterpriseCloudHost = hostname.endsWith('.GHE.COM');
+    const isLocalHost = hostname.endsWith('.LOCALHOST');
+    return !isGitHubHost && !isGitHubEnterpriseCloudHost && !isLocalHost;
 }
 exports.isGhes = isGhes;
 function isCacheFeatureAvailable() {

--- a/src/util.ts
+++ b/src/util.ts
@@ -92,7 +92,13 @@ export function isGhes(): boolean {
   const ghUrl = new URL(
     process.env['GITHUB_SERVER_URL'] || 'https://github.com'
   );
-  return ghUrl.hostname.toUpperCase() !== 'GITHUB.COM';
+
+  const hostname = ghUrl.hostname.trimEnd().toUpperCase()
+  const isGitHubHost = hostname === 'GITHUB.COM'
+  const isGitHubEnterpriseCloudHost = hostname.endsWith('.GHE.COM')
+  const isLocalHost = hostname.endsWith('.LOCALHOST')
+
+  return !isGitHubHost && !isGitHubEnterpriseCloudHost && !isLocalHost
 }
 
 export function isCacheFeatureAvailable(): boolean {

--- a/src/util.ts
+++ b/src/util.ts
@@ -93,12 +93,12 @@ export function isGhes(): boolean {
     process.env['GITHUB_SERVER_URL'] || 'https://github.com'
   );
 
-  const hostname = ghUrl.hostname.trimEnd().toUpperCase()
-  const isGitHubHost = hostname === 'GITHUB.COM'
-  const isGitHubEnterpriseCloudHost = hostname.endsWith('.GHE.COM')
-  const isLocalHost = hostname.endsWith('.LOCALHOST')
+  const hostname = ghUrl.hostname.trimEnd().toUpperCase();
+  const isGitHubHost = hostname === 'GITHUB.COM';
+  const isGitHubEnterpriseCloudHost = hostname.endsWith('.GHE.COM');
+  const isLocalHost = hostname.endsWith('.LOCALHOST');
 
-  return !isGitHubHost && !isGitHubEnterpriseCloudHost && !isLocalHost
+  return !isGitHubHost && !isGitHubEnterpriseCloudHost && !isLocalHost;
 }
 
 export function isCacheFeatureAvailable(): boolean {


### PR DESCRIPTION
**Description:**
I'm fixing the logic within helper method `isGhes` to ensure that it doesn't misrecognize GitHub Enterprise Cloud instances as GHES instances.

**Related issue:**
https://github.com/newsroom/press-releases/data-residency-in-the-eu

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.