### PR TITLE
Update distribution factory for AdoptDistribution and add tests

### DIFF
--- a/__tests__/distributors/distribution-factory.test.ts
+++ b/__tests__/distributors/distribution-factory.test.ts
@@ -100,7 +100,10 @@ describe('getJavaDistribution', () => {
   });
 
   it('returns null for unknown distribution name', () => {
-    const distribution = getJavaDistribution('unknown-distro', installerOptions);
+    const distribution = getJavaDistribution(
+      'unknown-distro',
+      installerOptions
+    );
     expect(distribution).toBeNull();
   });
 
@@ -121,7 +124,7 @@ describe('getJavaDistribution', () => {
     ) as AdoptDistribution;
     // @ts-ignore - accessing private fields
     const temurin = distribution['temurinDistribution'] as TemurinDistribution;
-    // @ts-ignore
+    // @ts-ignore - accessing private field
     expect(temurin['jvmImpl']).toBe(TemurinImplementation.Hotspot);
   });
 

--- a/__tests__/distributors/distribution-factory.test.ts
+++ b/__tests__/distributors/distribution-factory.test.ts
@@ -1,0 +1,154 @@
+import {getJavaDistribution} from '../../src/distributions/distribution-factory';
+import {
+  AdoptDistribution,
+  AdoptImplementation
+} from '../../src/distributions/adopt/installer';
+import {
+  TemurinDistribution,
+  TemurinImplementation
+} from '../../src/distributions/temurin/installer';
+import {ZuluDistribution} from '../../src/distributions/zulu/installer';
+import {LibericaDistributions} from '../../src/distributions/liberica/installer';
+import {MicrosoftDistributions} from '../../src/distributions/microsoft/installer';
+import {SemeruDistribution} from '../../src/distributions/semeru/installer';
+import {CorrettoDistribution} from '../../src/distributions/corretto/installer';
+import {OracleDistribution} from '../../src/distributions/oracle/installer';
+import {DragonwellDistribution} from '../../src/distributions/dragonwell/installer';
+import {SapMachineDistribution} from '../../src/distributions/sapmachine/installer';
+import {GraalVMDistribution} from '../../src/distributions/graalvm/installer';
+import {JetBrainsDistribution} from '../../src/distributions/jetbrains/installer';
+import {LocalDistribution} from '../../src/distributions/local/installer';
+import {JavaInstallerOptions} from '../../src/distributions/base-models';
+
+const installerOptions: JavaInstallerOptions = {
+  version: '11',
+  architecture: 'x64',
+  packageType: 'jdk',
+  checkLatest: false
+};
+
+describe('getJavaDistribution', () => {
+  it.each([
+    ['adopt', AdoptDistribution],
+    ['adopt-hotspot', AdoptDistribution]
+  ])(
+    'returns AdoptDistribution for "%s"',
+    (distributionName, ExpectedClass) => {
+      const distribution = getJavaDistribution(
+        distributionName,
+        installerOptions
+      );
+      expect(distribution).toBeInstanceOf(ExpectedClass);
+    }
+  );
+
+  it.each(['adopt', 'adopt-hotspot'])(
+    'passes a TemurinDistribution to AdoptDistribution for "%s"',
+    distributionName => {
+      const distribution = getJavaDistribution(
+        distributionName,
+        installerOptions
+      ) as AdoptDistribution;
+      expect(distribution).toBeInstanceOf(AdoptDistribution);
+      // @ts-ignore - accessing private field to verify TemurinDistribution is wired in
+      expect(distribution['temurinDistribution']).toBeInstanceOf(
+        TemurinDistribution
+      );
+    }
+  );
+
+  it('adopt-openj9 creates AdoptDistribution without TemurinDistribution', () => {
+    const distribution = getJavaDistribution(
+      'adopt-openj9',
+      installerOptions
+    ) as AdoptDistribution;
+    expect(distribution).toBeInstanceOf(AdoptDistribution);
+    // @ts-ignore - accessing private field
+    expect(distribution['temurinDistribution']).toBeNull();
+  });
+
+  it.each([
+    ['temurin', TemurinDistribution],
+    ['zulu', ZuluDistribution],
+    ['liberica', LibericaDistributions],
+    ['microsoft', MicrosoftDistributions],
+    ['semeru', SemeruDistribution],
+    ['corretto', CorrettoDistribution],
+    ['oracle', OracleDistribution],
+    ['dragonwell', DragonwellDistribution],
+    ['sapmachine', SapMachineDistribution],
+    ['graalvm', GraalVMDistribution],
+    ['jetbrains', JetBrainsDistribution]
+  ])(
+    'returns %s distribution instance for "%s"',
+    (distributionName, ExpectedClass) => {
+      const distribution = getJavaDistribution(
+        distributionName,
+        installerOptions
+      );
+      expect(distribution).toBeInstanceOf(ExpectedClass);
+    }
+  );
+
+  it('returns LocalDistribution for "jdkfile" with jdkFile provided', () => {
+    const distribution = getJavaDistribution(
+      'jdkfile',
+      installerOptions,
+      '/path/to/jdk.tar.gz'
+    );
+    expect(distribution).toBeInstanceOf(LocalDistribution);
+  });
+
+  it('returns null for unknown distribution name', () => {
+    const distribution = getJavaDistribution('unknown-distro', installerOptions);
+    expect(distribution).toBeNull();
+  });
+
+  it('temurin distribution uses Hotspot implementation', () => {
+    const distribution = getJavaDistribution(
+      'temurin',
+      installerOptions
+    ) as TemurinDistribution;
+    expect(distribution).toBeInstanceOf(TemurinDistribution);
+    // @ts-ignore - accessing private field
+    expect(distribution['jvmImpl']).toBe(TemurinImplementation.Hotspot);
+  });
+
+  it('adopt distribution TemurinDistribution uses Hotspot implementation', () => {
+    const distribution = getJavaDistribution(
+      'adopt',
+      installerOptions
+    ) as AdoptDistribution;
+    // @ts-ignore - accessing private fields
+    const temurin = distribution['temurinDistribution'] as TemurinDistribution;
+    // @ts-ignore
+    expect(temurin['jvmImpl']).toBe(TemurinImplementation.Hotspot);
+  });
+
+  it('adopt distribution uses Hotspot JVM implementation', () => {
+    const distribution = getJavaDistribution(
+      'adopt',
+      installerOptions
+    ) as AdoptDistribution;
+    // @ts-ignore - accessing private field
+    expect(distribution['jvmImpl']).toBe(AdoptImplementation.Hotspot);
+  });
+
+  it('adopt-hotspot distribution uses Hotspot JVM implementation', () => {
+    const distribution = getJavaDistribution(
+      'adopt-hotspot',
+      installerOptions
+    ) as AdoptDistribution;
+    // @ts-ignore - accessing private field
+    expect(distribution['jvmImpl']).toBe(AdoptImplementation.Hotspot);
+  });
+
+  it('adopt-openj9 distribution uses OpenJ9 JVM implementation', () => {
+    const distribution = getJavaDistribution(
+      'adopt-openj9',
+      installerOptions
+    ) as AdoptDistribution;
+    // @ts-ignore - accessing private field
+    expect(distribution['jvmImpl']).toBe(AdoptImplementation.OpenJ9);
+  });
+});

--- a/src/distributions/distribution-factory.ts
+++ b/src/distributions/distribution-factory.ts
@@ -44,7 +44,8 @@ export function getJavaDistribution(
     case JavaDistribution.AdoptHotspot:
       return new AdoptDistribution(
         installerOptions,
-        AdoptImplementation.Hotspot
+        AdoptImplementation.Hotspot,
+        new TemurinDistribution(installerOptions, TemurinImplementation.Hotspot)
       );
     case JavaDistribution.AdoptOpenJ9:
       return new AdoptDistribution(


### PR DESCRIPTION
**Description:**

Updates the factory logic to inject a `TemurinDistribution` instance into `AdoptDistribution` for the "adopt" and "adopt-hotspot" cases.

Adds comprehensive unit tests for the `getJavaDistribution` factory function, ensuring that all supported Java distributions are correctly instantiated and configured. It also .

**Factory logic update:**

* Updates `getJavaDistribution` to pass a `TemurinDistribution` instance to `AdoptDistribution` when the distribution is "adopt" or "adopt-hotspot", supporting better composition and testability.
Describe your changes.

**Testing improvements:**

* Adds a new test suite (`__tests__/distributors/distribution-factory.test.ts`) that verifies the correct distribution class is returned for each supported distribution name, including edge cases like unknown distributions and local file-based installs.
* Ensures that `AdoptDistribution` is properly wired with a `TemurinDistribution` when appropriate and that the correct JVM implementation is set for each distribution.


**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.