### PR TITLE
Remove duplicated GraalVM section from advanced usage doc

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -215,21 +215,6 @@ The available package types are:
 - `jdk+ft` - JBRSDK (FreeType)
 - `jre+ft` - JBR (FreeType)
 
-### GraalVM
-**NOTE:** Oracle GraalVM is only available for JDK 17 and later.
-
-```yaml
-steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-java@v4
-  with:
-    distribution: 'graalvm'
-    java-version: '21'
-- run: |
-    java -cp java HelloWorldApp
-    native-image -cp java HelloWorldApp
-```
-
 ## Installing custom Java package type
 ```yaml
 steps:


### PR DESCRIPTION
**Description:**
`advanced-usage.md` contains two sections for GraalVM.
This commit just removes the second one.

**Related issue:**
This is a simple doc change, not open a new issue for it.

**Check list:**
- [X] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.