### PR TITLE
Extended settings.xml - Profiles with Repo

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,7 +68,7 @@ inputs:
     required: false
     default: true
   prioritize-central:
-    description: 'Allows it to define, which Repo will be choosen first to download Dependencies. (default Central prior Custom)'
+    description: 'Allows it to define, which Repo will be chosen first to download Dependencies. (default Central prior Custom)'
     required: false
     default: true
   cache:

--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ inputs:
     description: 'URL of a repository where maven will look for Dependencies - e.g. "https://maven.pkg.github.com/<USERNAME_or_ORGANIZATION>/*"'
     required: false
   no-snapshots:
-    description: 'Sets the flag, if snapshots of custom repositories, shall be allowed of not. (default does allow Snapshots)'
+    description: 'Determines whether snapshots for custom repositories are allowed; defaults to allowing snapshots.'
     required: false
     default: false
   use-central:

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,24 @@ inputs:
     description: 'Environment variable name for the GPG private key passphrase. Default is
        $GPG_PASSPHRASE.'
     required: false
+  repo-id:
+    description: 'Identifier of a Named Repo - e.g. "github"'
+    required: false
+  repo-url:
+    description: 'URL of a repository where maven will look for Dependencies - e.g. "https://maven.pkg.github.com/<USERNAME_or_ORGANIZATION>/*"'
+    required: false
+  no-snapshots:
+    description: 'Sets the flag, if snapshots of custom repositories, shall be allowed of not. (default does allow Snapshots)'
+    required: false
+    default: false
+  use-central:
+    description: 'Sets the Flag, whether to use Maven-Central or not. (default allows Central repo)'
+    required: false
+    default: true
+  prioritize-central:
+    description: 'Allows it to define, which Repo will be choosen first to download Dependencies. (default Central prior Custom)'
+    required: false
+    default: true
   cache:
     description: 'Name of the build platform to cache dependencies. It can be "maven", "gradle" or "sbt".'
     required: false

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -436,6 +436,67 @@ See the help docs on [Publishing a Package](https://help.github.com/en/github/ma
 
 ***NOTE***: If the error that states, `gpg: Sorry, no terminal at all requested - can't get input` [is encountered](https://github.com/actions/setup-java/issues/554), please update the version of `maven-gpg-plugin` to 1.6 or higher.
 
+## Resolving Dependencies
+
+If you use setup-java action to build your project with dependencies of another repository then Maven Central, you need to tell maven where to find your Dependencies.
+
+
+```yaml    
+    - name: Set up Apache Maven Central
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '11'
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        server-username: ${{ secrets.USERNAME }}
+        server-password: ${{ secrets.PASS_WORD }}
+        repo-id: github
+        repo-url: 'https://maven.pkg.github.com/<USERNAME_or_ORGANIZATION>/*'
+        no-snapshots: false # (optional) default Snapshots enabled true
+        use-central: true # (optional) default uses Central
+        prioritize-central: true # (optional) default first lookup Maven Central
+```
+The generated `settings.xml` will look like:
+
+```xml
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <activeProfiles>
+    <activeProfile>github</activeProfile>
+  </activeProfiles>
+
+  <profiles>
+    <profile>
+      <id>github</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2</url>
+        </repository>
+        <repository>
+          <id>github</id>
+          <url>https://maven.pkg.github.com/<USERNAME_or_ORGANIZATION>/*</url>
+          <snapshots>
+<!--
+            <enabled>true</enabled>
+-->
+          </snapshots>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+
+  <servers>
+    <server>
+      <id>github</id>
+      <username>${secrets.USERNAME}</username>
+      <password>${secrets.PASS_WORD}</password>
+    </server>
+  </servers>
+</settings>
+```
+
 ## Apache Maven with a settings path
 
 When using an Actions self-hosted runner with multiple shared runners the default `$HOME` directory can be shared by a number runners at the same time which could overwrite existing settings file. Setting the `settings-path` variable allows you to choose a unique location for your settings file.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,6 +13,11 @@ export const INPUT_SETTINGS_PATH = 'settings-path';
 export const INPUT_OVERWRITE_SETTINGS = 'overwrite-settings';
 export const INPUT_GPG_PRIVATE_KEY = 'gpg-private-key';
 export const INPUT_GPG_PASSPHRASE = 'gpg-passphrase';
+export const INPUT_REPO_ID = 'repo-id';
+export const INPUT_REPO_URL = 'repo-url';
+export const INPUT_REPO_NO_SNAPSHOTS = 'no-snapshots';
+export const INPUT_USE_CENTRAL = 'use-central';
+export const INPUT_PRIORITIZE_CENTRAL = 'prioritize-central';
 
 export const INPUT_DEFAULT_GPG_PRIVATE_KEY = undefined;
 export const INPUT_DEFAULT_GPG_PASSPHRASE = 'GPG_PASSPHRASE';


### PR DESCRIPTION
Building Maven Project with dependencies of another Repository then Maven-Central.

This could be extended to support more than one repo.
Also the profile could be cut down to one overall-profile, i think.

I'm more the Backend Guy, hope its ok. :)

**Description:**
Extended settings.xml generation to include another Repository. 
This should provide nessecary Information while building with Maven.
So your build could refer to something like Artifacts in a private github repository.

**Related issue:**

**Check list:**
- [ x ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.