### PR TITLE
Fix GitHub Actions schema violations for non-string default values

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
   check-latest:
     description: 'Set this option if you want the action to check for the latest available version that satisfies the version spec'
     required: false
-    default: false
+    default: 'false'
   server-id:
     description: 'ID of the distributionManagement repository in the pom.xml
        file. Default is `github`'
@@ -45,7 +45,7 @@ inputs:
   overwrite-settings:
     description: 'Overwrite the settings.xml file if it exists. Default is "true".'
     required: false
-    default: true
+    default: 'true'
   gpg-private-key:
     description: 'GPG private key to import. Default is empty string.'
     required: false


### PR DESCRIPTION
**Description:**
I created a Action schema validation process that does self-documentation from the Action's yaml definition. In running the tool on the `setup-java` repo it failed validation.

The `default` input property fields expect a string value and in two locations within the action.yml there are boolean values provided as defaults.

![Screenshot 2025-02-09 102054](https://github.com/user-attachments/assets/4695e2d8-28f4-4a83-ae9e-b74b4259e15a)
![Screenshot 2025-02-09 102104](https://github.com/user-attachments/assets/ca2f9bdd-aca4-488d-b8c6-edbdaf0cb68a)

**Related issue:**
TODO

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.