### PR TITLE
Fix codeql workflow permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,5 +10,8 @@ on:
 
 jobs:
   call-codeQL-analysis:
+    permissions:
+      actions: read
+      security-events: write
     name: CodeQL analysis
     uses: actions/reusable-workflows/.github/workflows/codeql-analysis.yml@main


### PR DESCRIPTION
**Description:**
Without this, the workflow fails on forks with restricted permissions, e.g.:
https://github.com/check-spelling-sandbox/setup-java/actions/runs/23344893018
https://github.com/check-spelling-sandbox/setup-java/actions/runs/23344583872

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.