### PR TITLE
chore: Harden workflows: least-privilege permissions + zizmor integration

### DIFF
--- a/.github/workflows/basic-validation.yml
+++ b/.github/workflows/basic-validation.yml
@@ -11,6 +11,9 @@ on:
     paths-ignore:
       - '**.md'
 
+permissions:
+  contents: read
+
 jobs:
   call-basic-validation:
     name: Basic validation

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -11,6 +11,9 @@ on:
       - '**.md'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   call-check-dist:
     name: Check dist/

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,6 +8,8 @@ on:
   schedule:
     - cron: '0 3 * * 0'
 
+permissions: {}
+
 jobs:
   call-codeQL-analysis:
     permissions:

--- a/.github/workflows/e2e-cache-dependency-path.yml
+++ b/.github/workflows/e2e-cache-dependency-path.yml
@@ -11,6 +11,9 @@ on:
     paths-ignore:
       - '**.md'
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash
@@ -25,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Run setup-java with the cache for gradle
         uses: ./
         id: setup-java
@@ -52,6 +57,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Run setup-java with the cache for gradle
         uses: ./
         id: setup-java
@@ -77,6 +84,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Run setup-java with the cache for gradle
         uses: ./
         id: setup-java

--- a/.github/workflows/e2e-cache.yml
+++ b/.github/workflows/e2e-cache.yml
@@ -11,6 +11,9 @@ on:
     paths-ignore:
       - '**.md'
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash
@@ -25,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Run setup-java with the cache for gradle
         uses: ./
         id: setup-java
@@ -51,6 +56,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Run setup-java with the cache for gradle
         uses: ./
         id: setup-java
@@ -74,6 +81,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Run setup-java with the cache for maven
         uses: ./
         id: setup-java
@@ -98,6 +107,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Run setup-java with the cache for maven
         uses: ./
         id: setup-java
@@ -125,6 +136,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Run setup-java with the cache for sbt
         uses: ./
         id: setup-java
@@ -175,6 +188,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Run setup-java with the cache for sbt
         uses: ./
         id: setup-java

--- a/.github/workflows/e2e-local-file.yml
+++ b/.github/workflows/e2e-local-file.yml
@@ -11,6 +11,9 @@ on:
     paths-ignore:
       - '**.md'
 
+permissions:
+  contents: read
+
 jobs:
   setup-java-local-file-adopt:
     name: Validate installation from local file Adopt
@@ -22,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Download Adopt OpenJDK file
         run: |
           if ($IsLinux) {
@@ -46,7 +51,9 @@ jobs:
           java-version: '11.0.0-ea'
           architecture: x64
       - name: Verify Java version
-        run: bash __tests__/verify-java.sh "11.0.10" "${{ steps.setup-java.outputs.path }}"
+        env:
+          JAVA_PATH: ${{ steps.setup-java.outputs.path }}
+        run: bash __tests__/verify-java.sh "11.0.10" "$JAVA_PATH"
         shell: bash
 
   setup-java-local-file-zulu:
@@ -59,6 +66,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Download Zulu OpenJDK file
         run: |
           if ($IsLinux) {
@@ -83,7 +92,9 @@ jobs:
           java-version: '11.0.0-ea'
           architecture: x64
       - name: Verify Java version
-        run: bash __tests__/verify-java.sh "11.0" "${{ steps.setup-java.outputs.path }}"
+        env:
+          JAVA_PATH: ${{ steps.setup-java.outputs.path }}
+        run: bash __tests__/verify-java.sh "11.0" "$JAVA_PATH"
         shell: bash
 
   setup-java-local-file-temurin:
@@ -96,6 +107,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Download Eclipse Temurin file
         run: |
           if ($IsLinux) {
@@ -120,5 +133,7 @@ jobs:
           java-version: '11.0.0-ea'
           architecture: x64
       - name: Verify Java version
-        run: bash __tests__/verify-java.sh "11.0.12" "${{ steps.setup-java.outputs.path }}"
+        env:
+          JAVA_PATH: ${{ steps.setup-java.outputs.path }}
+        run: bash __tests__/verify-java.sh "11.0.12" "$JAVA_PATH"
         shell: bash

--- a/.github/workflows/e2e-publishing.yml
+++ b/.github/workflows/e2e-publishing.yml
@@ -11,6 +11,9 @@ on:
     paths-ignore:
       - '**.md'
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: pwsh
@@ -26,6 +29,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: setup-java
         uses: ./
         id: setup-java
@@ -61,6 +66,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Create fake settings.xml
         run: |
           $xmlDirectory = Join-Path $HOME ".m2"
@@ -97,6 +104,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Create fake settings.xml
         run: |
           $xmlDirectory = Join-Path $HOME ".m2"
@@ -134,6 +143,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: setup-java
         uses: ./
         id: setup-java

--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -13,6 +13,10 @@ on:
   schedule:
     - cron: '0 */12 * * *'
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   setup-java-major-versions:
     name: ${{ matrix.distribution }} ${{ matrix.version }} (jdk-x64) - ${{ matrix.os }}
@@ -74,6 +78,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: setup-java
         uses: ./
         id: setup-java
@@ -83,14 +89,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify Java
-        run: bash __tests__/verify-java.sh "${{ matrix.version }}" "${{ steps.setup-java.outputs.path }}"
+        env:
+          JAVA_VERSION: ${{ matrix.version }}
+          JAVA_PATH: ${{ steps.setup-java.outputs.path }}
+        run: bash __tests__/verify-java.sh "$JAVA_VERSION" "$JAVA_PATH"
         shell: bash
 
   setup-java-alpine-linux:
     name: ${{ matrix.distribution }} ${{ matrix.version }} (jdk-x64) - alpine-linux - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     container:
-      image: alpine:latest
+      image: alpine:3.21
     strategy:
       fail-fast: false
       matrix:
@@ -100,6 +109,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install bash
         run: apk add --no-cache bash
       - name: setup-java
@@ -109,7 +120,10 @@ jobs:
           java-version: ${{ matrix.version }}
           distribution: ${{ matrix.distribution }}
       - name: Verify Java
-        run: bash __tests__/verify-java.sh "${{ matrix.version }}" "${{ steps.setup-java.outputs.path }}"
+        env:
+          JAVA_VERSION: ${{ matrix.version }}
+          JAVA_PATH: ${{ steps.setup-java.outputs.path }}
+        run: bash __tests__/verify-java.sh "$JAVA_VERSION" "$JAVA_PATH"
         shell: bash
 
   setup-java-major-minor-versions:
@@ -150,6 +164,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: setup-java
         uses: ./
         id: setup-java
@@ -157,10 +173,12 @@ jobs:
           java-version: ${{ matrix.version }}
           distribution: ${{ matrix.distribution }}
       - name: Verify Java
-        run: bash __tests__/verify-java.sh "${{ matrix.version }}" "${{ steps.setup-java.outputs.path }}"
-        shell: bash
         env:
+          JAVA_VERSION: ${{ matrix.version }}
+          JAVA_PATH: ${{ steps.setup-java.outputs.path }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash __tests__/verify-java.sh "$JAVA_VERSION" "$JAVA_PATH"
+        shell: bash
 
   setup-java-check-latest:
     name: ${{ matrix.distribution }} ${{ matrix.version }} - check-latest flag - ${{ matrix.os }}
@@ -185,6 +203,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: setup-java
         uses: ./
         id: setup-java
@@ -195,7 +215,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify Java
-        run: bash __tests__/verify-java.sh "11" "${{ steps.setup-java.outputs.path }}"
+        env:
+          JAVA_PATH: ${{ steps.setup-java.outputs.path }}
+        run: bash __tests__/verify-java.sh "11" "$JAVA_PATH"
         shell: bash
 
   setup-java-multiple-jdks:
@@ -221,6 +243,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: setup-java
         uses: ./
         id: setup-java
@@ -245,7 +269,9 @@ jobs:
           }
         shell: pwsh
       - name: Verify Java
-        run: bash __tests__/verify-java.sh "17" "${{ steps.setup-java.outputs.path }}"
+        env:
+          JAVA_PATH: ${{ steps.setup-java.outputs.path }}
+        run: bash __tests__/verify-java.sh "17" "$JAVA_PATH"
         shell: bash
 
   setup-java-ea-versions-zulu:
@@ -260,6 +286,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: setup-java
         uses: ./
         id: setup-java
@@ -267,7 +295,10 @@ jobs:
           java-version: ${{ matrix.version }}
           distribution: zulu
       - name: Verify Java
-        run: bash __tests__/verify-java.sh "${{ matrix.version }}" "${{ steps.setup-java.outputs.path }}"
+        env:
+          JAVA_VERSION: ${{ matrix.version }}
+          JAVA_PATH: ${{ steps.setup-java.outputs.path }}
+        run: bash __tests__/verify-java.sh "$JAVA_VERSION" "$JAVA_PATH"
         shell: bash
 
   setup-java-ea-versions-temurin:
@@ -282,6 +313,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: setup-java
         uses: ./
         id: setup-java
@@ -289,7 +322,10 @@ jobs:
           java-version: ${{ matrix.version }}
           distribution: temurin
       - name: Verify Java
-        run: bash __tests__/verify-java.sh "${{ matrix.version }}" "${{ steps.setup-java.outputs.path }}"
+        env:
+          JAVA_VERSION: ${{ matrix.version }}
+          JAVA_PATH: ${{ steps.setup-java.outputs.path }}
+        run: bash __tests__/verify-java.sh "$JAVA_VERSION" "$JAVA_PATH"
         shell: bash
 
   setup-java-ea-versions-sapmachine:
@@ -304,6 +340,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: setup-java
         uses: ./
         id: setup-java
@@ -311,7 +349,10 @@ jobs:
           java-version: ${{ matrix.version }}
           distribution: sapmachine
       - name: Verify Java
-        run: bash __tests__/verify-java.sh "${{ matrix.version }}" "${{ steps.setup-java.outputs.path }}"
+        env:
+          JAVA_VERSION: ${{ matrix.version }}
+          JAVA_PATH: ${{ steps.setup-java.outputs.path }}
+        run: bash __tests__/verify-java.sh "$JAVA_VERSION" "$JAVA_PATH"
         shell: bash
 
   setup-java-custom-package-type:
@@ -391,6 +432,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: setup-java
         uses: ./
         id: setup-java
@@ -401,7 +444,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify Java
-        run: bash __tests__/verify-java.sh "${{ matrix.version }}" "${{ steps.setup-java.outputs.path }}"
+        env:
+          JAVA_VERSION: ${{ matrix.version }}
+          JAVA_PATH: ${{ steps.setup-java.outputs.path }}
+        run: bash __tests__/verify-java.sh "$JAVA_VERSION" "$JAVA_PATH"
         shell: bash
 
   # Only Liberica and Zulu provide x86
@@ -419,6 +465,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: setup-java
         uses: ./
         id: setup-java
@@ -427,7 +475,10 @@ jobs:
           java-version: ${{ matrix.version }}
           architecture: 'x86'
       - name: Verify Java
-        run: bash __tests__/verify-java.sh "${{ matrix.version }}" "${{ steps.setup-java.outputs.path }}"
+        env:
+          JAVA_VERSION: ${{ matrix.version }}
+          JAVA_PATH: ${{ steps.setup-java.outputs.path }}
+        run: bash __tests__/verify-java.sh "$JAVA_VERSION" "$JAVA_PATH"
         shell: bash
 
   setup-java-version-both-version-inputs-presents:
@@ -442,6 +493,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Create .java-version file
         shell: bash
         run: echo "17" > .java-version
@@ -456,7 +509,9 @@ jobs:
           java-version: 11
           java-version-file: ${{matrix.java-version-file }}
       - name: Verify Java
-        run: bash __tests__/verify-java.sh "11" "${{ steps.setup-java.outputs.path }}"
+        env:
+          JAVA_PATH: ${{ steps.setup-java.outputs.path }}
+        run: bash __tests__/verify-java.sh "11" "$JAVA_PATH"
         shell: bash
 
   setup-java-version-from-file-major-notation:
@@ -471,6 +526,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Create .java-version file
         shell: bash
         run: echo "11" > .java-version
@@ -484,7 +541,9 @@ jobs:
           distribution: ${{ matrix.distribution }}
           java-version-file: ${{matrix.java-version-file }}
       - name: Verify Java
-        run: bash __tests__/verify-java.sh "11" "${{ steps.setup-java.outputs.path }}"
+        env:
+          JAVA_PATH: ${{ steps.setup-java.outputs.path }}
+        run: bash __tests__/verify-java.sh "11" "$JAVA_PATH"
         shell: bash
 
   setup-java-version-from-file-major-minor-patch-notation:
@@ -499,6 +558,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Create .java-version file
         shell: bash
         run: echo "17.0.10" > .java-version
@@ -512,7 +573,9 @@ jobs:
           distribution: ${{ matrix.distribution }}
           java-version-file: ${{matrix.java-version-file }}
       - name: Verify Java
-        run: bash __tests__/verify-java.sh "17.0.10" "${{ steps.setup-java.outputs.path }}"
+        env:
+          JAVA_PATH: ${{ steps.setup-java.outputs.path }}
+        run: bash __tests__/verify-java.sh "17.0.10" "$JAVA_PATH"
         shell: bash
 
   setup-java-version-from-file-major-minor-patch-with-dist:
@@ -527,6 +590,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Create .java-version file
         shell: bash
         run: echo "openjdk64-17.0.10" > .java-version
@@ -543,5 +608,7 @@ jobs:
           distribution: ${{ matrix.distribution }}
           java-version-file: ${{matrix.java-version-file }}
       - name: Verify Java
-        run: bash __tests__/verify-java.sh "17.0.10" "${{ steps.setup-java.outputs.path }}"
+        env:
+          JAVA_PATH: ${{ steps.setup-java.outputs.path }}
+        run: bash __tests__/verify-java.sh "17.0.10" "$JAVA_PATH"
         shell: bash

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -9,6 +9,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   call-licensed:
     name: Licensed

--- a/.github/workflows/publish-immutable-actions.yml
+++ b/.github/workflows/publish-immutable-actions.yml
@@ -5,6 +5,8 @@ on:
     types: [released]
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -16,6 +18,8 @@ jobs:
     steps:
       - name: Checking out
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Publish
         id: publish
         uses: actions/publish-immutable-action@v0.0.4

--- a/.github/workflows/update-config-files.yml
+++ b/.github/workflows/update-config-files.yml
@@ -5,7 +5,12 @@ on:
     - cron: '0 3 * * 0'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   call-update-configuration-files:
     name: Update configuration files
+    permissions:
+      contents: write # to push the branch with updated configuration files
+      pull-requests: write # to open/update the configuration update PR
     uses: actions/reusable-workflows/.github/workflows/update-config-files.yml@main

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -41,7 +41,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload SARIF results to code scanning
-if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: zizmor.sarif

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -41,7 +41,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload SARIF results to code scanning
-        if: always()
+if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: zizmor.sarif

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,48 @@
+name: Security analysis with zizmor
+
+on:
+  push:
+    branches:
+      - main
+      - releases/*
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Analyze workflows with zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # to upload SARIF results to code scanning
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install zizmor
+        run: pip install zizmor
+
+      - name: Run zizmor
+        run: zizmor --format sarif .github/workflows/ > zizmor.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SARIF results to code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: zizmor.sarif
+          category: zizmor

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,11 @@
+# Configuration for zizmor (https://docs.zizmor.sh)
+rules:
+  unpinned-uses:
+    config:
+      # First-party GitHub-maintained actions are trusted and referenced by
+      # major-version tags (the convention used across the actions org).
+      # Any third-party action must be pinned to a full commit SHA.
+      policies:
+        actions/*: ref-pin
+        github/*: ref-pin
+        '*': hash-pin


### PR DESCRIPTION
## Summary

Hardens the action's **own** CI/CD workflows by applying GitHub Actions security best practices and integrates [zizmor](https://docs.zizmor.sh) so regressions are caught automatically going forward.

Motivation: after the recent supply-chain compromises in the Actions ecosystem, consumers increasingly expect the actions they depend on to follow least-privilege and hardening practices. These changes are **config-only** — no action source (`src/`/`dist/`) is touched, so runtime behavior of `setup-java` is unchanged.

## What changed

### 1. Least-privilege `permissions:` on every workflow
Previously most workflows had no `permissions:` block and therefore inherited the repository/organization default token scopes. Now each workflow declares exactly what it needs:

| Workflow | Permissions |
|---|---|
| `basic-validation`, `check-dist`, `licensed`, all `e2e-*` | `contents: read` |
| `codeql-analysis` | top-level `{}`, job keeps `actions: read` / `contents: read` / `security-events: write` |
| `publish-immutable-actions` | top-level `{}`, job keeps `contents: read` / `id-token: write` / `packages: write` |
| `update-config-files` | top-level `{}`, job gets `contents: write` + `pull-requests: write` (needed to push the branch and open the PR) |
| `release-new-action-version` | already scoped to `contents: write` (unchanged) |

### 2. Drop credential persistence
Added `persist-credentials: false` to **all** `actions/checkout` steps that don't subsequently use the `GITHUB_TOKEN` (every e2e/validation checkout plus the immutable-publish checkout). This prevents the token from lingering in the local git config.

### 3. Avoid template injection in `run:` blocks
Moved `${{ matrix.version }}` and `${{ steps.setup-java.outputs.path }}` expansions out of inline `run:` scripts into `env:` variables referenced as `"$VAR"`, the pattern recommended to avoid shell injection via expression interpolation.

### 4. Pin the container image
`alpine:latest` → `alpine:3.21` in `e2e-versions.yml` (mutable `latest` tag → fixed version).

### 5. Integrate zizmor
- **`.github/workflows/zizmor.yml`** — runs on push/PR, fails the build on any finding (regression gate), and uploads SARIF to the **Code scanning** tab.
- **`.github/zizmor.yml`** — pinning policy aligned with this repo's conventions: first-party `actions/*` and `github/*` may use version tags (`ref-pin`), while any third-party action must be pinned to a full commit SHA (`hash-pin`).

## Validation

zizmor goes from **39 high + 39 medium + 31 low/info** findings to **0**, both offline and online:

```
$ zizmor .github/workflows/
No findings to report. Good job!
```

All workflow YAML was validated for syntax.

## Related

Addresses the hardening/security-posture aspect mentioned alongside #1023 (immutable releases). The `publish-immutable-actions.yml` workflow that satisfies #1023 is also hardened here (`persist-credentials: false`, explicit top-level `{}`).
