### PR TITLE
docs: note jdkfile approach for Early Access / unreleased JDK builds

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -288,7 +288,7 @@ steps:
 - run: java --version
 ```
 
-For example, to use an **Early Access** build (such as an upcoming feature release from [jdk.java.net](https://jdk.java.net/)) that is not yet available through a regular distribution:
+For example, to use an **Early Access** build from [jdk.java.net](https://jdk.java.net/), download the archive for your runner OS/architecture and install it via `distribution: 'jdkfile'` (example below assumes Linux x64):
 
 ```yaml
 steps:

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -271,7 +271,7 @@ steps:
 If your use-case requires a custom distribution or a version that is not provided by setup-java, you can download it manually and setup-java will take care of the installation and caching on the VM:
 
 > [!NOTE]
-> This approach also lets you use builds that setup-java does not provide directly, such as **Early Access (EA)** or other unreleased JDK builds (for example, an upcoming feature release or a loom/valhalla preview build). Download the desired archive in a prior step and point `jdkFile` at it; setup-java will extract, install, and cache it just like a supported distribution. When targeting multiple architectures, select the correct binary per architecture in your workflow (for example, with a build matrix).
+> This approach also lets you use builds that setup-java does not provide directly, such as **Early Access (EA)** or other unreleased JDK builds (for example, an upcoming feature release or a Loom/Valhalla preview build). Download the desired archive in a prior step and point `jdkFile` at it; setup-java will extract, install, and cache it just like a supported distribution. When targeting multiple architectures, select the correct binary per architecture in your workflow (for example, with a build matrix).
 
 ```yaml
 steps:
@@ -299,7 +299,7 @@ steps:
   with:
     distribution: 'jdkfile'
     jdkFile: ${{ runner.temp }}/java_package.tar.gz
-    java-version: '25-ea'
+    java-version: '25.0.0-ea.36'
     architecture: x64
 
 - run: java --version

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -270,6 +270,9 @@ steps:
 ## Installing Java from local file
 If your use-case requires a custom distribution or a version that is not provided by setup-java, you can download it manually and setup-java will take care of the installation and caching on the VM:
 
+> [!NOTE]
+> This approach also lets you use builds that setup-java does not provide directly, such as **Early Access (EA)** or other unreleased JDK builds (for example, an upcoming feature release or a loom/valhalla preview build). Download the desired archive in a prior step and point `jdkFile` at it; setup-java will extract, install, and cache it just like a supported distribution. When targeting multiple architectures, select the correct binary per architecture in your workflow (for example, with a build matrix).
+
 ```yaml
 steps:
 - run: |
@@ -282,6 +285,23 @@ steps:
     java-version: '11.0.0'
     architecture: x64
     
+- run: java --version
+```
+
+For example, to use an **Early Access** build (such as an upcoming feature release from [jdk.java.net](https://jdk.java.net/)) that is not yet available through a regular distribution:
+
+```yaml
+steps:
+- run: |
+    download_url="https://download.java.net/java/early_access/jdk25/36/GPL/openjdk-25-ea+36_linux-x64_bin.tar.gz"
+    wget -O $RUNNER_TEMP/java_package.tar.gz $download_url
+- uses: actions/setup-java@v5
+  with:
+    distribution: 'jdkfile'
+    jdkFile: ${{ runner.temp }}/java_package.tar.gz
+    java-version: '25-ea'
+    architecture: x64
+
 - run: java --version
 ```
 


### PR DESCRIPTION
## Description

Adds a note and a concrete example to the **"Installing Java from local file"** section of `docs/advanced-usage.md` clarifying that the existing `jdkfile` distribution can be used to install **Early Access (EA)** or other unreleased JDK builds that setup-java does not provide directly.

Users download the desired archive in a prior step and point `jdkFile` at it; setup-java handles extraction, installation, and caching as with any supported distribution.

## Why

This is a recurring ask (e.g., wanting to test against EA / unreleased Java versions). The capability already exists via `jdkfile`, but it isn't called out for the EA use case, so users don't realize it's supported.

## Changes

- Add a `> [!NOTE]` callout explaining the EA / unreleased-build use case and per-architecture selection.
- Add a concrete EA example downloading an `jdk.java.net` early-access build and installing it via `distribution: 'jdkfile'`.

## Related

Addresses #612.
