### PR TITLE
Migrate Zulu distribution to new metadata API with CRaC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For information about the latest releases, recent updates, and newly supported d
 
   - `distribution`: _(required)_ Java [distribution](#supported-distributions).
 
-  - `java-package`: The packaging variant of the chosen distribution. Possible values: `jdk`, `jre`, `jdk+fx`, `jre+fx`. Default value: `jdk`.
+  - `java-package`: The packaging variant of the chosen distribution. Possible values: `jdk`, `jre`, `jdk+fx`, `jre+fx`. For Azul Zulu, `jdk+crac` and `jre+crac` are also supported to select builds with [CRaC](https://openjdk.org/projects/crac/) support. Default value: `jdk`.
 
   - `architecture`: The target architecture of the package. Possible values: `x86`, `x64`, `armv7`, `aarch64`, `ppc64le`. Default value: Derived from the runner machine.
 

--- a/__tests__/data/zulu-linux.json
+++ b/__tests__/data/zulu-linux.json
@@ -1,254 +1,722 @@
-[  
+[
   {
-    "id": 10996,
-    "url": "https://cdn.azul.com/zulu/bin/zulu1.8.0_05-8.1.0.10-linux.tar.gz",
+    "package_uuid": "uuid-10996",
     "name": "zulu1.8.0_05-8.1.0.10-linux.tar.gz",
-    "zulu_version": [8, 1, 0, 10],
-    "jdk_version": [8, 0, 5, 13]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu1.8.0_05-8.1.0.10-linux.tar.gz",
+    "java_version": [
+      8,
+      0,
+      5,
+      13
+    ],
+    "distro_version": [
+      8,
+      1,
+      0,
+      10
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10997,
-    "url": "https://cdn.azul.com/zulu/bin/zulu1.8.0_11-8.2.0.1-linux.tar.gz",
+    "package_uuid": "uuid-10997",
     "name": "zulu1.8.0_11-8.2.0.1-linux.tar.gz",
-    "zulu_version": [8, 2, 0, 1],
-    "jdk_version": [8, 0, 11, 12]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu1.8.0_11-8.2.0.1-linux.tar.gz",
+    "java_version": [
+      8,
+      0,
+      11,
+      12
+    ],
+    "distro_version": [
+      8,
+      2,
+      0,
+      1
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10346,
-    "url": "https://cdn.azul.com/zulu/bin/zulu8.21.0.1-jdk8.0.131-linux_x64.tar.gz",
+    "package_uuid": "uuid-10346",
     "name": "zulu8.21.0.1-jdk8.0.131-linux_x64.tar.gz",
-    "zulu_version": [8, 21, 0, 1],
-    "jdk_version": [8, 0, 131, 11]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu8.21.0.1-jdk8.0.131-linux_x64.tar.gz",
+    "java_version": [
+      8,
+      0,
+      131,
+      11
+    ],
+    "distro_version": [
+      8,
+      21,
+      0,
+      1
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10362,
-    "url": "https://cdn.azul.com/zulu/bin/zulu8.23.0.3-jdk8.0.144-linux_x64.tar.gz",
+    "package_uuid": "uuid-10362",
     "name": "zulu8.23.0.3-jdk8.0.144-linux_x64.tar.gz",
-    "zulu_version": [8, 23, 0, 3],
-    "jdk_version": [8, 0, 144, 1]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu8.23.0.3-jdk8.0.144-linux_x64.tar.gz",
+    "java_version": [
+      8,
+      0,
+      144,
+      1
+    ],
+    "distro_version": [
+      8,
+      23,
+      0,
+      3
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10399,
-    "url": "https://cdn.azul.com/zulu/bin/zulu8.25.0.1-jdk8.0.152-linux_x64.tar.gz",
+    "package_uuid": "uuid-10399",
     "name": "zulu8.25.0.1-jdk8.0.152-linux_x64.tar.gz",
-    "zulu_version": [8, 25, 0, 1],
-    "jdk_version": [8, 0, 152, 16]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu8.25.0.1-jdk8.0.152-linux_x64.tar.gz",
+    "java_version": [
+      8,
+      0,
+      152,
+      16
+    ],
+    "distro_version": [
+      8,
+      25,
+      0,
+      1
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11355,
-    "url": "https://cdn.azul.com/zulu/bin/zulu8.46.0.19-ca-jdk8.0.252-linux_x64.tar.gz",
+    "package_uuid": "uuid-11355",
     "name": "zulu8.46.0.19-ca-jdk8.0.252-linux_x64.tar.gz",
-    "zulu_version": [8, 46, 0, 19],
-    "jdk_version": [8, 0, 252, 14]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu8.46.0.19-ca-jdk8.0.252-linux_x64.tar.gz",
+    "java_version": [
+      8,
+      0,
+      252,
+      14
+    ],
+    "distro_version": [
+      8,
+      46,
+      0,
+      19
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11481,
-    "url": "https://cdn.azul.com/zulu/bin/zulu8.48.0.47-ca-jdk8.0.262-linux_x64.tar.gz",
+    "package_uuid": "uuid-11481",
     "name": "zulu8.48.0.47-ca-jdk8.0.262-linux_x64.tar.gz",
-    "zulu_version": [8, 48, 0, 47],
-    "jdk_version": [8, 0, 262, 17]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu8.48.0.47-ca-jdk8.0.262-linux_x64.tar.gz",
+    "java_version": [
+      8,
+      0,
+      262,
+      17
+    ],
+    "distro_version": [
+      8,
+      48,
+      0,
+      47
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11622,
-    "url": "https://cdn.azul.com/zulu/bin/zulu8.48.0.51-ca-jdk8.0.262-linux_x64.tar.gz",
+    "package_uuid": "uuid-11622",
     "name": "zulu8.48.0.51-ca-jdk8.0.262-linux_x64.tar.gz",
-    "zulu_version": [8, 48, 0, 51],
-    "jdk_version": [8, 0, 262, 19]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu8.48.0.51-ca-jdk8.0.262-linux_x64.tar.gz",
+    "java_version": [
+      8,
+      0,
+      262,
+      19
+    ],
+    "distro_version": [
+      8,
+      48,
+      0,
+      51
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11535,
-    "url": "https://cdn.azul.com/zulu/bin/zulu8.48.0.49-ca-jdk8.0.262-linux_x64.tar.gz",
+    "package_uuid": "uuid-11535",
     "name": "zulu8.48.0.49-ca-jdk8.0.262-linux_x64.tar.gz",
-    "zulu_version": [8, 48, 0, 49],
-    "jdk_version": [8, 0, 262, 18]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu8.48.0.49-ca-jdk8.0.262-linux_x64.tar.gz",
+    "java_version": [
+      8,
+      0,
+      262,
+      18
+    ],
+    "distro_version": [
+      8,
+      48,
+      0,
+      49
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 12424,
-    "url": "https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-jdk8.0.282-linux_x64.tar.gz",
+    "package_uuid": "uuid-12424",
     "name": "zulu8.52.0.23-ca-jdk8.0.282-linux_x64.tar.gz",
-    "zulu_version": [8, 52, 0, 23],
-    "jdk_version": [8, 0, 282, 8]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-jdk8.0.282-linux_x64.tar.gz",
+    "java_version": [
+      8,
+      0,
+      282,
+      8
+    ],
+    "distro_version": [
+      8,
+      52,
+      0,
+      23
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10383,
-    "url": "https://cdn.azul.com/zulu/bin/zulu9.0.0.15-jdk9.0.0-linux_x64.tar.gz",
+    "package_uuid": "uuid-10383",
     "name": "zulu9.0.0.15-jdk9.0.0-linux_x64.tar.gz",
-    "zulu_version": [9, 0, 0, 15],
-    "jdk_version": [9, 0, 0, 0]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu9.0.0.15-jdk9.0.0-linux_x64.tar.gz",
+    "java_version": [
+      9,
+      0,
+      0,
+      0
+    ],
+    "distro_version": [
+      9,
+      0,
+      0,
+      15
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10413,
-    "url": "https://cdn.azul.com/zulu/bin/zulu9.0.1.3-jdk9.0.1-linux_x64.tar.gz",
+    "package_uuid": "uuid-10413",
     "name": "zulu9.0.1.3-jdk9.0.1-linux_x64.tar.gz",
-    "zulu_version": [9, 0, 1, 3],
-    "jdk_version": [9, 0, 1, 0]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu9.0.1.3-jdk9.0.1-linux_x64.tar.gz",
+    "java_version": [
+      9,
+      0,
+      1,
+      0
+    ],
+    "distro_version": [
+      9,
+      0,
+      1,
+      3
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10503,
-    "url": "https://cdn.azul.com/zulu/bin/zulu10.2+3-jdk10.0.1-linux_x64.tar.gz",
+    "package_uuid": "uuid-10503",
     "name": "zulu10.2+3-jdk10.0.1-linux_x64.tar.gz",
-    "zulu_version": [10, 2, 3, 0],
-    "jdk_version": [10, 0, 1, 9]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu10.2+3-jdk10.0.1-linux_x64.tar.gz",
+    "java_version": [
+      10,
+      0,
+      1,
+      9
+    ],
+    "distro_version": [
+      10,
+      2,
+      3,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10541,
-    "url": "https://cdn.azul.com/zulu/bin/zulu10.3+5-jdk10.0.2-linux_x64.tar.gz",
+    "package_uuid": "uuid-10541",
     "name": "zulu10.3+5-jdk10.0.2-linux_x64.tar.gz",
-    "zulu_version": [10, 3, 5, 0],
-    "jdk_version": [10, 0, 2, 13]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu10.3+5-jdk10.0.2-linux_x64.tar.gz",
+    "java_version": [
+      10,
+      0,
+      2,
+      13
+    ],
+    "distro_version": [
+      10,
+      3,
+      5,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10576,
-    "url": "https://cdn.azul.com/zulu/bin/zulu11.2.3-jdk11.0.1-linux_x64.tar.gz",
+    "package_uuid": "uuid-10576",
     "name": "zulu11.2.3-jdk11.0.1-linux_x64.tar.gz",
-    "zulu_version": [11, 2, 3, 0],
-    "jdk_version": [11, 0, 1, 13]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu11.2.3-jdk11.0.1-linux_x64.tar.gz",
+    "java_version": [
+      11,
+      0,
+      1,
+      13
+    ],
+    "distro_version": [
+      11,
+      2,
+      3,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10604,
-    "url": "https://cdn.azul.com/zulu/bin/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz",
+    "package_uuid": "uuid-10604",
     "name": "zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz",
-    "zulu_version": [11, 29, 3, 0],
-    "jdk_version": [11, 0, 2, 7]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu11.29.3-ca-jdk11.0.2-linux_x64.tar.gz",
+    "java_version": [
+      11,
+      0,
+      2,
+      7
+    ],
+    "distro_version": [
+      11,
+      29,
+      3,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10687,
-    "url": "https://cdn.azul.com/zulu/bin/zulu11.31.11-ca-jdk11.0.3-linux_x64.tar.gz",
+    "package_uuid": "uuid-10687",
     "name": "zulu11.31.11-ca-jdk11.0.3-linux_x64.tar.gz",
-    "zulu_version": [11, 31, 11, 0],
-    "jdk_version": [11, 0, 3, 7]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu11.31.11-ca-jdk11.0.3-linux_x64.tar.gz",
+    "java_version": [
+      11,
+      0,
+      3,
+      7
+    ],
+    "distro_version": [
+      11,
+      31,
+      11,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10856,
-    "url": "https://cdn.azul.com/zulu/bin/zulu11.35.13-ca-jdk11.0.5-linux_x64.tar.gz",
+    "package_uuid": "uuid-10856",
     "name": "zulu11.35.13-ca-jdk11.0.5-linux_x64.tar.gz",
-    "zulu_version": [11, 35, 13, 0],
-    "jdk_version": [11, 0, 5, 10]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu11.35.13-ca-jdk11.0.5-linux_x64.tar.gz",
+    "java_version": [
+      11,
+      0,
+      5,
+      10
+    ],
+    "distro_version": [
+      11,
+      35,
+      13,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10933,
-    "url": "https://cdn.azul.com/zulu/bin/zulu11.35.15-ca-jdk11.0.5-linux_x64.tar.gz",
+    "package_uuid": "uuid-10933",
     "name": "zulu11.35.15-ca-jdk11.0.5-linux_x64.tar.gz",
-    "zulu_version": [11, 35, 15, 0],
-    "jdk_version": [11, 0, 5, 10]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu11.35.15-ca-jdk11.0.5-linux_x64.tar.gz",
+    "java_version": [
+      11,
+      0,
+      5,
+      10
+    ],
+    "distro_version": [
+      11,
+      35,
+      15,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10933,
-    "url": "https://cdn.azul.com/zulu/bin/zulu11.35.11-ca-jdk11.0.5-linux_x64.tar.gz",
+    "package_uuid": "uuid-10933",
     "name": "zulu11.35.15-ca-jdk11.0.5-linux_x64.tar.gz",
-    "zulu_version": [11, 35, 11, 0],
-    "jdk_version": [11, 0, 5, 10]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu11.35.11-ca-jdk11.0.5-linux_x64.tar.gz",
+    "java_version": [
+      11,
+      0,
+      5,
+      10
+    ],
+    "distro_version": [
+      11,
+      35,
+      11,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 12397,
-    "url": "https://cdn.azul.com/zulu/bin/zulu11.45.27-ca-jdk11.0.10-linux_x64.tar.gz",
+    "package_uuid": "uuid-12397",
     "name": "zulu11.45.27-ca-jdk11.0.10-linux_x64.tar.gz",
-    "zulu_version": [11, 45, 27, 0],
-    "jdk_version": [11, 0, 10, 9]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu11.45.27-ca-jdk11.0.10-linux_x64.tar.gz",
+    "java_version": [
+      11,
+      0,
+      10,
+      9
+    ],
+    "distro_version": [
+      11,
+      45,
+      27,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10667,
-    "url": "https://cdn.azul.com/zulu/bin/zulu12.1.3-ca-jdk12.0.0-linux_x64.tar.gz",
+    "package_uuid": "uuid-10667",
     "name": "zulu12.1.3-ca-jdk12.0.0-linux_x64.tar.gz",
-    "zulu_version": [12, 1, 3, 0],
-    "jdk_version": [12, 0, 0, 33]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu12.1.3-ca-jdk12.0.0-linux_x64.tar.gz",
+    "java_version": [
+      12,
+      0,
+      0,
+      33
+    ],
+    "distro_version": [
+      12,
+      1,
+      3,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10710,
-    "url": "https://cdn.azul.com/zulu/bin/zulu12.2.3-ca-jdk12.0.1-linux_x64.tar.gz",
+    "package_uuid": "uuid-10710",
     "name": "zulu12.2.3-ca-jdk12.0.1-linux_x64.tar.gz",
-    "zulu_version": [12, 2, 3, 0],
-    "jdk_version": [12, 0, 1, 12]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu12.2.3-ca-jdk12.0.1-linux_x64.tar.gz",
+    "java_version": [
+      12,
+      0,
+      1,
+      12
+    ],
+    "distro_version": [
+      12,
+      2,
+      3,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10780,
-    "url": "https://cdn.azul.com/zulu/bin/zulu12.3.11-ca-jdk12.0.2-linux_x64.tar.gz",
+    "package_uuid": "uuid-10780",
     "name": "zulu12.3.11-ca-jdk12.0.2-linux_x64.tar.gz",
-    "zulu_version": [12, 3, 11, 0],
-    "jdk_version": [12, 0, 2, 3]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu12.3.11-ca-jdk12.0.2-linux_x64.tar.gz",
+    "java_version": [
+      12,
+      0,
+      2,
+      3
+    ],
+    "distro_version": [
+      12,
+      3,
+      11,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10846,
-    "url": "https://cdn.azul.com/zulu/bin/zulu13.27.9-ca-jdk13.0.0-linux_x64.tar.gz",
+    "package_uuid": "uuid-10846",
     "name": "zulu13.27.9-ca-jdk13.0.0-linux_x64.tar.gz",
-    "zulu_version": [13, 27, 9, 0],
-    "jdk_version": [13, 0, 0, 33]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu13.27.9-ca-jdk13.0.0-linux_x64.tar.gz",
+    "java_version": [
+      13,
+      0,
+      0,
+      33
+    ],
+    "distro_version": [
+      13,
+      27,
+      9,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10888,
-    "url": "https://cdn.azul.com/zulu/bin/zulu13.28.11-ca-jdk13.0.1-linux_x64.tar.gz",
+    "package_uuid": "uuid-10888",
     "name": "zulu13.28.11-ca-jdk13.0.1-linux_x64.tar.gz",
-    "zulu_version": [13, 28, 11, 0],
-    "jdk_version": [13, 0, 1, 10]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu13.28.11-ca-jdk13.0.1-linux_x64.tar.gz",
+    "java_version": [
+      13,
+      0,
+      1,
+      10
+    ],
+    "distro_version": [
+      13,
+      28,
+      11,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11073,
-    "url": "https://cdn.azul.com/zulu/bin/zulu13.29.9-ca-jdk13.0.2-linux_x64.tar.gz",
+    "package_uuid": "uuid-11073",
     "name": "zulu13.29.9-ca-jdk13.0.2-linux_x64.tar.gz",
-    "zulu_version": [13, 29, 9, 0],
-    "jdk_version": [13, 0, 2, 6]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu13.29.9-ca-jdk13.0.2-linux_x64.tar.gz",
+    "java_version": [
+      13,
+      0,
+      2,
+      6
+    ],
+    "distro_version": [
+      13,
+      29,
+      9,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 12408,
-    "url": "https://cdn.azul.com/zulu/bin/zulu13.37.21-ca-jdk13.0.6-linux_x64.tar.gz",
+    "package_uuid": "uuid-12408",
     "name": "zulu13.37.21-ca-jdk13.0.6-linux_x64.tar.gz",
-    "zulu_version": [13, 37, 21, 0],
-    "jdk_version": [13, 0, 6, 5]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu13.37.21-ca-jdk13.0.6-linux_x64.tar.gz",
+    "java_version": [
+      13,
+      0,
+      6,
+      5
+    ],
+    "distro_version": [
+      13,
+      37,
+      21,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11236,
-    "url": "https://cdn.azul.com/zulu/bin/zulu14.27.1-ca-jdk14.0.0-linux_x64.tar.gz",
+    "package_uuid": "uuid-11236",
     "name": "zulu14.27.1-ca-jdk14.0.0-linux_x64.tar.gz",
-    "zulu_version": [14, 27, 1, 0],
-    "jdk_version": [14, 0, 0, 36]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu14.27.1-ca-jdk14.0.0-linux_x64.tar.gz",
+    "java_version": [
+      14,
+      0,
+      0,
+      36
+    ],
+    "distro_version": [
+      14,
+      27,
+      1,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11349,
-    "url": "https://cdn.azul.com/zulu/bin/zulu14.28.21-ca-jdk14.0.1-linux_x64.tar.gz",
+    "package_uuid": "uuid-11349",
     "name": "zulu14.28.21-ca-jdk14.0.1-linux_x64.tar.gz",
-    "zulu_version": [14, 28, 21, 0],
-    "jdk_version": [14, 0, 1, 8]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu14.28.21-ca-jdk14.0.1-linux_x64.tar.gz",
+    "java_version": [
+      14,
+      0,
+      1,
+      8
+    ],
+    "distro_version": [
+      14,
+      28,
+      21,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11513,
-    "url": "https://cdn.azul.com/zulu/bin/zulu14.29.23-ca-jdk14.0.2-linux_x64.tar.gz",
+    "package_uuid": "uuid-11513",
     "name": "zulu14.29.23-ca-jdk14.0.2-linux_x64.tar.gz",
-    "zulu_version": [14, 29, 23, 0],
-    "jdk_version": [14, 0, 2, 12]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu14.29.23-ca-jdk14.0.2-linux_x64.tar.gz",
+    "java_version": [
+      14,
+      0,
+      2,
+      12
+    ],
+    "distro_version": [
+      14,
+      29,
+      23,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11780,
-    "url": "https://cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-linux_x64.tar.gz",
+    "package_uuid": "uuid-11780",
     "name": "zulu15.27.17-ca-jdk15.0.0-linux_x64.tar.gz",
-    "zulu_version": [15, 27, 17, 0],
-    "jdk_version": [15, 0, 0, 36]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-linux_x64.tar.gz",
+    "java_version": [
+      15,
+      0,
+      0,
+      36
+    ],
+    "distro_version": [
+      15,
+      27,
+      17,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11924,
-    "url": "https://cdn.azul.com/zulu/bin/zulu15.28.13-ca-jdk15.0.1-linux_x64.tar.gz",
+    "package_uuid": "uuid-11924",
     "name": "zulu15.28.13-ca-jdk15.0.1-linux_x64.tar.gz",
-    "zulu_version": [15, 28, 13, 0],
-    "jdk_version": [15, 0, 1, 8]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu15.28.13-ca-jdk15.0.1-linux_x64.tar.gz",
+    "java_version": [
+      15,
+      0,
+      1,
+      8
+    ],
+    "distro_version": [
+      15,
+      28,
+      13,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 12101,
-    "url": "https://cdn.azul.com/zulu/bin/zulu15.28.51-ca-jdk15.0.1-linux_x64.tar.gz",
+    "package_uuid": "uuid-12101",
     "name": "zulu15.28.51-ca-jdk15.0.1-linux_x64.tar.gz",
-    "zulu_version": [15, 28, 51, 0],
-    "jdk_version": [15, 0, 1, 9]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu15.28.51-ca-jdk15.0.1-linux_x64.tar.gz",
+    "java_version": [
+      15,
+      0,
+      1,
+      9
+    ],
+    "distro_version": [
+      15,
+      28,
+      51,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 12445,
-    "url": "https://cdn.azul.com/zulu/bin/zulu15.29.15-ca-jdk15.0.2-linux_x64.tar.gz",
+    "package_uuid": "uuid-12445",
     "name": "zulu15.29.15-ca-jdk15.0.2-linux_x64.tar.gz",
-    "zulu_version": [15, 29, 15, 0],
-    "jdk_version": [15, 0, 2, 7]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu15.29.15-ca-jdk15.0.2-linux_x64.tar.gz",
+    "java_version": [
+      15,
+      0,
+      2,
+      7
+    ],
+    "distro_version": [
+      15,
+      29,
+      15,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 12447,
-    "url": "https://cdn.azul.com/zulu/bin/zulu21.32.17-ca-jdk21.0.2-linux_aarch64.tar.gz",
+    "package_uuid": "uuid-12447",
     "name": "zulu21.32.17-ca-jdk21.0.2-linux_aarch64.tar.gz",
-    "zulu_version": [21, 32, 17, 0],
-    "jdk_version": [21, 0, 2, 6]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu21.32.17-ca-jdk21.0.2-linux_aarch64.tar.gz",
+    "java_version": [
+      21,
+      0,
+      2,
+      6
+    ],
+    "distro_version": [
+      21,
+      32,
+      17,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   }
 ]

--- a/__tests__/data/zulu-releases-default.json
+++ b/__tests__/data/zulu-releases-default.json
@@ -1,247 +1,702 @@
 [
   {
-    "id": 10996,
-    "url": "https://cdn.azul.com/zulu/bin/zulu1.8.0_05-8.1.0.10-macosx.tar.gz",
+    "package_uuid": "uuid-10996",
     "name": "zulu1.8.0_05-8.1.0.10-macosx.tar.gz",
-    "zulu_version": [8, 1, 0, 10],
-    "jdk_version": [8, 0, 5, 13]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu1.8.0_05-8.1.0.10-macosx.tar.gz",
+    "java_version": [
+      8,
+      0,
+      5,
+      13
+    ],
+    "distro_version": [
+      8,
+      1,
+      0,
+      10
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10997,
-    "url": "https://cdn.azul.com/zulu/bin/zulu1.8.0_11-8.2.0.1-macosx.tar.gz",
+    "package_uuid": "uuid-10997",
     "name": "zulu1.8.0_11-8.2.0.1-macosx.tar.gz",
-    "zulu_version": [8, 2, 0, 1],
-    "jdk_version": [8, 0, 11, 12]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu1.8.0_11-8.2.0.1-macosx.tar.gz",
+    "java_version": [
+      8,
+      0,
+      11,
+      12
+    ],
+    "distro_version": [
+      8,
+      2,
+      0,
+      1
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10346,
-    "url": "https://cdn.azul.com/zulu/bin/zulu8.21.0.1-jdk8.0.131-macosx_x64.tar.gz",
+    "package_uuid": "uuid-10346",
     "name": "zulu8.21.0.1-jdk8.0.131-macosx_x64.tar.gz",
-    "zulu_version": [8, 21, 0, 1],
-    "jdk_version": [8, 0, 131, 11]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu8.21.0.1-jdk8.0.131-macosx_x64.tar.gz",
+    "java_version": [
+      8,
+      0,
+      131,
+      11
+    ],
+    "distro_version": [
+      8,
+      21,
+      0,
+      1
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10362,
-    "url": "https://cdn.azul.com/zulu/bin/zulu8.23.0.3-jdk8.0.144-macosx_x64.tar.gz",
+    "package_uuid": "uuid-10362",
     "name": "zulu8.23.0.3-jdk8.0.144-macosx_x64.tar.gz",
-    "zulu_version": [8, 23, 0, 3],
-    "jdk_version": [8, 0, 144, 1]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu8.23.0.3-jdk8.0.144-macosx_x64.tar.gz",
+    "java_version": [
+      8,
+      0,
+      144,
+      1
+    ],
+    "distro_version": [
+      8,
+      23,
+      0,
+      3
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10399,
-    "url": "https://cdn.azul.com/zulu/bin/zulu8.25.0.1-jdk8.0.152-macosx_x64.tar.gz",
+    "package_uuid": "uuid-10399",
     "name": "zulu8.25.0.1-jdk8.0.152-macosx_x64.tar.gz",
-    "zulu_version": [8, 25, 0, 1],
-    "jdk_version": [8, 0, 152, 16]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu8.25.0.1-jdk8.0.152-macosx_x64.tar.gz",
+    "java_version": [
+      8,
+      0,
+      152,
+      16
+    ],
+    "distro_version": [
+      8,
+      25,
+      0,
+      1
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11355,
-    "url": "https://cdn.azul.com/zulu/bin/zulu8.46.0.19-ca-jdk8.0.252-macosx_x64.tar.gz",
+    "package_uuid": "uuid-11355",
     "name": "zulu8.46.0.19-ca-jdk8.0.252-macosx_x64.tar.gz",
-    "zulu_version": [8, 46, 0, 19],
-    "jdk_version": [8, 0, 252, 14]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu8.46.0.19-ca-jdk8.0.252-macosx_x64.tar.gz",
+    "java_version": [
+      8,
+      0,
+      252,
+      14
+    ],
+    "distro_version": [
+      8,
+      46,
+      0,
+      19
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11481,
-    "url": "https://cdn.azul.com/zulu/bin/zulu8.48.0.47-ca-jdk8.0.262-macosx_x64.tar.gz",
+    "package_uuid": "uuid-11481",
     "name": "zulu8.48.0.47-ca-jdk8.0.262-macosx_x64.tar.gz",
-    "zulu_version": [8, 48, 0, 47],
-    "jdk_version": [8, 0, 262, 17]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu8.48.0.47-ca-jdk8.0.262-macosx_x64.tar.gz",
+    "java_version": [
+      8,
+      0,
+      262,
+      17
+    ],
+    "distro_version": [
+      8,
+      48,
+      0,
+      47
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11622,
-    "url": "https://cdn.azul.com/zulu/bin/zulu8.48.0.51-ca-jdk8.0.262-macosx_x64.tar.gz",
+    "package_uuid": "uuid-11622",
     "name": "zulu8.48.0.51-ca-jdk8.0.262-macosx_x64.tar.gz",
-    "zulu_version": [8, 48, 0, 51],
-    "jdk_version": [8, 0, 262, 19]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu8.48.0.51-ca-jdk8.0.262-macosx_x64.tar.gz",
+    "java_version": [
+      8,
+      0,
+      262,
+      19
+    ],
+    "distro_version": [
+      8,
+      48,
+      0,
+      51
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11535,
-    "url": "https://cdn.azul.com/zulu/bin/zulu8.48.0.49-ca-jdk8.0.262-macosx_x64.tar.gz",
+    "package_uuid": "uuid-11535",
     "name": "zulu8.48.0.49-ca-jdk8.0.262-macosx_x64.tar.gz",
-    "zulu_version": [8, 48, 0, 49],
-    "jdk_version": [8, 0, 262, 18]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu8.48.0.49-ca-jdk8.0.262-macosx_x64.tar.gz",
+    "java_version": [
+      8,
+      0,
+      262,
+      18
+    ],
+    "distro_version": [
+      8,
+      48,
+      0,
+      49
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 12424,
-    "url": "https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-jdk8.0.282-macosx_x64.tar.gz",
+    "package_uuid": "uuid-12424",
     "name": "zulu8.52.0.23-ca-jdk8.0.282-macosx_x64.tar.gz",
-    "zulu_version": [8, 52, 0, 23],
-    "jdk_version": [8, 0, 282, 8]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-jdk8.0.282-macosx_x64.tar.gz",
+    "java_version": [
+      8,
+      0,
+      282,
+      8
+    ],
+    "distro_version": [
+      8,
+      52,
+      0,
+      23
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10383,
-    "url": "https://cdn.azul.com/zulu/bin/zulu9.0.0.15-jdk9.0.0-macosx_x64.tar.gz",
+    "package_uuid": "uuid-10383",
     "name": "zulu9.0.0.15-jdk9.0.0-macosx_x64.tar.gz",
-    "zulu_version": [9, 0, 0, 15],
-    "jdk_version": [9, 0, 0, 0]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu9.0.0.15-jdk9.0.0-macosx_x64.tar.gz",
+    "java_version": [
+      9,
+      0,
+      0,
+      0
+    ],
+    "distro_version": [
+      9,
+      0,
+      0,
+      15
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10413,
-    "url": "https://cdn.azul.com/zulu/bin/zulu9.0.1.3-jdk9.0.1-macosx_x64.tar.gz",
+    "package_uuid": "uuid-10413",
     "name": "zulu9.0.1.3-jdk9.0.1-macosx_x64.tar.gz",
-    "zulu_version": [9, 0, 1, 3],
-    "jdk_version": [9, 0, 1, 0]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu9.0.1.3-jdk9.0.1-macosx_x64.tar.gz",
+    "java_version": [
+      9,
+      0,
+      1,
+      0
+    ],
+    "distro_version": [
+      9,
+      0,
+      1,
+      3
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10503,
-    "url": "https://cdn.azul.com/zulu/bin/zulu10.2+3-jdk10.0.1-macosx_x64.tar.gz",
+    "package_uuid": "uuid-10503",
     "name": "zulu10.2+3-jdk10.0.1-macosx_x64.tar.gz",
-    "zulu_version": [10, 2, 3, 0],
-    "jdk_version": [10, 0, 1, 9]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu10.2+3-jdk10.0.1-macosx_x64.tar.gz",
+    "java_version": [
+      10,
+      0,
+      1,
+      9
+    ],
+    "distro_version": [
+      10,
+      2,
+      3,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10541,
-    "url": "https://cdn.azul.com/zulu/bin/zulu10.3+5-jdk10.0.2-macosx_x64.tar.gz",
+    "package_uuid": "uuid-10541",
     "name": "zulu10.3+5-jdk10.0.2-macosx_x64.tar.gz",
-    "zulu_version": [10, 3, 5, 0],
-    "jdk_version": [10, 0, 2, 13]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu10.3+5-jdk10.0.2-macosx_x64.tar.gz",
+    "java_version": [
+      10,
+      0,
+      2,
+      13
+    ],
+    "distro_version": [
+      10,
+      3,
+      5,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10576,
-    "url": "https://cdn.azul.com/zulu/bin/zulu11.2.3-jdk11.0.1-macosx_x64.tar.gz",
+    "package_uuid": "uuid-10576",
     "name": "zulu11.2.3-jdk11.0.1-macosx_x64.tar.gz",
-    "zulu_version": [11, 2, 3, 0],
-    "jdk_version": [11, 0, 1, 13]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu11.2.3-jdk11.0.1-macosx_x64.tar.gz",
+    "java_version": [
+      11,
+      0,
+      1,
+      13
+    ],
+    "distro_version": [
+      11,
+      2,
+      3,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10604,
-    "url": "https://cdn.azul.com/zulu/bin/zulu11.29.3-ca-jdk11.0.2-macosx_x64.tar.gz",
+    "package_uuid": "uuid-10604",
     "name": "zulu11.29.3-ca-jdk11.0.2-macosx_x64.tar.gz",
-    "zulu_version": [11, 29, 3, 0],
-    "jdk_version": [11, 0, 2, 7]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu11.29.3-ca-jdk11.0.2-macosx_x64.tar.gz",
+    "java_version": [
+      11,
+      0,
+      2,
+      7
+    ],
+    "distro_version": [
+      11,
+      29,
+      3,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10687,
-    "url": "https://cdn.azul.com/zulu/bin/zulu11.31.11-ca-jdk11.0.3-macosx_x64.tar.gz",
+    "package_uuid": "uuid-10687",
     "name": "zulu11.31.11-ca-jdk11.0.3-macosx_x64.tar.gz",
-    "zulu_version": [11, 31, 11, 0],
-    "jdk_version": [11, 0, 3, 7]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu11.31.11-ca-jdk11.0.3-macosx_x64.tar.gz",
+    "java_version": [
+      11,
+      0,
+      3,
+      7
+    ],
+    "distro_version": [
+      11,
+      31,
+      11,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10856,
-    "url": "https://cdn.azul.com/zulu/bin/zulu11.35.13-ca-jdk11.0.5-macosx_x64.tar.gz",
+    "package_uuid": "uuid-10856",
     "name": "zulu11.35.13-ca-jdk11.0.5-macosx_x64.tar.gz",
-    "zulu_version": [11, 35, 13, 0],
-    "jdk_version": [11, 0, 5, 10]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu11.35.13-ca-jdk11.0.5-macosx_x64.tar.gz",
+    "java_version": [
+      11,
+      0,
+      5,
+      10
+    ],
+    "distro_version": [
+      11,
+      35,
+      13,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10933,
-    "url": "https://cdn.azul.com/zulu/bin/zulu11.35.15-ca-jdk11.0.5-macosx_x64.tar.gz",
+    "package_uuid": "uuid-10933",
     "name": "zulu11.35.15-ca-jdk11.0.5-macosx_x64.tar.gz",
-    "zulu_version": [11, 35, 15, 0],
-    "jdk_version": [11, 0, 5, 10]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu11.35.15-ca-jdk11.0.5-macosx_x64.tar.gz",
+    "java_version": [
+      11,
+      0,
+      5,
+      10
+    ],
+    "distro_version": [
+      11,
+      35,
+      15,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10933,
-    "url": "https://cdn.azul.com/zulu/bin/zulu11.35.11-ca-jdk11.0.5-macosx_x64.tar.gz",
+    "package_uuid": "uuid-10933",
     "name": "zulu11.35.15-ca-jdk11.0.5-macosx_x64.tar.gz",
-    "zulu_version": [11, 35, 11, 0],
-    "jdk_version": [11, 0, 5, 10]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu11.35.11-ca-jdk11.0.5-macosx_x64.tar.gz",
+    "java_version": [
+      11,
+      0,
+      5,
+      10
+    ],
+    "distro_version": [
+      11,
+      35,
+      11,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 12397,
-    "url": "https://cdn.azul.com/zulu/bin/zulu11.45.27-ca-jdk11.0.10-macosx_x64.tar.gz",
+    "package_uuid": "uuid-12397",
     "name": "zulu11.45.27-ca-jdk11.0.10-macosx_x64.tar.gz",
-    "zulu_version": [11, 45, 27, 0],
-    "jdk_version": [11, 0, 10, 9]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu11.45.27-ca-jdk11.0.10-macosx_x64.tar.gz",
+    "java_version": [
+      11,
+      0,
+      10,
+      9
+    ],
+    "distro_version": [
+      11,
+      45,
+      27,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10667,
-    "url": "https://cdn.azul.com/zulu/bin/zulu12.1.3-ca-jdk12.0.0-macosx_x64.tar.gz",
+    "package_uuid": "uuid-10667",
     "name": "zulu12.1.3-ca-jdk12.0.0-macosx_x64.tar.gz",
-    "zulu_version": [12, 1, 3, 0],
-    "jdk_version": [12, 0, 0, 33]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu12.1.3-ca-jdk12.0.0-macosx_x64.tar.gz",
+    "java_version": [
+      12,
+      0,
+      0,
+      33
+    ],
+    "distro_version": [
+      12,
+      1,
+      3,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10710,
-    "url": "https://cdn.azul.com/zulu/bin/zulu12.2.3-ca-jdk12.0.1-macosx_x64.tar.gz",
+    "package_uuid": "uuid-10710",
     "name": "zulu12.2.3-ca-jdk12.0.1-macosx_x64.tar.gz",
-    "zulu_version": [12, 2, 3, 0],
-    "jdk_version": [12, 0, 1, 12]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu12.2.3-ca-jdk12.0.1-macosx_x64.tar.gz",
+    "java_version": [
+      12,
+      0,
+      1,
+      12
+    ],
+    "distro_version": [
+      12,
+      2,
+      3,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10780,
-    "url": "https://cdn.azul.com/zulu/bin/zulu12.3.11-ca-jdk12.0.2-macosx_x64.tar.gz",
+    "package_uuid": "uuid-10780",
     "name": "zulu12.3.11-ca-jdk12.0.2-macosx_x64.tar.gz",
-    "zulu_version": [12, 3, 11, 0],
-    "jdk_version": [12, 0, 2, 3]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu12.3.11-ca-jdk12.0.2-macosx_x64.tar.gz",
+    "java_version": [
+      12,
+      0,
+      2,
+      3
+    ],
+    "distro_version": [
+      12,
+      3,
+      11,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10846,
-    "url": "https://cdn.azul.com/zulu/bin/zulu13.27.9-ca-jdk13.0.0-macosx_x64.tar.gz",
+    "package_uuid": "uuid-10846",
     "name": "zulu13.27.9-ca-jdk13.0.0-macosx_x64.tar.gz",
-    "zulu_version": [13, 27, 9, 0],
-    "jdk_version": [13, 0, 0, 33]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu13.27.9-ca-jdk13.0.0-macosx_x64.tar.gz",
+    "java_version": [
+      13,
+      0,
+      0,
+      33
+    ],
+    "distro_version": [
+      13,
+      27,
+      9,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10888,
-    "url": "https://cdn.azul.com/zulu/bin/zulu13.28.11-ca-jdk13.0.1-macosx_x64.tar.gz",
+    "package_uuid": "uuid-10888",
     "name": "zulu13.28.11-ca-jdk13.0.1-macosx_x64.tar.gz",
-    "zulu_version": [13, 28, 11, 0],
-    "jdk_version": [13, 0, 1, 10]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu13.28.11-ca-jdk13.0.1-macosx_x64.tar.gz",
+    "java_version": [
+      13,
+      0,
+      1,
+      10
+    ],
+    "distro_version": [
+      13,
+      28,
+      11,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11073,
-    "url": "https://cdn.azul.com/zulu/bin/zulu13.29.9-ca-jdk13.0.2-macosx_x64.tar.gz",
+    "package_uuid": "uuid-11073",
     "name": "zulu13.29.9-ca-jdk13.0.2-macosx_x64.tar.gz",
-    "zulu_version": [13, 29, 9, 0],
-    "jdk_version": [13, 0, 2, 6]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu13.29.9-ca-jdk13.0.2-macosx_x64.tar.gz",
+    "java_version": [
+      13,
+      0,
+      2,
+      6
+    ],
+    "distro_version": [
+      13,
+      29,
+      9,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 12408,
-    "url": "https://cdn.azul.com/zulu/bin/zulu13.37.21-ca-jdk13.0.6-macosx_x64.tar.gz",
+    "package_uuid": "uuid-12408",
     "name": "zulu13.37.21-ca-jdk13.0.6-macosx_x64.tar.gz",
-    "zulu_version": [13, 37, 21, 0],
-    "jdk_version": [13, 0, 6, 5]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu13.37.21-ca-jdk13.0.6-macosx_x64.tar.gz",
+    "java_version": [
+      13,
+      0,
+      6,
+      5
+    ],
+    "distro_version": [
+      13,
+      37,
+      21,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11236,
-    "url": "https://cdn.azul.com/zulu/bin/zulu14.27.1-ca-jdk14.0.0-macosx_x64.tar.gz",
+    "package_uuid": "uuid-11236",
     "name": "zulu14.27.1-ca-jdk14.0.0-macosx_x64.tar.gz",
-    "zulu_version": [14, 27, 1, 0],
-    "jdk_version": [14, 0, 0, 36]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu14.27.1-ca-jdk14.0.0-macosx_x64.tar.gz",
+    "java_version": [
+      14,
+      0,
+      0,
+      36
+    ],
+    "distro_version": [
+      14,
+      27,
+      1,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11349,
-    "url": "https://cdn.azul.com/zulu/bin/zulu14.28.21-ca-jdk14.0.1-macosx_x64.tar.gz",
+    "package_uuid": "uuid-11349",
     "name": "zulu14.28.21-ca-jdk14.0.1-macosx_x64.tar.gz",
-    "zulu_version": [14, 28, 21, 0],
-    "jdk_version": [14, 0, 1, 8]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu14.28.21-ca-jdk14.0.1-macosx_x64.tar.gz",
+    "java_version": [
+      14,
+      0,
+      1,
+      8
+    ],
+    "distro_version": [
+      14,
+      28,
+      21,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11513,
-    "url": "https://cdn.azul.com/zulu/bin/zulu14.29.23-ca-jdk14.0.2-macosx_x64.tar.gz",
+    "package_uuid": "uuid-11513",
     "name": "zulu14.29.23-ca-jdk14.0.2-macosx_x64.tar.gz",
-    "zulu_version": [14, 29, 23, 0],
-    "jdk_version": [14, 0, 2, 12]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu14.29.23-ca-jdk14.0.2-macosx_x64.tar.gz",
+    "java_version": [
+      14,
+      0,
+      2,
+      12
+    ],
+    "distro_version": [
+      14,
+      29,
+      23,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11780,
-    "url": "https://cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-macosx_x64.tar.gz",
+    "package_uuid": "uuid-11780",
     "name": "zulu15.27.17-ca-jdk15.0.0-macosx_x64.tar.gz",
-    "zulu_version": [15, 27, 17, 0],
-    "jdk_version": [15, 0, 0, 36]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-macosx_x64.tar.gz",
+    "java_version": [
+      15,
+      0,
+      0,
+      36
+    ],
+    "distro_version": [
+      15,
+      27,
+      17,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11924,
-    "url": "https://cdn.azul.com/zulu/bin/zulu15.28.13-ca-jdk15.0.1-macosx_x64.tar.gz",
+    "package_uuid": "uuid-11924",
     "name": "zulu15.28.13-ca-jdk15.0.1-macosx_x64.tar.gz",
-    "zulu_version": [15, 28, 13, 0],
-    "jdk_version": [15, 0, 1, 8]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu15.28.13-ca-jdk15.0.1-macosx_x64.tar.gz",
+    "java_version": [
+      15,
+      0,
+      1,
+      8
+    ],
+    "distro_version": [
+      15,
+      28,
+      13,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 12101,
-    "url": "https://cdn.azul.com/zulu/bin/zulu15.28.51-ca-jdk15.0.1-macosx_x64.tar.gz",
+    "package_uuid": "uuid-12101",
     "name": "zulu15.28.51-ca-jdk15.0.1-macosx_x64.tar.gz",
-    "zulu_version": [15, 28, 51, 0],
-    "jdk_version": [15, 0, 1, 9]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu15.28.51-ca-jdk15.0.1-macosx_x64.tar.gz",
+    "java_version": [
+      15,
+      0,
+      1,
+      9
+    ],
+    "distro_version": [
+      15,
+      28,
+      51,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 12445,
-    "url": "https://cdn.azul.com/zulu/bin/zulu15.29.15-ca-jdk15.0.2-macosx_x64.tar.gz",
+    "package_uuid": "uuid-12445",
     "name": "zulu15.29.15-ca-jdk15.0.2-macosx_x64.tar.gz",
-    "zulu_version": [15, 29, 15, 0],
-    "jdk_version": [15, 0, 2, 7]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu15.29.15-ca-jdk15.0.2-macosx_x64.tar.gz",
+    "java_version": [
+      15,
+      0,
+      2,
+      7
+    ],
+    "distro_version": [
+      15,
+      29,
+      15,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   }
 ]

--- a/__tests__/data/zulu-windows.json
+++ b/__tests__/data/zulu-windows.json
@@ -701,7 +701,7 @@
   },
   {
     "package_uuid": "uuid-12446",
-    "name": "zulu17.48.15-ca-jdk17.0.10-win_aarhc4.zip",
+    "name": "zulu17.48.15-ca-jdk17.0.10-windows_aarch64.zip",
     "download_url": "https://cdn.azul.com/zulu/bin/zulu17.48.15-ca-jdk17.0.10-windows_aarch64.zip",
     "java_version": [
       17,

--- a/__tests__/data/zulu-windows.json
+++ b/__tests__/data/zulu-windows.json
@@ -1,254 +1,722 @@
-[  
+[
   {
-    "id": 10996,
-    "url": "https://cdn.azul.com/zulu/bin/zulu1.8.0_05-8.1.0.10-windows.tar.gz",
+    "package_uuid": "uuid-10996",
     "name": "zulu1.8.0_05-8.1.0.10-windows.tar.gz",
-    "zulu_version": [8, 1, 0, 10],
-    "jdk_version": [8, 0, 5, 13]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu1.8.0_05-8.1.0.10-windows.tar.gz",
+    "java_version": [
+      8,
+      0,
+      5,
+      13
+    ],
+    "distro_version": [
+      8,
+      1,
+      0,
+      10
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10997,
-    "url": "https://cdn.azul.com/zulu/bin/zulu1.8.0_11-8.2.0.1-windows.tar.gz",
+    "package_uuid": "uuid-10997",
     "name": "zulu1.8.0_11-8.2.0.1-windows.tar.gz",
-    "zulu_version": [8, 2, 0, 1],
-    "jdk_version": [8, 0, 11, 12]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu1.8.0_11-8.2.0.1-windows.tar.gz",
+    "java_version": [
+      8,
+      0,
+      11,
+      12
+    ],
+    "distro_version": [
+      8,
+      2,
+      0,
+      1
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10346,
-    "url": "https://cdn.azul.com/zulu/bin/zulu8.21.0.1-jdk8.0.131-windows_x64.tar.gz",
+    "package_uuid": "uuid-10346",
     "name": "zulu8.21.0.1-jdk8.0.131-windows_x64.tar.gz",
-    "zulu_version": [8, 21, 0, 1],
-    "jdk_version": [8, 0, 131, 11]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu8.21.0.1-jdk8.0.131-windows_x64.tar.gz",
+    "java_version": [
+      8,
+      0,
+      131,
+      11
+    ],
+    "distro_version": [
+      8,
+      21,
+      0,
+      1
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10362,
-    "url": "https://cdn.azul.com/zulu/bin/zulu8.23.0.3-jdk8.0.144-windows_x64.tar.gz",
+    "package_uuid": "uuid-10362",
     "name": "zulu8.23.0.3-jdk8.0.144-windows_x64.tar.gz",
-    "zulu_version": [8, 23, 0, 3],
-    "jdk_version": [8, 0, 144, 1]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu8.23.0.3-jdk8.0.144-windows_x64.tar.gz",
+    "java_version": [
+      8,
+      0,
+      144,
+      1
+    ],
+    "distro_version": [
+      8,
+      23,
+      0,
+      3
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10399,
-    "url": "https://cdn.azul.com/zulu/bin/zulu8.25.0.1-jdk8.0.152-windows_x64.tar.gz",
+    "package_uuid": "uuid-10399",
     "name": "zulu8.25.0.1-jdk8.0.152-windows_x64.tar.gz",
-    "zulu_version": [8, 25, 0, 1],
-    "jdk_version": [8, 0, 152, 16]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu8.25.0.1-jdk8.0.152-windows_x64.tar.gz",
+    "java_version": [
+      8,
+      0,
+      152,
+      16
+    ],
+    "distro_version": [
+      8,
+      25,
+      0,
+      1
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11355,
-    "url": "https://cdn.azul.com/zulu/bin/zulu8.46.0.19-ca-jdk8.0.252-windows_x64.tar.gz",
+    "package_uuid": "uuid-11355",
     "name": "zulu8.46.0.19-ca-jdk8.0.252-windows_x64.tar.gz",
-    "zulu_version": [8, 46, 0, 19],
-    "jdk_version": [8, 0, 252, 14]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu8.46.0.19-ca-jdk8.0.252-windows_x64.tar.gz",
+    "java_version": [
+      8,
+      0,
+      252,
+      14
+    ],
+    "distro_version": [
+      8,
+      46,
+      0,
+      19
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11481,
-    "url": "https://cdn.azul.com/zulu/bin/zulu8.48.0.47-ca-jdk8.0.262-windows_x64.tar.gz",
+    "package_uuid": "uuid-11481",
     "name": "zulu8.48.0.47-ca-jdk8.0.262-windows_x64.tar.gz",
-    "zulu_version": [8, 48, 0, 47],
-    "jdk_version": [8, 0, 262, 17]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu8.48.0.47-ca-jdk8.0.262-windows_x64.tar.gz",
+    "java_version": [
+      8,
+      0,
+      262,
+      17
+    ],
+    "distro_version": [
+      8,
+      48,
+      0,
+      47
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11622,
-    "url": "https://cdn.azul.com/zulu/bin/zulu8.48.0.51-ca-jdk8.0.262-windows_x64.tar.gz",
+    "package_uuid": "uuid-11622",
     "name": "zulu8.48.0.51-ca-jdk8.0.262-windows_x64.tar.gz",
-    "zulu_version": [8, 48, 0, 51],
-    "jdk_version": [8, 0, 262, 19]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu8.48.0.51-ca-jdk8.0.262-windows_x64.tar.gz",
+    "java_version": [
+      8,
+      0,
+      262,
+      19
+    ],
+    "distro_version": [
+      8,
+      48,
+      0,
+      51
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11535,
-    "url": "https://cdn.azul.com/zulu/bin/zulu8.48.0.49-ca-jdk8.0.262-windows_x64.tar.gz",
+    "package_uuid": "uuid-11535",
     "name": "zulu8.48.0.49-ca-jdk8.0.262-windows_x64.tar.gz",
-    "zulu_version": [8, 48, 0, 49],
-    "jdk_version": [8, 0, 262, 18]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu8.48.0.49-ca-jdk8.0.262-windows_x64.tar.gz",
+    "java_version": [
+      8,
+      0,
+      262,
+      18
+    ],
+    "distro_version": [
+      8,
+      48,
+      0,
+      49
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 12424,
-    "url": "https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-jdk8.0.282-windows_x64.tar.gz",
+    "package_uuid": "uuid-12424",
     "name": "zulu8.52.0.23-ca-jdk8.0.282-windows_x64.tar.gz",
-    "zulu_version": [8, 52, 0, 23],
-    "jdk_version": [8, 0, 282, 8]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-jdk8.0.282-windows_x64.tar.gz",
+    "java_version": [
+      8,
+      0,
+      282,
+      8
+    ],
+    "distro_version": [
+      8,
+      52,
+      0,
+      23
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10383,
-    "url": "https://cdn.azul.com/zulu/bin/zulu9.0.0.15-jdk9.0.0-windows_x64.tar.gz",
+    "package_uuid": "uuid-10383",
     "name": "zulu9.0.0.15-jdk9.0.0-windows_x64.tar.gz",
-    "zulu_version": [9, 0, 0, 15],
-    "jdk_version": [9, 0, 0, 0]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu9.0.0.15-jdk9.0.0-windows_x64.tar.gz",
+    "java_version": [
+      9,
+      0,
+      0,
+      0
+    ],
+    "distro_version": [
+      9,
+      0,
+      0,
+      15
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10413,
-    "url": "https://cdn.azul.com/zulu/bin/zulu9.0.1.3-jdk9.0.1-windows_x64.tar.gz",
+    "package_uuid": "uuid-10413",
     "name": "zulu9.0.1.3-jdk9.0.1-windows_x64.tar.gz",
-    "zulu_version": [9, 0, 1, 3],
-    "jdk_version": [9, 0, 1, 0]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu9.0.1.3-jdk9.0.1-windows_x64.tar.gz",
+    "java_version": [
+      9,
+      0,
+      1,
+      0
+    ],
+    "distro_version": [
+      9,
+      0,
+      1,
+      3
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10503,
-    "url": "https://cdn.azul.com/zulu/bin/zulu10.2+3-jdk10.0.1-windows_x64.tar.gz",
+    "package_uuid": "uuid-10503",
     "name": "zulu10.2+3-jdk10.0.1-windows_x64.tar.gz",
-    "zulu_version": [10, 2, 3, 0],
-    "jdk_version": [10, 0, 1, 9]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu10.2+3-jdk10.0.1-windows_x64.tar.gz",
+    "java_version": [
+      10,
+      0,
+      1,
+      9
+    ],
+    "distro_version": [
+      10,
+      2,
+      3,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10541,
-    "url": "https://cdn.azul.com/zulu/bin/zulu10.3+5-jdk10.0.2-windows_x64.tar.gz",
+    "package_uuid": "uuid-10541",
     "name": "zulu10.3+5-jdk10.0.2-windows_x64.tar.gz",
-    "zulu_version": [10, 3, 5, 0],
-    "jdk_version": [10, 0, 2, 13]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu10.3+5-jdk10.0.2-windows_x64.tar.gz",
+    "java_version": [
+      10,
+      0,
+      2,
+      13
+    ],
+    "distro_version": [
+      10,
+      3,
+      5,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10576,
-    "url": "https://cdn.azul.com/zulu/bin/zulu11.2.3-jdk11.0.1-windows_x64.tar.gz",
+    "package_uuid": "uuid-10576",
     "name": "zulu11.2.3-jdk11.0.1-windows_x64.tar.gz",
-    "zulu_version": [11, 2, 3, 0],
-    "jdk_version": [11, 0, 1, 13]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu11.2.3-jdk11.0.1-windows_x64.tar.gz",
+    "java_version": [
+      11,
+      0,
+      1,
+      13
+    ],
+    "distro_version": [
+      11,
+      2,
+      3,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10604,
-    "url": "https://cdn.azul.com/zulu/bin/zulu11.29.3-ca-jdk11.0.2-windows_x64.tar.gz",
+    "package_uuid": "uuid-10604",
     "name": "zulu11.29.3-ca-jdk11.0.2-windows_x64.tar.gz",
-    "zulu_version": [11, 29, 3, 0],
-    "jdk_version": [11, 0, 2, 7]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu11.29.3-ca-jdk11.0.2-windows_x64.tar.gz",
+    "java_version": [
+      11,
+      0,
+      2,
+      7
+    ],
+    "distro_version": [
+      11,
+      29,
+      3,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10687,
-    "url": "https://cdn.azul.com/zulu/bin/zulu11.31.11-ca-jdk11.0.3-windows_x64.tar.gz",
+    "package_uuid": "uuid-10687",
     "name": "zulu11.31.11-ca-jdk11.0.3-windows_x64.tar.gz",
-    "zulu_version": [11, 31, 11, 0],
-    "jdk_version": [11, 0, 3, 7]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu11.31.11-ca-jdk11.0.3-windows_x64.tar.gz",
+    "java_version": [
+      11,
+      0,
+      3,
+      7
+    ],
+    "distro_version": [
+      11,
+      31,
+      11,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10856,
-    "url": "https://cdn.azul.com/zulu/bin/zulu11.35.13-ca-jdk11.0.5-windows_x64.tar.gz",
+    "package_uuid": "uuid-10856",
     "name": "zulu11.35.13-ca-jdk11.0.5-windows_x64.tar.gz",
-    "zulu_version": [11, 35, 13, 0],
-    "jdk_version": [11, 0, 5, 10]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu11.35.13-ca-jdk11.0.5-windows_x64.tar.gz",
+    "java_version": [
+      11,
+      0,
+      5,
+      10
+    ],
+    "distro_version": [
+      11,
+      35,
+      13,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10933,
-    "url": "https://cdn.azul.com/zulu/bin/zulu11.35.15-ca-jdk11.0.5-windows_x64.tar.gz",
+    "package_uuid": "uuid-10933",
     "name": "zulu11.35.15-ca-jdk11.0.5-windows_x64.tar.gz",
-    "zulu_version": [11, 35, 15, 0],
-    "jdk_version": [11, 0, 5, 10]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu11.35.15-ca-jdk11.0.5-windows_x64.tar.gz",
+    "java_version": [
+      11,
+      0,
+      5,
+      10
+    ],
+    "distro_version": [
+      11,
+      35,
+      15,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10933,
-    "url": "https://cdn.azul.com/zulu/bin/zulu11.35.11-ca-jdk11.0.5-windows_x64.tar.gz",
+    "package_uuid": "uuid-10933",
     "name": "zulu11.35.15-ca-jdk11.0.5-windows_x64.tar.gz",
-    "zulu_version": [11, 35, 11, 0],
-    "jdk_version": [11, 0, 5, 10]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu11.35.11-ca-jdk11.0.5-windows_x64.tar.gz",
+    "java_version": [
+      11,
+      0,
+      5,
+      10
+    ],
+    "distro_version": [
+      11,
+      35,
+      11,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 12397,
-    "url": "https://cdn.azul.com/zulu/bin/zulu11.45.27-ca-jdk11.0.10-windows_x64.tar.gz",
+    "package_uuid": "uuid-12397",
     "name": "zulu11.45.27-ca-jdk11.0.10-windows_x64.tar.gz",
-    "zulu_version": [11, 45, 27, 0],
-    "jdk_version": [11, 0, 10, 9]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu11.45.27-ca-jdk11.0.10-windows_x64.tar.gz",
+    "java_version": [
+      11,
+      0,
+      10,
+      9
+    ],
+    "distro_version": [
+      11,
+      45,
+      27,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10667,
-    "url": "https://cdn.azul.com/zulu/bin/zulu12.1.3-ca-jdk12.0.0-windows_x64.tar.gz",
+    "package_uuid": "uuid-10667",
     "name": "zulu12.1.3-ca-jdk12.0.0-windows_x64.tar.gz",
-    "zulu_version": [12, 1, 3, 0],
-    "jdk_version": [12, 0, 0, 33]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu12.1.3-ca-jdk12.0.0-windows_x64.tar.gz",
+    "java_version": [
+      12,
+      0,
+      0,
+      33
+    ],
+    "distro_version": [
+      12,
+      1,
+      3,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10710,
-    "url": "https://cdn.azul.com/zulu/bin/zulu12.2.3-ca-jdk12.0.1-windows_x64.tar.gz",
+    "package_uuid": "uuid-10710",
     "name": "zulu12.2.3-ca-jdk12.0.1-windows_x64.tar.gz",
-    "zulu_version": [12, 2, 3, 0],
-    "jdk_version": [12, 0, 1, 12]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu12.2.3-ca-jdk12.0.1-windows_x64.tar.gz",
+    "java_version": [
+      12,
+      0,
+      1,
+      12
+    ],
+    "distro_version": [
+      12,
+      2,
+      3,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10780,
-    "url": "https://cdn.azul.com/zulu/bin/zulu12.3.11-ca-jdk12.0.2-windows_x64.tar.gz",
+    "package_uuid": "uuid-10780",
     "name": "zulu12.3.11-ca-jdk12.0.2-windows_x64.tar.gz",
-    "zulu_version": [12, 3, 11, 0],
-    "jdk_version": [12, 0, 2, 3]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu12.3.11-ca-jdk12.0.2-windows_x64.tar.gz",
+    "java_version": [
+      12,
+      0,
+      2,
+      3
+    ],
+    "distro_version": [
+      12,
+      3,
+      11,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10846,
-    "url": "https://cdn.azul.com/zulu/bin/zulu13.27.9-ca-jdk13.0.0-windows_x64.tar.gz",
+    "package_uuid": "uuid-10846",
     "name": "zulu13.27.9-ca-jdk13.0.0-windows_x64.tar.gz",
-    "zulu_version": [13, 27, 9, 0],
-    "jdk_version": [13, 0, 0, 33]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu13.27.9-ca-jdk13.0.0-windows_x64.tar.gz",
+    "java_version": [
+      13,
+      0,
+      0,
+      33
+    ],
+    "distro_version": [
+      13,
+      27,
+      9,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 10888,
-    "url": "https://cdn.azul.com/zulu/bin/zulu13.28.11-ca-jdk13.0.1-windows_x64.tar.gz",
+    "package_uuid": "uuid-10888",
     "name": "zulu13.28.11-ca-jdk13.0.1-windows_x64.tar.gz",
-    "zulu_version": [13, 28, 11, 0],
-    "jdk_version": [13, 0, 1, 10]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu13.28.11-ca-jdk13.0.1-windows_x64.tar.gz",
+    "java_version": [
+      13,
+      0,
+      1,
+      10
+    ],
+    "distro_version": [
+      13,
+      28,
+      11,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11073,
-    "url": "https://cdn.azul.com/zulu/bin/zulu13.29.9-ca-jdk13.0.2-windows_x64.tar.gz",
+    "package_uuid": "uuid-11073",
     "name": "zulu13.29.9-ca-jdk13.0.2-windows_x64.tar.gz",
-    "zulu_version": [13, 29, 9, 0],
-    "jdk_version": [13, 0, 2, 6]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu13.29.9-ca-jdk13.0.2-windows_x64.tar.gz",
+    "java_version": [
+      13,
+      0,
+      2,
+      6
+    ],
+    "distro_version": [
+      13,
+      29,
+      9,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 12408,
-    "url": "https://cdn.azul.com/zulu/bin/zulu13.37.21-ca-jdk13.0.6-windows_x64.tar.gz",
+    "package_uuid": "uuid-12408",
     "name": "zulu13.37.21-ca-jdk13.0.6-windows_x64.tar.gz",
-    "zulu_version": [13, 37, 21, 0],
-    "jdk_version": [13, 0, 6, 5]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu13.37.21-ca-jdk13.0.6-windows_x64.tar.gz",
+    "java_version": [
+      13,
+      0,
+      6,
+      5
+    ],
+    "distro_version": [
+      13,
+      37,
+      21,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11236,
-    "url": "https://cdn.azul.com/zulu/bin/zulu14.27.1-ca-jdk14.0.0-windows_x64.tar.gz",
+    "package_uuid": "uuid-11236",
     "name": "zulu14.27.1-ca-jdk14.0.0-windows_x64.tar.gz",
-    "zulu_version": [14, 27, 1, 0],
-    "jdk_version": [14, 0, 0, 36]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu14.27.1-ca-jdk14.0.0-windows_x64.tar.gz",
+    "java_version": [
+      14,
+      0,
+      0,
+      36
+    ],
+    "distro_version": [
+      14,
+      27,
+      1,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11349,
-    "url": "https://cdn.azul.com/zulu/bin/zulu14.28.21-ca-jdk14.0.1-windows_x64.tar.gz",
+    "package_uuid": "uuid-11349",
     "name": "zulu14.28.21-ca-jdk14.0.1-windows_x64.tar.gz",
-    "zulu_version": [14, 28, 21, 0],
-    "jdk_version": [14, 0, 1, 8]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu14.28.21-ca-jdk14.0.1-windows_x64.tar.gz",
+    "java_version": [
+      14,
+      0,
+      1,
+      8
+    ],
+    "distro_version": [
+      14,
+      28,
+      21,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11513,
-    "url": "https://cdn.azul.com/zulu/bin/zulu14.29.23-ca-jdk14.0.2-windows_x64.tar.gz",
+    "package_uuid": "uuid-11513",
     "name": "zulu14.29.23-ca-jdk14.0.2-windows_x64.tar.gz",
-    "zulu_version": [14, 29, 23, 0],
-    "jdk_version": [14, 0, 2, 12]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu14.29.23-ca-jdk14.0.2-windows_x64.tar.gz",
+    "java_version": [
+      14,
+      0,
+      2,
+      12
+    ],
+    "distro_version": [
+      14,
+      29,
+      23,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11780,
-    "url": "https://cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-windows_x64.tar.gz",
+    "package_uuid": "uuid-11780",
     "name": "zulu15.27.17-ca-jdk15.0.0-windows_x64.tar.gz",
-    "zulu_version": [15, 27, 17, 0],
-    "jdk_version": [15, 0, 0, 36]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu15.27.17-ca-jdk15.0.0-windows_x64.tar.gz",
+    "java_version": [
+      15,
+      0,
+      0,
+      36
+    ],
+    "distro_version": [
+      15,
+      27,
+      17,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 11924,
-    "url": "https://cdn.azul.com/zulu/bin/zulu15.28.13-ca-jdk15.0.1-windows_x64.tar.gz",
+    "package_uuid": "uuid-11924",
     "name": "zulu15.28.13-ca-jdk15.0.1-windows_x64.tar.gz",
-    "zulu_version": [15, 28, 13, 0],
-    "jdk_version": [15, 0, 1, 8]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu15.28.13-ca-jdk15.0.1-windows_x64.tar.gz",
+    "java_version": [
+      15,
+      0,
+      1,
+      8
+    ],
+    "distro_version": [
+      15,
+      28,
+      13,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 12101,
-    "url": "https://cdn.azul.com/zulu/bin/zulu15.28.51-ca-jdk15.0.1-windows_x64.tar.gz",
+    "package_uuid": "uuid-12101",
     "name": "zulu15.28.51-ca-jdk15.0.1-windows_x64.tar.gz",
-    "zulu_version": [15, 28, 51, 0],
-    "jdk_version": [15, 0, 1, 9]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu15.28.51-ca-jdk15.0.1-windows_x64.tar.gz",
+    "java_version": [
+      15,
+      0,
+      1,
+      9
+    ],
+    "distro_version": [
+      15,
+      28,
+      51,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 12445,
-    "url": "https://cdn.azul.com/zulu/bin/zulu15.29.15-ca-jdk15.0.2-windows_x64.tar.gz",
+    "package_uuid": "uuid-12445",
     "name": "zulu15.29.15-ca-jdk15.0.2-windows_x64.tar.gz",
-    "zulu_version": [15, 29, 15, 0],
-    "jdk_version": [15, 0, 2, 7]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu15.29.15-ca-jdk15.0.2-windows_x64.tar.gz",
+    "java_version": [
+      15,
+      0,
+      2,
+      7
+    ],
+    "distro_version": [
+      15,
+      29,
+      15,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   },
   {
-    "id": 12446,
-    "url": "https://cdn.azul.com/zulu/bin/zulu17.48.15-ca-jdk17.0.10-windows_aarch64.zip",
+    "package_uuid": "uuid-12446",
     "name": "zulu17.48.15-ca-jdk17.0.10-win_aarhc4.zip",
-    "zulu_version": [17, 48, 15, 0],
-    "jdk_version": [17, 0, 10, 7]
+    "download_url": "https://cdn.azul.com/zulu/bin/zulu17.48.15-ca-jdk17.0.10-windows_aarch64.zip",
+    "java_version": [
+      17,
+      0,
+      10,
+      7
+    ],
+    "distro_version": [
+      17,
+      48,
+      15,
+      0
+    ],
+    "availability_type": "ca",
+    "javafx_bundled": false,
+    "crac_supported": false
   }
 ]

--- a/__tests__/distributors/jetbrains-installer.test.ts
+++ b/__tests__/distributors/jetbrains-installer.test.ts
@@ -3,10 +3,10 @@ import {HttpClient} from '@actions/http-client';
 import {JetBrainsDistribution} from '../../src/distributions/jetbrains/installer';
 
 import manifestData from '../data/jetbrains.json';
+import os from 'os';
 
 describe('getAvailableVersions', () => {
   let spyHttpClient: jest.SpyInstance;
-  let spyHttpClientHead: jest.SpyInstance;
 
   beforeEach(() => {
     spyHttpClient = jest.spyOn(HttpClient.prototype, 'getJson');
@@ -14,10 +14,6 @@ describe('getAvailableVersions', () => {
       statusCode: 200,
       headers: {},
       result: []
-    });
-    spyHttpClientHead = jest.spyOn(HttpClient.prototype, 'head');
-    spyHttpClientHead.mockReturnValue({
-      message: {statusCode: 200}
     });
   });
 
@@ -44,8 +40,9 @@ describe('getAvailableVersions', () => {
     const availableVersions = await distribution['getAvailableVersions']();
     expect(availableVersions).not.toBeNull();
 
-    // manifestData items + 2 hidden versions (always included when head is mocked to return 200)
-    expect(availableVersions.length).toBe(manifestData.length + 2);
+    const length =
+      os.platform() === 'win32' ? manifestData.length : manifestData.length + 2;
+    expect(availableVersions.length).toBe(length);
   }, 10_000);
 });
 

--- a/__tests__/distributors/jetbrains-installer.test.ts
+++ b/__tests__/distributors/jetbrains-installer.test.ts
@@ -3,10 +3,10 @@ import {HttpClient} from '@actions/http-client';
 import {JetBrainsDistribution} from '../../src/distributions/jetbrains/installer';
 
 import manifestData from '../data/jetbrains.json';
-import os from 'os';
 
 describe('getAvailableVersions', () => {
   let spyHttpClient: jest.SpyInstance;
+  let spyHttpClientHead: jest.SpyInstance;
 
   beforeEach(() => {
     spyHttpClient = jest.spyOn(HttpClient.prototype, 'getJson');
@@ -14,6 +14,10 @@ describe('getAvailableVersions', () => {
       statusCode: 200,
       headers: {},
       result: []
+    });
+    spyHttpClientHead = jest.spyOn(HttpClient.prototype, 'head');
+    spyHttpClientHead.mockReturnValue({
+      message: {statusCode: 200}
     });
   });
 
@@ -40,9 +44,8 @@ describe('getAvailableVersions', () => {
     const availableVersions = await distribution['getAvailableVersions']();
     expect(availableVersions).not.toBeNull();
 
-    const length =
-      os.platform() === 'win32' ? manifestData.length : manifestData.length + 2;
-    expect(availableVersions.length).toBe(length);
+    // manifestData items + 2 hidden versions (always included when head is mocked to return 200)
+    expect(availableVersions.length).toBe(manifestData.length + 2);
   }, 10_000);
 });
 

--- a/__tests__/distributors/zulu-installer.test.ts
+++ b/__tests__/distributors/zulu-installer.test.ts
@@ -164,6 +164,28 @@ describe('getAvailableVersions', () => {
     const availableVersions = await distribution['getAvailableVersions']();
     expect(availableVersions).toHaveLength(manifestData.length);
   });
+
+  it('fetches multiple pages when first page is full', async () => {
+    const firstPage = Array(100).fill(manifestData[0]) as IZuluVersions[];
+    const secondPage = manifestData.slice(0, 5) as IZuluVersions[];
+
+    spyHttpClient
+      .mockReturnValueOnce({statusCode: 200, headers: {}, result: firstPage})
+      .mockReturnValueOnce({statusCode: 200, headers: {}, result: secondPage});
+
+    const distribution = new ZuluDistribution({
+      version: '11',
+      architecture: 'x86',
+      packageType: 'jdk',
+      checkLatest: false
+    });
+    distribution['getPlatformOption'] = () => 'linux';
+
+    const availableVersions = await distribution['getAvailableVersions']();
+
+    expect(spyHttpClient).toHaveBeenCalledTimes(2);
+    expect(availableVersions).toHaveLength(firstPage.length + secondPage.length);
+  });
 });
 
 describe('getArchitectureOptions', () => {

--- a/__tests__/distributors/zulu-installer.test.ts
+++ b/__tests__/distributors/zulu-installer.test.ts
@@ -39,7 +39,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=macos&ext=tar.gz&bundle_type=jdk&javafx=false&arch=x86&hw_bitness=32&release_status=ga'
+      '?os=macos&arch=x86&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -48,7 +48,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=macos&ext=tar.gz&bundle_type=jdk&javafx=false&arch=x86&hw_bitness=32&release_status=ea'
+      '?os=macos&arch=x86&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ea&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -57,7 +57,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=macos&ext=tar.gz&bundle_type=jdk&javafx=false&arch=x86&hw_bitness=64&release_status=ga'
+      '?os=macos&arch=x86&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -66,7 +66,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jre',
         checkLatest: false
       },
-      '?os=macos&ext=tar.gz&bundle_type=jre&javafx=false&arch=x86&hw_bitness=64&release_status=ga'
+      '?os=macos&arch=x86&archive_type=tar.gz&java_package_type=jre&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -75,7 +75,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk+fx',
         checkLatest: false
       },
-      '?os=macos&ext=tar.gz&bundle_type=jdk&javafx=true&arch=x86&hw_bitness=64&release_status=ga&features=fx'
+      '?os=macos&arch=x86&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=true&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -84,7 +84,16 @@ describe('getAvailableVersions', () => {
         packageType: 'jre+fx',
         checkLatest: false
       },
-      '?os=macos&ext=tar.gz&bundle_type=jre&javafx=true&arch=x86&hw_bitness=64&release_status=ga&features=fx'
+      '?os=macos&arch=x86&archive_type=tar.gz&java_package_type=jre&javafx_bundled=true&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
+    ],
+    [
+      {
+        version: '8',
+        architecture: 'x64',
+        packageType: 'jdk+crac',
+        checkLatest: false
+      },
+      '?os=macos&arch=x86&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=false&crac_supported=true&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -93,7 +102,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=macos&ext=tar.gz&bundle_type=jdk&javafx=false&arch=arm&hw_bitness=64&release_status=ga'
+      '?os=macos&arch=arm&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -102,12 +111,12 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=macos&ext=tar.gz&bundle_type=jdk&javafx=false&arch=arm&hw_bitness=&release_status=ga'
+      '?os=macos&arch=arm&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ]
   ])('build correct url for %s -> %s', async (input, parsedUrl) => {
     const distribution = new ZuluDistribution(input);
     distribution['getPlatformOption'] = () => 'macos';
-    const buildUrl = `https://api.azul.com/zulu/download/community/v1.0/bundles/${parsedUrl}`;
+    const buildUrl = `https://api.azul.com/metadata/v1/zulu/packages/${parsedUrl}`;
 
     await distribution['getAvailableVersions']();
 
@@ -136,7 +145,7 @@ describe('getAvailableVersions', () => {
         checkLatest: false
       });
       distribution['getPlatformOption'] = () => 'macos';
-      const buildUrl = `https://api.azul.com/zulu/download/community/v1.0/bundles/?os=macos&ext=tar.gz&bundle_type=jdk&javafx=false&arch=${distroArch.arch}&hw_bitness=${distroArch.bitness}&release_status=ga`;
+      const buildUrl = `https://api.azul.com/metadata/v1/zulu/packages/?os=macos&arch=${distroArch.arch}&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100`;
 
       await distribution['getAvailableVersions']();
 

--- a/__tests__/distributors/zulu-installer.test.ts
+++ b/__tests__/distributors/zulu-installer.test.ts
@@ -48,7 +48,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=macos&arch=x86&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ea&availability_types=ca&certifications=tck&page=1&page_size=100'
+      '?os=macos&arch=x86&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ea&availability_types=ca&page=1&page_size=100'
     ],
     [
       {
@@ -57,7 +57,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=macos&arch=x86&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
+      '?os=macos&arch=x64&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -66,7 +66,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jre',
         checkLatest: false
       },
-      '?os=macos&arch=x86&archive_type=tar.gz&java_package_type=jre&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
+      '?os=macos&arch=x64&archive_type=tar.gz&java_package_type=jre&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -75,7 +75,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk+fx',
         checkLatest: false
       },
-      '?os=macos&arch=x86&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=true&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
+      '?os=macos&arch=x64&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=true&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -84,7 +84,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jre+fx',
         checkLatest: false
       },
-      '?os=macos&arch=x86&archive_type=tar.gz&java_package_type=jre&javafx_bundled=true&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
+      '?os=macos&arch=x64&archive_type=tar.gz&java_package_type=jre&javafx_bundled=true&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -93,7 +93,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk+crac',
         checkLatest: false
       },
-      '?os=macos&arch=x86&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=false&crac_supported=true&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
+      '?os=macos&arch=x64&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=false&crac_supported=true&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -102,7 +102,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=macos&arch=arm&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
+      '?os=macos&arch=aarch64&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -129,8 +129,8 @@ describe('getAvailableVersions', () => {
     arch: string;
   };
   it.each([
-    ['amd64', {bitness: '64', arch: 'x86'}],
-    ['arm64', {bitness: '64', arch: 'arm'}]
+    ['amd64', {bitness: '64', arch: 'x64'}],
+    ['arm64', {bitness: '64', arch: 'aarch64'}]
   ])(
     'defaults to os.arch(): %s mapped to distro arch: %s',
     async (osArch: string, distroArch: DistroArch) => {

--- a/__tests__/distributors/zulu-linux-installer.test.ts
+++ b/__tests__/distributors/zulu-linux-installer.test.ts
@@ -58,7 +58,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=linux-glibc&arch=x86&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
+      '?os=linux-glibc&arch=x64&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -67,7 +67,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jre',
         checkLatest: false
       },
-      '?os=linux-glibc&arch=x86&archive_type=zip&java_package_type=jre&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
+      '?os=linux-glibc&arch=x64&archive_type=zip&java_package_type=jre&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -76,7 +76,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk+fx',
         checkLatest: false
       },
-      '?os=linux-glibc&arch=x86&archive_type=zip&java_package_type=jdk&javafx_bundled=true&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
+      '?os=linux-glibc&arch=x64&archive_type=zip&java_package_type=jdk&javafx_bundled=true&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -85,7 +85,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jre+fx',
         checkLatest: false
       },
-      '?os=linux-glibc&arch=x86&archive_type=zip&java_package_type=jre&javafx_bundled=true&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
+      '?os=linux-glibc&arch=x64&archive_type=zip&java_package_type=jre&javafx_bundled=true&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -94,7 +94,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=linux-glibc&arch=arm&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
+      '?os=linux-glibc&arch=arm64&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -139,7 +139,8 @@ describe('getAvailableVersions', () => {
       distribution['getPlatformOption'] = () => 'linux';
       // Override extension for linux default arch case to match util behavior
       spyUtilGetDownloadArchiveExtension.mockReturnValue('tar.gz');
-      const buildUrl = `https://api.azul.com/metadata/v1/zulu/packages/?os=linux-glibc&arch=${distroArch.arch}&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100`;
+      const expectedArch = distroArch.bitness === '64' && distroArch.arch === 'x86' ? 'x64' : distroArch.bitness === '64' && distroArch.arch === 'arm' ? 'arm64' : distroArch.arch;
+      const buildUrl = `https://api.azul.com/metadata/v1/zulu/packages/?os=linux-glibc&arch=${expectedArch}&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100`;
 
       await distribution['getAvailableVersions']();
 

--- a/__tests__/distributors/zulu-linux-installer.test.ts
+++ b/__tests__/distributors/zulu-linux-installer.test.ts
@@ -40,7 +40,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=linux&ext=zip&bundle_type=jdk&javafx=false&arch=x86&hw_bitness=32&release_status=ga'
+      '?os=linux-glibc&arch=x86&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -49,7 +49,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=linux&ext=zip&bundle_type=jdk&javafx=false&arch=x86&hw_bitness=32&release_status=ea'
+      '?os=linux-glibc&arch=x86&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ea&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -58,7 +58,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=linux&ext=zip&bundle_type=jdk&javafx=false&arch=x86&hw_bitness=64&release_status=ga'
+      '?os=linux-glibc&arch=x86&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -67,7 +67,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jre',
         checkLatest: false
       },
-      '?os=linux&ext=zip&bundle_type=jre&javafx=false&arch=x86&hw_bitness=64&release_status=ga'
+      '?os=linux-glibc&arch=x86&archive_type=zip&java_package_type=jre&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -76,7 +76,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk+fx',
         checkLatest: false
       },
-      '?os=linux&ext=zip&bundle_type=jdk&javafx=true&arch=x86&hw_bitness=64&release_status=ga&features=fx'
+      '?os=linux-glibc&arch=x86&archive_type=zip&java_package_type=jdk&javafx_bundled=true&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -85,7 +85,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jre+fx',
         checkLatest: false
       },
-      '?os=linux&ext=zip&bundle_type=jre&javafx=true&arch=x86&hw_bitness=64&release_status=ga&features=fx'
+      '?os=linux-glibc&arch=x86&archive_type=zip&java_package_type=jre&javafx_bundled=true&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -94,7 +94,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=linux&ext=zip&bundle_type=jdk&javafx=false&arch=arm&hw_bitness=64&release_status=ga'
+      '?os=linux-glibc&arch=arm&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -103,12 +103,12 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=linux&ext=zip&bundle_type=jdk&javafx=false&arch=arm&hw_bitness=&release_status=ga'
+      '?os=linux-glibc&arch=arm&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ]
   ])('build correct url for %s -> %s', async (input, parsedUrl) => {
     const distribution = new ZuluDistribution(input);
     distribution['getPlatformOption'] = () => 'linux';
-    const buildUrl = `https://api.azul.com/zulu/download/community/v1.0/bundles/${parsedUrl}`;
+    const buildUrl = `https://api.azul.com/metadata/v1/zulu/packages/${parsedUrl}`;
 
     await distribution['getAvailableVersions']();
 
@@ -139,7 +139,7 @@ describe('getAvailableVersions', () => {
       distribution['getPlatformOption'] = () => 'linux';
       // Override extension for linux default arch case to match util behavior
       spyUtilGetDownloadArchiveExtension.mockReturnValue('tar.gz');
-      const buildUrl = `https://api.azul.com/zulu/download/community/v1.0/bundles/?os=linux&ext=tar.gz&bundle_type=jdk&javafx=false&arch=${distroArch.arch}&hw_bitness=${distroArch.bitness}&release_status=ga`;
+      const buildUrl = `https://api.azul.com/metadata/v1/zulu/packages/?os=linux-glibc&arch=${distroArch.arch}&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100`;
 
       await distribution['getAvailableVersions']();
 

--- a/__tests__/distributors/zulu-linux-installer.test.ts
+++ b/__tests__/distributors/zulu-linux-installer.test.ts
@@ -49,7 +49,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=linux-glibc&arch=x86&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ea&availability_types=ca&certifications=tck&page=1&page_size=100'
+      '?os=linux-glibc&arch=x86&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ea&availability_types=ca&page=1&page_size=100'
     ],
     [
       {
@@ -94,7 +94,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=linux-glibc&arch=arm64&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
+      '?os=linux-glibc&arch=aarch64&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -139,7 +139,7 @@ describe('getAvailableVersions', () => {
       distribution['getPlatformOption'] = () => 'linux';
       // Override extension for linux default arch case to match util behavior
       spyUtilGetDownloadArchiveExtension.mockReturnValue('tar.gz');
-      const expectedArch = distroArch.bitness === '64' && distroArch.arch === 'x86' ? 'x64' : distroArch.bitness === '64' && distroArch.arch === 'arm' ? 'arm64' : distroArch.arch;
+      const expectedArch = distroArch.bitness === '64' && distroArch.arch === 'x86' ? 'x64' : distroArch.bitness === '64' && distroArch.arch === 'arm' ? 'aarch64' : distroArch.arch;
       const buildUrl = `https://api.azul.com/metadata/v1/zulu/packages/?os=linux-glibc&arch=${expectedArch}&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100`;
 
       await distribution['getAvailableVersions']();

--- a/__tests__/distributors/zulu-windows-installer.test.ts
+++ b/__tests__/distributors/zulu-windows-installer.test.ts
@@ -40,7 +40,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=windows&ext=zip&bundle_type=jdk&javafx=false&arch=x86&hw_bitness=32&release_status=ga'
+      '?os=windows&arch=x86&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -49,7 +49,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=windows&ext=zip&bundle_type=jdk&javafx=false&arch=x86&hw_bitness=32&release_status=ea'
+      '?os=windows&arch=x86&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ea&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -58,7 +58,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=windows&ext=zip&bundle_type=jdk&javafx=false&arch=x86&hw_bitness=64&release_status=ga'
+      '?os=windows&arch=x86&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -67,7 +67,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jre',
         checkLatest: false
       },
-      '?os=windows&ext=zip&bundle_type=jre&javafx=false&arch=x86&hw_bitness=64&release_status=ga'
+      '?os=windows&arch=x86&archive_type=zip&java_package_type=jre&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -76,7 +76,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk+fx',
         checkLatest: false
       },
-      '?os=windows&ext=zip&bundle_type=jdk&javafx=true&arch=x86&hw_bitness=64&release_status=ga&features=fx'
+      '?os=windows&arch=x86&archive_type=zip&java_package_type=jdk&javafx_bundled=true&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -85,7 +85,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jre+fx',
         checkLatest: false
       },
-      '?os=windows&ext=zip&bundle_type=jre&javafx=true&arch=x86&hw_bitness=64&release_status=ga&features=fx'
+      '?os=windows&arch=x86&archive_type=zip&java_package_type=jre&javafx_bundled=true&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -94,7 +94,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=windows&ext=zip&bundle_type=jdk&javafx=false&arch=arm&hw_bitness=64&release_status=ga'
+      '?os=windows&arch=arm&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -103,12 +103,12 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=windows&ext=zip&bundle_type=jdk&javafx=false&arch=arm&hw_bitness=&release_status=ga'
+      '?os=windows&arch=arm&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ]
   ])('build correct url for %s -> %s', async (input, parsedUrl) => {
     const distribution = new ZuluDistribution(input);
     distribution['getPlatformOption'] = () => 'windows';
-    const buildUrl = `https://api.azul.com/zulu/download/community/v1.0/bundles/${parsedUrl}`;
+    const buildUrl = `https://api.azul.com/metadata/v1/zulu/packages/${parsedUrl}`;
 
     await distribution['getAvailableVersions']();
 
@@ -137,7 +137,7 @@ describe('getAvailableVersions', () => {
         checkLatest: false
       });
       distribution['getPlatformOption'] = () => 'windows';
-      const buildUrl = `https://api.azul.com/zulu/download/community/v1.0/bundles/?os=windows&ext=zip&bundle_type=jdk&javafx=false&arch=${distroArch.arch}&hw_bitness=${distroArch.bitness}&release_status=ga`;
+      const buildUrl = `https://api.azul.com/metadata/v1/zulu/packages/?os=windows&arch=${distroArch.arch}&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100`;
 
       await distribution['getAvailableVersions']();
 

--- a/__tests__/distributors/zulu-windows-installer.test.ts
+++ b/__tests__/distributors/zulu-windows-installer.test.ts
@@ -49,7 +49,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=windows&arch=x86&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ea&availability_types=ca&certifications=tck&page=1&page_size=100'
+      '?os=windows&arch=x86&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ea&availability_types=ca&page=1&page_size=100'
     ],
     [
       {
@@ -94,7 +94,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=windows&arch=arm64&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
+      '?os=windows&arch=aarch64&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -137,7 +137,7 @@ describe('getAvailableVersions', () => {
         checkLatest: false
       });
       distribution['getPlatformOption'] = () => 'windows';
-      const expectedArch = distroArch.bitness === '64' && distroArch.arch === 'x86' ? 'x64' : distroArch.bitness === '64' && distroArch.arch === 'arm' ? 'arm64' : distroArch.arch;
+      const expectedArch = distroArch.bitness === '64' && distroArch.arch === 'x86' ? 'x64' : distroArch.bitness === '64' && distroArch.arch === 'arm' ? 'aarch64' : distroArch.arch;
       const buildUrl = `https://api.azul.com/metadata/v1/zulu/packages/?os=windows&arch=${expectedArch}&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100`;
 
       await distribution['getAvailableVersions']();

--- a/__tests__/distributors/zulu-windows-installer.test.ts
+++ b/__tests__/distributors/zulu-windows-installer.test.ts
@@ -58,7 +58,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=windows&arch=x86&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
+      '?os=windows&arch=x64&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -67,7 +67,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jre',
         checkLatest: false
       },
-      '?os=windows&arch=x86&archive_type=zip&java_package_type=jre&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
+      '?os=windows&arch=x64&archive_type=zip&java_package_type=jre&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -76,7 +76,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk+fx',
         checkLatest: false
       },
-      '?os=windows&arch=x86&archive_type=zip&java_package_type=jdk&javafx_bundled=true&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
+      '?os=windows&arch=x64&archive_type=zip&java_package_type=jdk&javafx_bundled=true&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -85,7 +85,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jre+fx',
         checkLatest: false
       },
-      '?os=windows&arch=x86&archive_type=zip&java_package_type=jre&javafx_bundled=true&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
+      '?os=windows&arch=x64&archive_type=zip&java_package_type=jre&javafx_bundled=true&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -94,7 +94,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=windows&arch=arm&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
+      '?os=windows&arch=arm64&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100'
     ],
     [
       {
@@ -137,7 +137,8 @@ describe('getAvailableVersions', () => {
         checkLatest: false
       });
       distribution['getPlatformOption'] = () => 'windows';
-      const buildUrl = `https://api.azul.com/metadata/v1/zulu/packages/?os=windows&arch=${distroArch.arch}&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100`;
+      const expectedArch = distroArch.bitness === '64' && distroArch.arch === 'x86' ? 'x64' : distroArch.bitness === '64' && distroArch.arch === 'arm' ? 'arm64' : distroArch.arch;
+      const buildUrl = `https://api.azul.com/metadata/v1/zulu/packages/?os=windows&arch=${expectedArch}&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&release_status=ga&availability_types=ca&certifications=tck&page=1&page_size=100`;
 
       await distribution['getAvailableVersions']();
 

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: 'Java distribution. See the list of supported distributions in README file'
     required: true
   java-package:
-    description: 'The package type (jdk, jre, jdk+fx, jre+fx)'
+    description: 'The package type (jdk, jre, jdk+fx, jre+fx, jdk+crac, jre+crac)'
     required: false
     default: 'jdk'
   architecture:

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -61,9 +61,24 @@ steps:
   with:
     distribution: 'zulu'
     java-version: '21'
-    java-package: jdk # optional (jdk, jre, jdk+fx or jre+fx) - defaults to jdk
+    java-package: jdk # optional (jdk, jre, jdk+fx, jre+fx, jdk+crac or jre+crac) - defaults to jdk
 - run: java -cp java HelloWorldApp
 ```
+
+To use a Zulu JDK build with [CRaC (Coordinated Restore at Checkpoint)](https://openjdk.org/projects/crac/) support, set `java-package` to `jdk+crac` or `jre+crac`:
+
+```yaml
+steps:
+- uses: actions/checkout@v6
+- uses: actions/setup-java@v5
+  with:
+    distribution: 'zulu'
+    java-version: '21'
+    java-package: jdk+crac
+- run: java -cp java HelloWorldApp
+```
+
+> **Note:** CRaC builds are only available for specific Zulu versions on Linux. The default (`jdk`) selects non-CRaC builds.
 
 ### Liberica
 

--- a/src/distributions/zulu/installer.ts
+++ b/src/distributions/zulu/installer.ts
@@ -100,7 +100,7 @@ export class ZuluDistribution extends JavaBase {
   }
 
   private async getAvailableVersions(): Promise<IZuluVersions[]> {
-    const {arch, hw_bitness, abi} = this.getArchitectureOptions();
+    const {arch, hw_bitness} = this.getArchitectureOptions();
     const [bundleType, features] = this.packageType.split('+');
     const platform = this.getPlatformOption();
     const extension = getDownloadArchiveExtension();

--- a/src/distributions/zulu/installer.ts
+++ b/src/distributions/zulu/installer.ts
@@ -113,13 +113,12 @@ export class ZuluDistribution extends JavaBase {
     }
 
     // Map old API parameters to new metadata API parameters
-    const archParam = hw_bitness === '64' ? arch : arch;
     const osParam = this.getOsParam(platform);
     const archiveType = this.getArchiveType(extension);
 
     const requestArguments = [
       `os=${osParam}`,
-      `arch=${archParam}`,
+      `arch=${arch}`,
       `archive_type=${archiveType}`,
       `java_package_type=${bundleType}`,
       `javafx_bundled=${javafx}`,

--- a/src/distributions/zulu/installer.ts
+++ b/src/distributions/zulu/installer.ts
@@ -40,7 +40,7 @@ export class ZuluDistribution extends JavaBase {
     const satisfiedVersions = availableVersions
       .filter(item => isVersionSatisfies(version, item.version))
       .sort((a, b) => {
-        // Azul provides two versions: jdk_version and azul_version
+        // Azul provides two versions: java_version and distro_version
         // we should sort by both fields by descending
         return (
           -semver.compareBuild(a.version, b.version) ||
@@ -112,6 +112,11 @@ export class ZuluDistribution extends JavaBase {
       console.time('Retrieving available versions for Zulu took'); // eslint-disable-line no-console
     }
 
+    // Map old API parameters to new metadata API parameters
+    const osParam = this.getOsParam(platform);
+    const archiveType = this.getArchiveType(extension);
+    const archParam = this.getArchParam(arch, hw_bitness);
+
     // Fetch all pages to avoid missing packages when there are > 100 results
     let allVersions: IZuluVersions[] = [];
     let page = 1;
@@ -119,18 +124,10 @@ export class ZuluDistribution extends JavaBase {
     let hasMore = true;
 
     while (hasMore) {
-      // Map architecture for new metadata API (x86+64bit -> x64, arm+64bit -> aarch64, etc.)
-      let archParam = arch;
-      if (arch === 'x86' && hw_bitness === '64') {
-        archParam = 'x64';
-      } else if (arch === 'arm' && hw_bitness === '64') {
-        archParam = 'aarch64';
-      }
-
       const requestArguments = [
-        `os=${platform === 'linux' ? 'linux-glibc' : platform}`,
+        `os=${osParam}`,
         `arch=${archParam}`,
-        `archive_type=${extension}`,
+        `archive_type=${archiveType}`,
         `java_package_type=${bundleType}`,
         `javafx_bundled=${javafx}`,
         `crac_supported=${crac}`,
@@ -201,6 +198,49 @@ export class ZuluDistribution extends JavaBase {
         return 'windows';
       default:
         return process.platform;
+    }
+  }
+
+  private getOsParam(platform: string): string {
+    // Map platform to new metadata API OS parameter
+    // The new API uses more specific OS names like 'linux-glibc', 'macos', 'windows'
+    switch (platform) {
+      case 'linux':
+        return 'linux-glibc';
+      case 'macos':
+        return 'macos';
+      case 'windows':
+        return 'windows';
+      default:
+        return platform;
+    }
+  }
+
+  private getArchParam(arch: string, hw_bitness: string): string {
+    // Map architecture to new metadata API arch parameter
+    // The new API uses x64, x86, aarch64, arm
+    if (arch === 'x86' && hw_bitness === '64') {
+      return 'x64';
+    } else if (arch === 'x86' && hw_bitness === '32') {
+      return 'x86';
+    } else if (arch === 'arm' && hw_bitness === '64') {
+      return 'aarch64';
+    } else if (arch === 'arm' && hw_bitness === '') {
+      return 'arm';
+    }
+    // Fallback for other architectures
+    return arch;
+  }
+
+  private getArchiveType(extension: string): string {
+    // Map extension to archive_type parameter for new API
+    switch (extension) {
+      case 'tar.gz':
+        return 'tar.gz';
+      case 'zip':
+        return 'zip';
+      default:
+        return extension;
     }
   }
 }

--- a/src/distributions/zulu/installer.ts
+++ b/src/distributions/zulu/installer.ts
@@ -40,7 +40,7 @@ export class ZuluDistribution extends JavaBase {
     const satisfiedVersions = availableVersions
       .filter(item => isVersionSatisfies(version, item.version))
       .sort((a, b) => {
-        // Azul provides two versions: java_version and distro_version
+        // Azul provides two versions: jdk_version and azul_version
         // we should sort by both fields by descending
         return (
           -semver.compareBuild(a.version, b.version) ||
@@ -112,11 +112,6 @@ export class ZuluDistribution extends JavaBase {
       console.time('Retrieving available versions for Zulu took'); // eslint-disable-line no-console
     }
 
-    // Map old API parameters to new metadata API parameters
-    const osParam = this.getOsParam(platform);
-    const archiveType = this.getArchiveType(extension);
-    const archParam = this.getArchParam(arch, hw_bitness);
-
     // Fetch all pages to avoid missing packages when there are > 100 results
     let allVersions: IZuluVersions[] = [];
     let page = 1;
@@ -124,10 +119,18 @@ export class ZuluDistribution extends JavaBase {
     let hasMore = true;
 
     while (hasMore) {
+      // Map architecture for new metadata API (x86+64bit -> x64, arm+64bit -> aarch64, etc.)
+      let archParam = arch;
+      if (arch === 'x86' && hw_bitness === '64') {
+        archParam = 'x64';
+      } else if (arch === 'arm' && hw_bitness === '64') {
+        archParam = 'aarch64';
+      }
+
       const requestArguments = [
-        `os=${osParam}`,
+        `os=${platform === 'linux' ? 'linux-glibc' : platform}`,
         `arch=${archParam}`,
-        `archive_type=${archiveType}`,
+        `archive_type=${extension}`,
         `java_package_type=${bundleType}`,
         `javafx_bundled=${javafx}`,
         `crac_supported=${crac}`,
@@ -198,49 +201,6 @@ export class ZuluDistribution extends JavaBase {
         return 'windows';
       default:
         return process.platform;
-    }
-  }
-
-  private getOsParam(platform: string): string {
-    // Map platform to new metadata API OS parameter
-    // The new API uses more specific OS names like 'linux-glibc', 'macos', 'windows'
-    switch (platform) {
-      case 'linux':
-        return 'linux-glibc';
-      case 'macos':
-        return 'macos';
-      case 'windows':
-        return 'windows';
-      default:
-        return platform;
-    }
-  }
-
-  private getArchParam(arch: string, hw_bitness: string): string {
-    // Map architecture to new metadata API arch parameter
-    // The new API uses x64, x86, aarch64, arm
-    if (arch === 'x86' && hw_bitness === '64') {
-      return 'x64';
-    } else if (arch === 'x86' && hw_bitness === '32') {
-      return 'x86';
-    } else if (arch === 'arm' && hw_bitness === '64') {
-      return 'aarch64';
-    } else if (arch === 'arm' && hw_bitness === '') {
-      return 'arm';
-    }
-    // Fallback for other architectures
-    return arch;
-  }
-
-  private getArchiveType(extension: string): string {
-    // Map extension to archive_type parameter for new API
-    switch (extension) {
-      case 'tar.gz':
-        return 'tar.gz';
-      case 'zip':
-        return 'zip';
-      default:
-        return extension;
     }
   }
 }

--- a/src/distributions/zulu/installer.ts
+++ b/src/distributions/zulu/installer.ts
@@ -31,16 +31,16 @@ export class ZuluDistribution extends JavaBase {
     const availableVersionsRaw = await this.getAvailableVersions();
     const availableVersions = availableVersionsRaw.map(item => {
       return {
-        version: convertVersionToSemver(item.jdk_version),
-        url: item.url,
-        zuluVersion: convertVersionToSemver(item.zulu_version)
+        version: convertVersionToSemver(item.java_version),
+        url: item.download_url,
+        zuluVersion: convertVersionToSemver(item.distro_version)
       };
     });
 
     const satisfiedVersions = availableVersions
       .filter(item => isVersionSatisfies(version, item.version))
       .sort((a, b) => {
-        // Azul provides two versions: jdk_version and azul_version
+        // Azul provides two versions: java_version and distro_version
         // we should sort by both fields by descending
         return (
           -semver.compareBuild(a.version, b.version) ||
@@ -105,27 +105,35 @@ export class ZuluDistribution extends JavaBase {
     const platform = this.getPlatformOption();
     const extension = getDownloadArchiveExtension();
     const javafx = features?.includes('fx') ?? false;
+    const crac = features?.includes('crac') ?? false;
     const releaseStatus = this.stable ? 'ga' : 'ea';
 
     if (core.isDebug()) {
       console.time('Retrieving available versions for Zulu took'); // eslint-disable-line no-console
     }
 
+    // Map old API parameters to new metadata API parameters
+    const archParam = hw_bitness === '64' ? arch : arch;
+    const osParam = this.getOsParam(platform);
+    const archiveType = this.getArchiveType(extension);
+
     const requestArguments = [
-      `os=${platform}`,
-      `ext=${extension}`,
-      `bundle_type=${bundleType}`,
-      `javafx=${javafx}`,
-      `arch=${arch}`,
-      `hw_bitness=${hw_bitness}`,
+      `os=${osParam}`,
+      `arch=${archParam}`,
+      `archive_type=${archiveType}`,
+      `java_package_type=${bundleType}`,
+      `javafx_bundled=${javafx}`,
+      `crac_supported=${crac}`,
       `release_status=${releaseStatus}`,
-      abi ? `abi=${abi}` : null,
-      features ? `features=${features}` : null
+      `availability_types=ca`,
+      `certifications=tck`,
+      `page=1`,
+      `page_size=100`
     ]
       .filter(Boolean)
       .join('&');
 
-    const availableVersionsUrl = `https://api.azul.com/zulu/download/community/v1.0/bundles/?${requestArguments}`;
+    const availableVersionsUrl = `https://api.azul.com/metadata/v1/zulu/packages/?${requestArguments}`;
 
     core.debug(`Gathering available versions from '${availableVersionsUrl}'`);
 
@@ -138,7 +146,7 @@ export class ZuluDistribution extends JavaBase {
       console.timeEnd('Retrieving available versions for Zulu took'); // eslint-disable-line no-console
       core.debug(`Available versions: [${availableVersions.length}]`);
       core.debug(
-        availableVersions.map(item => item.jdk_version.join('.')).join(', ')
+        availableVersions.map(item => item.java_version.join('.')).join(', ')
       );
       core.endGroup();
     }
@@ -174,6 +182,33 @@ export class ZuluDistribution extends JavaBase {
         return 'windows';
       default:
         return process.platform;
+    }
+  }
+
+  private getOsParam(platform: string): string {
+    // Map platform to new metadata API OS parameter
+    // The new API uses more specific OS names like 'linux-glibc', 'macos', 'windows'
+    switch (platform) {
+      case 'linux':
+        return 'linux-glibc';
+      case 'macos':
+        return 'macos';
+      case 'windows':
+        return 'windows';
+      default:
+        return platform;
+    }
+  }
+
+  private getArchiveType(extension: string): string {
+    // Map extension to archive_type parameter for new API
+    switch (extension) {
+      case 'tar.gz':
+        return 'tar.gz';
+      case 'zip':
+        return 'zip';
+      default:
+        return extension;
     }
   }
 }

--- a/src/distributions/zulu/installer.ts
+++ b/src/distributions/zulu/installer.ts
@@ -133,7 +133,9 @@ export class ZuluDistribution extends JavaBase {
         `crac_supported=${crac}`,
         `release_status=${releaseStatus}`,
         `availability_types=ca`,
-        `certifications=tck`,
+        // Only filter by TCK certification for GA releases
+        // EA releases typically don't have TCK certification
+        releaseStatus === 'ga' ? `certifications=tck` : '',
         `page=${page}`,
         `page_size=${pageSize}`
       ]
@@ -216,13 +218,13 @@ export class ZuluDistribution extends JavaBase {
 
   private getArchParam(arch: string, hw_bitness: string): string {
     // Map architecture to new metadata API arch parameter
-    // The new API uses x64, x86, arm64, arm (not the legacy x86 + hw_bitness pattern)
+    // The new API uses x64, x86, aarch64, arm
     if (arch === 'x86' && hw_bitness === '64') {
       return 'x64';
     } else if (arch === 'x86' && hw_bitness === '32') {
       return 'x86';
     } else if (arch === 'arm' && hw_bitness === '64') {
-      return 'arm64';
+      return 'aarch64';
     } else if (arch === 'arm' && hw_bitness === '') {
       return 'arm';
     }

--- a/src/distributions/zulu/installer.ts
+++ b/src/distributions/zulu/installer.ts
@@ -115,42 +115,57 @@ export class ZuluDistribution extends JavaBase {
     // Map old API parameters to new metadata API parameters
     const osParam = this.getOsParam(platform);
     const archiveType = this.getArchiveType(extension);
+    const archParam = this.getArchParam(arch, hw_bitness);
 
-    const requestArguments = [
-      `os=${osParam}`,
-      `arch=${arch}`,
-      `archive_type=${archiveType}`,
-      `java_package_type=${bundleType}`,
-      `javafx_bundled=${javafx}`,
-      `crac_supported=${crac}`,
-      `release_status=${releaseStatus}`,
-      `availability_types=ca`,
-      `certifications=tck`,
-      `page=1`,
-      `page_size=100`
-    ]
-      .filter(Boolean)
-      .join('&');
+    // Fetch all pages to avoid missing packages when there are > 100 results
+    let allVersions: IZuluVersions[] = [];
+    let page = 1;
+    const pageSize = 100;
+    let hasMore = true;
 
-    const availableVersionsUrl = `https://api.azul.com/metadata/v1/zulu/packages/?${requestArguments}`;
+    while (hasMore) {
+      const requestArguments = [
+        `os=${osParam}`,
+        `arch=${archParam}`,
+        `archive_type=${archiveType}`,
+        `java_package_type=${bundleType}`,
+        `javafx_bundled=${javafx}`,
+        `crac_supported=${crac}`,
+        `release_status=${releaseStatus}`,
+        `availability_types=ca`,
+        `certifications=tck`,
+        `page=${page}`,
+        `page_size=${pageSize}`
+      ]
+        .filter(Boolean)
+        .join('&');
 
-    core.debug(`Gathering available versions from '${availableVersionsUrl}'`);
+      const availableVersionsUrl = `https://api.azul.com/metadata/v1/zulu/packages/?${requestArguments}`;
 
-    const availableVersions =
-      (await this.http.getJson<Array<IZuluVersions>>(availableVersionsUrl))
-        .result ?? [];
+      core.debug(`Gathering available versions from '${availableVersionsUrl}'`);
+
+      const pageResults =
+        (await this.http.getJson<Array<IZuluVersions>>(availableVersionsUrl))
+          .result ?? [];
+
+      allVersions = allVersions.concat(pageResults);
+
+      // If we got fewer results than page size, we've reached the end
+      hasMore = pageResults.length === pageSize;
+      page++;
+    }
 
     if (core.isDebug()) {
       core.startGroup('Print information about available versions');
       console.timeEnd('Retrieving available versions for Zulu took'); // eslint-disable-line no-console
-      core.debug(`Available versions: [${availableVersions.length}]`);
+      core.debug(`Available versions: [${allVersions.length}]`);
       core.debug(
-        availableVersions.map(item => item.java_version.join('.')).join(', ')
+        allVersions.map(item => item.java_version.join('.')).join(', ')
       );
       core.endGroup();
     }
 
-    return availableVersions;
+    return allVersions;
   }
 
   private getArchitectureOptions(): {
@@ -197,6 +212,22 @@ export class ZuluDistribution extends JavaBase {
       default:
         return platform;
     }
+  }
+
+  private getArchParam(arch: string, hw_bitness: string): string {
+    // Map architecture to new metadata API arch parameter
+    // The new API uses x64, x86, arm64, arm (not the legacy x86 + hw_bitness pattern)
+    if (arch === 'x86' && hw_bitness === '64') {
+      return 'x64';
+    } else if (arch === 'x86' && hw_bitness === '32') {
+      return 'x86';
+    } else if (arch === 'arm' && hw_bitness === '64') {
+      return 'arm64';
+    } else if (arch === 'arm' && hw_bitness === '') {
+      return 'arm';
+    }
+    // Fallback for other architectures
+    return arch;
   }
 
   private getArchiveType(extension: string): string {

--- a/src/distributions/zulu/models.ts
+++ b/src/distributions/zulu/models.ts
@@ -1,9 +1,12 @@
-// Models from https://app.swaggerhub.com/apis-docs/azul/zulu-download-community/1.0
+// Models from https://api.azul.com/metadata/v1/docs/swagger (metadata API v1)
 
 export interface IZuluVersions {
-  id: number;
+  package_uuid: string;
   name: string;
-  url: string;
-  jdk_version: Array<number>;
-  zulu_version: Array<number>;
+  download_url: string;
+  java_version: Array<number>;
+  distro_version: Array<number>;
+  availability_type: string;
+  javafx_bundled: boolean;
+  crac_supported?: boolean;
 }


### PR DESCRIPTION
Fixes #636 

This pull request updates the test cases for the Zulu installer across macOS, Linux, and Windows to reflect changes in the URL structure and parameter mapping for the Azul Zulu API. The main focus is on aligning the tests with the new API endpoint and parameter conventions, as well as updating architecture mappings to match the latest standards.

**API endpoint and parameter updates:**

* All test cases now use the new `https://api.azul.com/metadata/v1/zulu/packages/` endpoint instead of the old `/zulu/download/community/v1.0/bundles/` endpoint, and update URL parameters to match the new API specification (e.g., `archive_type`, `java_package_type`, `javafx_bundled`, `crac_supported`, `availability_types`, `certifications`, pagination, etc.). [[1]](diffhunk://#diff-f857b3b3f7e62f139630fa754793c66ffb05f96a4f807e540600f3bbc967fd78L42-R42) [[2]](diffhunk://#diff-1d5ffb05f4dbabd3e480d88280d7ce34feabcdae356980fa540c4a5ac8010206L43-R43) [[3]](diffhunk://#diff-7dbf4cd7694c5deb4933d805219fd41e790965e0c6f06783c4a1b8b27379a770L43-R43) [[4]](diffhunk://#diff-f857b3b3f7e62f139630fa754793c66ffb05f96a4f807e540600f3bbc967fd78L105-R119) [[5]](diffhunk://#diff-1d5ffb05f4dbabd3e480d88280d7ce34feabcdae356980fa540c4a5ac8010206L106-R111) [[6]](diffhunk://#diff-7dbf4cd7694c5deb4933d805219fd41e790965e0c6f06783c4a1b8b27379a770L106-R111) [[7]](diffhunk://#diff-f857b3b3f7e62f139630fa754793c66ffb05f96a4f807e540600f3bbc967fd78L139-R148) [[8]](diffhunk://#diff-1d5ffb05f4dbabd3e480d88280d7ce34feabcdae356980fa540c4a5ac8010206L142-R143) [[9]](diffhunk://#diff-7dbf4cd7694c5deb4933d805219fd41e790965e0c6f06783c4a1b8b27379a770L140-R141)

**Architecture and parameter mapping improvements:**

* Architecture mapping is updated: test cases now use `x64` instead of `x86` for 64-bit, and `aarch64` instead of `arm` for ARM 64-bit, to match the new API's expected values.
* Test cases now include logic for mapping architecture names based on bitness and architecture, improving accuracy for different platforms. [[1]](diffhunk://#diff-1d5ffb05f4dbabd3e480d88280d7ce34feabcdae356980fa540c4a5ac8010206L142-R143) [[2]](diffhunk://#diff-7dbf4cd7694c5deb4933d805219fd41e790965e0c6f06783c4a1b8b27379a770L140-R141)

**Test coverage enhancements:**

* Added a new test case for the `jdk+crac` package type, ensuring that CRaC (Coordinated Restore at Checkpoint) support is correctly handled in the URL parameters.

**Consistency and completeness:**

* All package types (JDK, JRE, with/without JavaFX, with CRaC) and platforms (macOS, Linux, Windows) are now consistently tested with the updated parameters and endpoint. [[1]](diffhunk://#diff-f857b3b3f7e62f139630fa754793c66ffb05f96a4f807e540600f3bbc967fd78L42-R42) [[2]](diffhunk://#diff-1d5ffb05f4dbabd3e480d88280d7ce34feabcdae356980fa540c4a5ac8010206L43-R43) [[3]](diffhunk://#diff-7dbf4cd7694c5deb4933d805219fd41e790965e0c6f06783c4a1b8b27379a770L43-R43) [[4]](diffhunk://#diff-f857b3b3f7e62f139630fa754793c66ffb05f96a4f807e540600f3bbc967fd78L60-R60) [[5]](diffhunk://#diff-1d5ffb05f4dbabd3e480d88280d7ce34feabcdae356980fa540c4a5ac8010206L61-R61) [[6]](diffhunk://#diff-7dbf4cd7694c5deb4933d805219fd41e790965e0c6f06783c4a1b8b27379a770L61-R61) [[7]](diffhunk://#diff-f857b3b3f7e62f139630fa754793c66ffb05f96a4f807e540600f3bbc967fd78L69-R69) [[8]](diffhunk://#diff-1d5ffb05f4dbabd3e480d88280d7ce34feabcdae356980fa540c4a5ac8010206L70-R70) [[9]](diffhunk://#diff-7dbf4cd7694c5deb4933d805219fd41e790965e0c6f06783c4a1b8b27379a770L70-R70) [[10]](diffhunk://#diff-f857b3b3f7e62f139630fa754793c66ffb05f96a4f807e540600f3bbc967fd78L78-R78) [[11]](diffhunk://#diff-1d5ffb05f4dbabd3e480d88280d7ce34feabcdae356980fa540c4a5ac8010206L79-R79) [[12]](diffhunk://#diff-7dbf4cd7694c5deb4933d805219fd41e790965e0c6f06783c4a1b8b27379a770L79-R79) [[13]](diffhunk://#diff-f857b3b3f7e62f139630fa754793c66ffb05f96a4f807e540600f3bbc967fd78L87-R96) [[14]](diffhunk://#diff-1d5ffb05f4dbabd3e480d88280d7ce34feabcdae356980fa540c4a5ac8010206L88-R88) [[15]](diffhunk://#diff-7dbf4cd7694c5deb4933d805219fd41e790965e0c6f06783c4a1b8b27379a770L88-R88) [[16]](diffhunk://#diff-f857b3b3f7e62f139630fa754793c66ffb05f96a4f807e540600f3bbc967fd78L96-R105) [[17]](diffhunk://#diff-1d5ffb05f4dbabd3e480d88280d7ce34feabcdae356980fa540c4a5ac8010206L97-R97) [[18]](diffhunk://#diff-7dbf4cd7694c5deb4933d805219fd41e790965e0c6f06783c4a1b8b27379a770L97-R97)

Overall, these changes ensure that the Zulu installer tests are up-to-date with the latest Azul Zulu API and accurately reflect the new parameter and architecture conventions.