### PR TITLE
Updated jetbrains test: https.request() now catches errors. This fixes leaking tests as well

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npm run build && npm test

--- a/__tests__/distributors/jetbrains-installer.test.ts
+++ b/__tests__/distributors/jetbrains-installer.test.ts
@@ -89,14 +89,20 @@ describe('findPackageForDownload', () => {
 
       await new Promise<void>((resolve, reject) => {
         const request = https.request(url, options, res => {
+          let assertionError: unknown;
+
           try {
             // JetBrains uses 403 for non-existent packages
             expect(res.statusCode).not.toBe(403);
-            res.resume();
-            res.on('end', resolve);
           } catch (error) {
-            reject(error);
+            assertionError = error;
           }
+
+          res.resume();
+          res.once('error', reject);
+          res.once('end', () =>
+            assertionError ? reject(assertionError as Error) : resolve()
+          );
         });
 
         request.on('error', reject);

--- a/__tests__/distributors/jetbrains-installer.test.ts
+++ b/__tests__/distributors/jetbrains-installer.test.ts
@@ -87,10 +87,20 @@ describe('findPackageForDownload', () => {
       const url = resolvedVersion.url;
       const options = {method: 'HEAD'};
 
-      https.request(url, options, res => {
-        // JetBrains uses 403 for inexistent packages
-        expect(res.statusCode).not.toBe(403);
-        res.resume();
+      await new Promise<void>((resolve, reject) => {
+        const request = https.request(url, options, res => {
+          try {
+            // JetBrains uses 403 for non-existent packages
+            expect(res.statusCode).not.toBe(403);
+            res.resume();
+            res.on('end', resolve);
+          } catch (error) {
+            reject(error);
+          }
+        });
+
+        request.on('error', reject);
+        request.end();
       });
     }
   );


### PR DESCRIPTION
**Description:**
Now running https.request() within a try/catch to make sure that errors are caught and the test if rejected upon error. This fixes an issue where `npm run check` would always finish with the following warning:
`A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them`

Also removed deprecated code lines from `.husky/pre-commit` and `.husky/pre-push`. These lines would begin to fail in husky version 10.0.0, but this PR fixes that :)

**Related issue:**
Add link to the related issue.

**Check list:**
- [x] Ran `npm run check` locally (format, lint, build, test) and all checks pass.
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.