### PR TITLE
fix CodeQL permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,6 +12,7 @@ jobs:
   call-codeQL-analysis:
     permissions:
       actions: read
+      contents: read
       security-events: write
     name: CodeQL analysis
     uses: actions/reusable-workflows/.github/workflows/codeql-analysis.yml@main


### PR DESCRIPTION
**Description:**
fixes:

```output
The workflow is not valid. .github/workflows/codeql-analysis.yml (Line: 12, Col: 3): Error calling workflow 'actions/reusable-workflows/.github/workflows/codeql-analysis.yml@main'. The nested job 'analyze' is requesting 'contents: read', but is only allowed 'contents: none'.
```

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.