### PR TITLE
Update workflows for GraalVM and Version Enhancements

### DIFF
--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -51,7 +51,7 @@ jobs:
             version: 21
           - distribution: graalvm
             os: macos-latest
-            version: 17
+            version: 17.0.12
           - distribution: graalvm
             os: windows-latest
             version: 21

--- a/.github/workflows/release-new-action-version.yml
+++ b/.github/workflows/release-new-action-version.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Update the ${{ env.TAG_NAME }} tag
         id: update-major-tag
-        uses: actions/publish-action@v0.2.2
+        uses: actions/publish-action@v0.3.0
         with:
           source-tag: ${{ env.TAG_NAME }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
**Description:**
Updated workflow to use the minor version of GraalVM JDK 17 as support for Major Version is not supported. Version enhancement for publish-action.

**Related issue:**
NA

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.