### PR TITLE
dist: Apply Copilot review suggestions from PR #1042 (GraalVM Community)

### DIFF
--- a/__tests__/distributors/graalvm-installer.test.ts
+++ b/__tests__/distributors/graalvm-installer.test.ts
@@ -1058,6 +1058,20 @@ describe('GraalVMDistribution', () => {
           'GraalVM Community does not provide early access builds'
         );
       });
+
+      it('should surface an error when the releases listing is not an array', async () => {
+        mockHttpClient.getJson.mockResolvedValue({
+          result: {message: 'API rate limit exceeded'},
+          statusCode: 403,
+          headers: {}
+        });
+
+        await expect(
+          (communityDistribution as any).findPackageForDownload('21')
+        ).rejects.toThrow(
+          /Unexpected response while listing GraalVM Community releases.*HTTP status code: 403/s
+        );
+      });
     });
   });
 });

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -186,8 +186,8 @@ steps:
     distribution: 'graalvm-community'
     java-version: '21'
 - run: |
-    java -cp java HelloWorldApp
-    native-image -cp java HelloWorldApp
+    java --version
+    native-image --version
 ```
 
 ### JetBrains

--- a/src/distributions/graalvm/installer.ts
+++ b/src/distributions/graalvm/installer.ts
@@ -391,7 +391,20 @@ export class GraalVMCommunityDistribution extends GraalVMDistribution {
         headers
       );
 
-      const releases = Array.isArray(response.result) ? response.result : [];
+      // A successful GitHub releases listing is always a JSON array (possibly
+      // empty). Anything else indicates an unexpected/error payload (rate
+      // limiting, auth failure, etc.) that must be surfaced instead of being
+      // silently treated as "no releases", which would later look like a
+      // misleading "version not found" error.
+      if (!Array.isArray(response.result)) {
+        throw new Error(
+          `Unexpected response while listing GraalVM Community releases from ${releasesUrl} ` +
+            `(HTTP status code: ${response.statusCode}). Expected a JSON array of releases. ` +
+            `Please check if the service is available at ${GRAALVM_COMMUNITY_DOWNLOAD_URL}.`
+        );
+      }
+
+      const releases = response.result;
       if (releases.length === 0) {
         break;
       }


### PR DESCRIPTION
## Description

Follow-up to #1042 (now merged) addressing the two suggestions left by the Copilot reviewer that weren't applied before merge.

### 1. `src/distributions/graalvm/installer.ts` — surface API errors instead of masking them
The GraalVM Community release listing previously treated any non-array JSON result as "no releases" and broke out of pagination. If the GitHub API returned an error payload (rate limiting, auth failure, etc.), this would later surface as a misleading **"version not found"** error rather than reporting the actual API failure.

Now, a non-array response throws a descriptive error including the HTTP status code and a pointer to the GraalVM Community download page. A legitimate empty array (`[]`) still terminates pagination normally.

### 2. `docs/advanced-usage.md` — make the GraalVM Community example self-contained
The example ran `java -cp java HelloWorldApp` / `native-image -cp java HelloWorldApp`, but never created `HelloWorldApp` or a `java` classpath directory, so it would fail when copied as-is. It now checks the installed binaries' versions (`java --version` / `native-image --version`), matching the GraalVM (Oracle) example just above it.

### Tests
Added a test covering the new non-array release listing error path. Full GraalVM suite passes (50 tests). Rebuilt the `dist/` bundle.

## Related
- Follow-up to #1042
- Copilot review: https://github.com/actions/setup-java/pull/1042#pullrequestreview (inline suggestions)

## Check list
- [x] Documentation changes (docs/advanced-usage.md)
- [x] Tests added/updated
