### PR TITLE
Update documentation to use checkout and Java v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This action allows you to work with Java and Scala projects.
 - V2 supports custom distributions and provides support for Azul Zulu OpenJDK, Eclipse Temurin and AdoptOpenJDK  out of the box. V1 supports only Azul Zulu OpenJDK.
 - V2 requires you to specify distribution along with the version. V1 defaults to Azul Zulu OpenJDK, only version input is required. Follow [the migration guide](docs/switching-to-v2.md) to switch from V1 to V2.
 
+For information about the latest releases, recent updates, and newly supported distributions, please refer to the `setup-java` [Releases](https://github.com/actions/setup-java/releases).
+
 ## Usage
 
   - `java-version`: The Java version that is going to be set up. Takes a whole or [semver](#supported-version-syntax) Java version. If not specified, the action will expect `java-version-file` input to be specified.
@@ -69,8 +71,8 @@ This action allows you to work with Java and Scala projects.
 #### Eclipse Temurin
 ```yaml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-java@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-java@v5
   with:
     distribution: 'temurin' # See 'Supported distributions' for available options
     java-version: '21'
@@ -80,8 +82,8 @@ steps:
 #### Azul Zulu OpenJDK
 ```yaml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-java@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-java@v5
   with:
     distribution: 'zulu' # See 'Supported distributions' for available options
     java-version: '21'
@@ -136,8 +138,8 @@ The cache input is optional, and caching is turned off by default.
 #### Caching gradle dependencies
 ```yaml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-java@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-java@v5
   with:
     distribution: 'temurin'
     java-version: '21'
@@ -151,8 +153,8 @@ steps:
 #### Caching maven dependencies
 ```yaml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-java@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-java@v5
   with:
     distribution: 'temurin'
     java-version: '21'
@@ -165,8 +167,8 @@ steps:
 #### Caching sbt dependencies
 ```yaml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-java@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-java@v5
   with:
     distribution: 'temurin'
     java-version: '21'
@@ -185,8 +187,8 @@ Usually, cache gets downloaded in multiple segments of fixed sizes. Sometimes, a
 env:
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: '5'
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-java@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-java@v5
   with:
     distribution: 'temurin'
     java-version: '21'
@@ -205,8 +207,8 @@ For Java distributions that are not cached on Hosted images, `check-latest` alwa
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-java@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-java@v5
   with:
     distribution: 'temurin'
     java-version: '21'
@@ -224,9 +226,9 @@ jobs:
         java: [ '8', '11', '17', '21' ]
     name: Java ${{ matrix.Java }} sample
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: '<distribution>'
           java-version: ${{ matrix.java }}
@@ -239,7 +241,7 @@ All versions are added to the PATH. The last version will be used and available 
 
 ```yaml
     steps:
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: '<distribution>'
           java-version: |

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -31,8 +31,8 @@ Inputs `java-version` and `distribution` are mandatory and needs to be provided.
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-java@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-java@v5
   with:
     distribution: 'temurin'
     java-version: '21'
@@ -44,8 +44,8 @@ steps:
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-java@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-java@v5
   with:
     distribution: 'adopt-hotspot'
     java-version: '11'
@@ -56,8 +56,8 @@ steps:
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-java@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-java@v5
   with:
     distribution: 'zulu'
     java-version: '21'
@@ -69,8 +69,8 @@ steps:
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-java@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-java@v5
   with:
     distribution: 'liberica'
     java-version: '21'
@@ -82,8 +82,8 @@ steps:
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-java@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-java@v5
   with:
     distribution: 'microsoft'
     java-version: '21'
@@ -97,7 +97,7 @@ steps:
 To get a higher rate limit, you can [generate a personal access token on github.com](https://github.com/settings/tokens/new) and pass it as the `token` input for the action:
 
 ```yaml
-uses: actions/setup-java@v4
+uses: actions/setup-java@v5
 with:
   token: ${{ secrets.GH_DOTCOM_TOKEN }}
   distribution: 'microsoft'
@@ -111,8 +111,8 @@ If the runner is not able to access github.com, any Java versions requested duri
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-java@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-java@v5
   with:
     distribution: 'corretto'
     java-version: '21'
@@ -124,8 +124,8 @@ steps:
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-java@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-java@v5
   with:
     distribution: 'oracle'
     java-version: '21'
@@ -137,8 +137,8 @@ steps:
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-java@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-java@v5
   with:
     distribution: 'dragonwell'
     java-version: '8'
@@ -149,8 +149,8 @@ steps:
 **NOTE:** An OpenJDK release maintained and supported by SAP
 ```yaml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-java@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-java@v5
   with:
     distribution: 'sapmachine'
     java-version: '21'
@@ -162,8 +162,8 @@ steps:
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-java@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-java@v5
   with:
     distribution: 'graalvm'
     java-version: '21'
@@ -181,8 +181,8 @@ For example, `11.0.24` is not available but `11.0.16` is.
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-java@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-java@v5
   with:
     distribution: 'jetbrains'
     java-version: '11'
@@ -194,8 +194,8 @@ GitHub token to the action to increase the rate limit. Set the `GITHUB_TOKEN` en
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-java@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-java@v5
   with:
     distribution: 'jetbrains'
     java-version: '17'
@@ -219,8 +219,8 @@ The available package types are:
 ## Installing custom Java package type
 ```yaml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-java@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-java@v5
   with:
     distribution: '<distribution>'
     java-version: '11'
@@ -232,8 +232,8 @@ steps:
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-java@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-java@v5
   with:
     distribution: '<distribution>'
     java-version: '11'
@@ -249,7 +249,7 @@ steps:
 - run: |
     download_url="https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz"
     wget -O $RUNNER_TEMP/java_package.tar.gz $download_url
-- uses: actions/setup-java@v4
+- uses: actions/setup-java@v5
   with:
     distribution: 'jdkfile'
     jdkFile: ${{ runner.temp }}/java_package.tar.gz
@@ -275,7 +275,7 @@ If your use-case requires a custom distribution (in the example, alpine-linux is
           latest_semver_version=$(curl -sL $latest_jdk_json_url | jq -r 'version.semver')
           echo "java_version=$latest_semver_version" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: 'jdkfile'
           jdkFile: ${{ runner.temp }}/java_package.tar.gz
@@ -296,9 +296,9 @@ jobs:
         java: [ '8', '11' ]
     name: Java ${{ matrix.Java }} (${{ matrix.distribution }}) sample
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: ${{ matrix.distribution }}
           java-version: ${{ matrix.java }}
@@ -316,9 +316,9 @@ jobs:
         os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
     name: Java ${{ matrix.Java }} (${{ matrix.os }}) sample
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
@@ -333,9 +333,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up JDK 11
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: '<distribution>'
         java-version: '11'
@@ -349,7 +349,7 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }} # GITHUB_TOKEN is the default env for the password
 
     - name: Set up Apache Maven Central
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with: # running setup-java again overwrites the settings.xml
         distribution: 'temurin'
         java-version: '11'
@@ -446,9 +446,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up JDK 11 for Shared Runner
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: '<distribution>'
         java-version: '11'
@@ -472,10 +472,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: '<distribution>'
         java-version: '11'
@@ -509,14 +509,14 @@ Subsequent calls to `setup-java` with distinct distribution and version paramete
 
 ```yaml
 steps:
-- uses: actions/setup-java@v4
+- uses: actions/setup-java@v5
   with:
     distribution: '<distribution>'
     java-version: |
       8
       11
 
-- uses: actions/setup-java@v4
+- uses: actions/setup-java@v5
   with:
     distribution: '<distribution>'
     java-version: '15'
@@ -528,7 +528,7 @@ The result is a Toolchain with entries for JDKs 8, 11 and 15. You can even combi
 - run: |
     download_url="https://example.com/java/jdk/6u45-b06/jdk-6u45-linux-x64.tar.gz"
     wget -O $RUNNER_TEMP/java_package.tar.gz $download_url
-- uses: actions/setup-java@v4
+- uses: actions/setup-java@v5
   with:
     distribution: 'jdkfile'
     jdkFile: ${{ runner.temp }}/java_package.tar.gz
@@ -545,7 +545,7 @@ Each JDK provider will receive a default `vendor` using the `distribution` input
 - run: |
     download_url="https://example.com/java/jdk/6u45-b06/jdk-6u45-linux-x64.tar.gz"
     wget -O $RUNNER_TEMP/java_package.tar.gz $download_url
-- uses: actions/setup-java@v4
+- uses: actions/setup-java@v5
   with:
     distribution: 'jdkfile'
     jdkFile: ${{ runner.temp }}/java_package.tar.gz
@@ -560,7 +560,7 @@ In case you install multiple versions of Java at once with multi-line `java-vers
 
 ```yaml
 steps:
-- uses: actions/setup-java@v4
+- uses: actions/setup-java@v5
   with:
     distribution: '<distribution>'
     java-version: |
@@ -574,8 +574,8 @@ Each JDK provider will receive a default `id` based on the combination of `distr
 
 ```yaml
 steps:
-- uses: actions/checkout@v4
-- uses: actions/setup-java@v4
+- uses: actions/checkout@v5
+- uses: actions/setup-java@v5
   with:
     distribution: 'temurin'
     java-version: '11'
@@ -587,7 +587,7 @@ In case you install multiple versions of Java at once you can use the same synta
 
 ```yaml
 steps:
-- uses: actions/setup-java@v4
+- uses: actions/setup-java@v5
   with:
     distribution: '<distribution>'
     java-version: |


### PR DESCRIPTION
**Description:**

This pull request updates all documentation references to use the latest major versions:

- Upgrades `actions/checkout` to v4 → v5
- Upgrades `actions/setup-java` to v4 → v5

Also, Updated the README to include a reference to the [Releases](https://github.com/actions/setup-java/releases) page


**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.