### PR TITLE
feat: add microsoft openjdk 17.0.18

### DIFF
--- a/__tests__/data/microsoft.json
+++ b/__tests__/data/microsoft.json
@@ -80,6 +80,49 @@
       ]
     },
     {
+      "version": "17.0.18",
+      "stable": true,
+      "release_url": "https://aka.ms/download-jdk",
+      "files": [
+        {
+          "filename": "microsoft-jdk-17.0.18-macos-x64.tar.gz",
+          "arch": "x64",
+          "platform": "darwin",
+          "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.18-macos-x64.tar.gz"
+        },
+        {
+          "filename": "microsoft-jdk-17.0.18-linux-x64.tar.gz",
+          "arch": "x64",
+          "platform": "linux",
+          "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.18-linux-x64.tar.gz"
+        },
+        {
+          "filename": "microsoft-jdk-17.0.18-windows-x64.zip",
+          "arch": "x64",
+          "platform": "win32",
+          "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.18-windows-x64.zip"
+        },
+        {
+          "filename": "microsoft-jdk-17.0.18-macos-aarch64.tar.gz",
+          "arch": "aarch64",
+          "platform": "darwin",
+          "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.18-macos-aarch64.tar.gz"
+        },
+        {
+          "filename": "microsoft-jdk-17.0.18-linux-aarch64.tar.gz",
+          "arch": "aarch64",
+          "platform": "linux",
+          "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.18-linux-aarch64.tar.gz"
+        },
+        {
+          "filename": "microsoft-jdk-17.0.18-windows-aarch64.zip",
+          "arch": "aarch64",
+          "platform": "win32",
+          "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.18-windows-aarch64.zip"
+        }
+      ]
+    },
+    {
         "version": "17.0.7",
         "stable": true,
         "release_url": "https://aka.ms/download-jdk",

--- a/__tests__/distributors/microsoft-installer.test.ts
+++ b/__tests__/distributors/microsoft-installer.test.ts
@@ -45,14 +45,19 @@ describe('findPackageForDownload', () => {
       'https://aka.ms/download-jdk/microsoft-jdk-21.0.0-{{OS_TYPE}}-x64.{{ARCHIVE_TYPE}}'
     ],
     [
+      '17.x',
+      '17.0.18',
+      'https://aka.ms/download-jdk/microsoft-jdk-17.0.18-{{OS_TYPE}}-x64.{{ARCHIVE_TYPE}}'
+    ],
+    [
+      '17.0.7',
+      '17.0.7',
+      'https://aka.ms/download-jdk/microsoft-jdk-17.0.7-{{OS_TYPE}}-x64.{{ARCHIVE_TYPE}}'
+    ],
+    [
       '17.0.1',
       '17.0.1+12.1',
       'https://aka.ms/download-jdk/microsoft-jdk-17.0.1.12.1-{{OS_TYPE}}-x64.{{ARCHIVE_TYPE}}'
-    ],
-    [
-      '17.x',
-      '17.0.7',
-      'https://aka.ms/download-jdk/microsoft-jdk-17.0.7-{{OS_TYPE}}-x64.{{ARCHIVE_TYPE}}'
     ],
     [
       '16.0.x',
@@ -119,7 +124,7 @@ describe('findPackageForDownload', () => {
       });
 
       const result = await distro['findPackageForDownload'](version);
-      const expectedUrl = `https://aka.ms/download-jdk/microsoft-jdk-17.0.7-macos-${distroArch}.tar.gz`;
+      const expectedUrl = `https://aka.ms/download-jdk/microsoft-jdk-17.0.18-macos-${distroArch}.tar.gz`;
 
       expect(result.url).toBe(expectedUrl);
     }
@@ -145,7 +150,7 @@ describe('findPackageForDownload', () => {
       });
 
       const result = await distro['findPackageForDownload'](version);
-      const expectedUrl = `https://aka.ms/download-jdk/microsoft-jdk-17.0.7-linux-${distroArch}.tar.gz`;
+      const expectedUrl = `https://aka.ms/download-jdk/microsoft-jdk-17.0.18-linux-${distroArch}.tar.gz`;
 
       expect(result.url).toBe(expectedUrl);
     }
@@ -171,7 +176,7 @@ describe('findPackageForDownload', () => {
       });
 
       const result = await distro['findPackageForDownload'](version);
-      const expectedUrl = `https://aka.ms/download-jdk/microsoft-jdk-17.0.7-windows-${distroArch}.zip`;
+      const expectedUrl = `https://aka.ms/download-jdk/microsoft-jdk-17.0.18-windows-${distroArch}.zip`;
 
       expect(result.url).toBe(expectedUrl);
     }

--- a/src/distributions/microsoft/microsoft-openjdk-versions.json
+++ b/src/distributions/microsoft/microsoft-openjdk-versions.json
@@ -172,6 +172,49 @@
     ]
   },
   {
+    "version": "17.0.18",
+    "stable": true,
+    "release_url": "https://aka.ms/download-jdk",
+    "files": [
+      {
+        "filename": "microsoft-jdk-17.0.18-macos-x64.tar.gz",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.18-macos-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.18-linux-x64.tar.gz",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.18-linux-x64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.18-windows-x64.zip",
+        "arch": "x64",
+        "platform": "win32",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.18-windows-x64.zip"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.18-macos-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "darwin",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.18-macos-aarch64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.18-linux-aarch64.tar.gz",
+        "arch": "aarch64",
+        "platform": "linux",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.18-linux-aarch64.tar.gz"
+      },
+      {
+        "filename": "microsoft-jdk-17.0.18-windows-aarch64.zip",
+        "arch": "aarch64",
+        "platform": "win32",
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.18-windows-aarch64.zip"
+      }
+    ]
+  },
+  {
     "version": "17.0.10",
     "stable": true,
     "release_url": "https://aka.ms/download-jdk",

--- a/src/distributions/microsoft/microsoft-openjdk-versions.json
+++ b/src/distributions/microsoft/microsoft-openjdk-versions.json
@@ -223,7 +223,7 @@
         "filename": "microsoft-jdk-17.0.10-macos-x64.tar.gz",
         "arch": "x64",
         "platform": "darwin",
-        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.7-macos-x64.tar.gz"
+        "download_url": "https://aka.ms/download-jdk/microsoft-jdk-17.0.10-macos-x64.tar.gz"
       },
       {
         "filename": "microsoft-jdk-17.0.10-linux-x64.tar.gz",


### PR DESCRIPTION
**Description:**
- Adds Microsoft OpenJDK 17.0.18
- Corrects the URL of the microsoft-jdk-17.0.10-macos-x64.tar.gz file.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.