### PR TITLE
Clarify JAVA_HOME and PATH setup in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ jobs:
 
 ### Install multiple JDKs
 
-All versions are added to the PATH. The last version will be used and available globally. Other Java versions can be accessed through env variables with such specification as 'JAVA_HOME_{{ MAJOR_VERSION }}_{{ ARCHITECTURE }}'.
+All versions are added to the PATH. The last version will be used and available globally. Other Java versions can be accessed through env variables with such specification as 'JAVA_HOME_{{ MAJOR_VERSION }}_{{ ARCHITECTURE }}'. To set up a specific Java version, update the JAVA_HOME environment variable and prepend its bin directory to the PATH to ensure the desired JDK takes priority during execution.
 
 ```yaml
     steps:


### PR DESCRIPTION
**Description:**
This pull request updates the documentation in the `README.md` file to clarify how to set up a specific Java version when multiple JDKs are installed.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L238-R238): Added instructions for updating the `JAVA_HOME` environment variable and prepending the desired JDK's `bin` directory to the `PATH` to prioritize a specific Java version.

**Related issue:**
#835 

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.