### PR TITLE
Map Zulu x86 architecture to i686 for Azul Metadata API

### DIFF
--- a/__tests__/distributors/zulu-installer.test.ts
+++ b/__tests__/distributors/zulu-installer.test.ts
@@ -87,7 +87,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=macos&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=false&crac_supported=false&arch=x86&release_status=ga&availability_types=ca&page=1&page_size=100'
+      '?os=macos&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=false&crac_supported=false&arch=i686&release_status=ga&availability_types=ca&page=1&page_size=100'
     ],
     [
       {
@@ -96,7 +96,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=macos&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=false&crac_supported=false&arch=x86&release_status=ea&availability_types=ca&page=1&page_size=100'
+      '?os=macos&archive_type=tar.gz&java_package_type=jdk&javafx_bundled=false&crac_supported=false&arch=i686&release_status=ea&availability_types=ca&page=1&page_size=100'
     ],
     [
       {
@@ -225,7 +225,7 @@ describe('getAvailableVersions', () => {
 describe('getArchitectureOptions', () => {
   it.each([
     [{architecture: 'x64'}, 'x64'],
-    [{architecture: 'x86'}, 'x86'],
+    [{architecture: 'x86'}, 'i686'],
     [{architecture: 'aarch64'}, 'aarch64'],
     [{architecture: 'arm64'}, 'aarch64'],
     [{architecture: 'arm'}, 'arm']

--- a/__tests__/distributors/zulu-linux-installer.test.ts
+++ b/__tests__/distributors/zulu-linux-installer.test.ts
@@ -89,7 +89,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=linux_glibc&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&arch=x86&release_status=ga&availability_types=ca&page=1&page_size=100'
+      '?os=linux_glibc&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&arch=i686&release_status=ga&availability_types=ca&page=1&page_size=100'
     ],
     [
       {
@@ -98,7 +98,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=linux_glibc&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&arch=x86&release_status=ea&availability_types=ca&page=1&page_size=100'
+      '?os=linux_glibc&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&arch=i686&release_status=ea&availability_types=ca&page=1&page_size=100'
     ],
     [
       {
@@ -229,7 +229,7 @@ describe('getAvailableVersions', () => {
 describe('getArchitectureOptions', () => {
   it.each([
     [{architecture: 'x64'}, 'x64'],
-    [{architecture: 'x86'}, 'x86'],
+    [{architecture: 'x86'}, 'i686'],
     [{architecture: 'aarch64'}, 'aarch64'],
     [{architecture: 'arm64'}, 'aarch64'],
     [{architecture: 'arm'}, 'arm']

--- a/__tests__/distributors/zulu-windows-installer.test.ts
+++ b/__tests__/distributors/zulu-windows-installer.test.ts
@@ -88,7 +88,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=windows&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&arch=x86&release_status=ga&availability_types=ca&page=1&page_size=100'
+      '?os=windows&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&arch=i686&release_status=ga&availability_types=ca&page=1&page_size=100'
     ],
     [
       {
@@ -97,7 +97,7 @@ describe('getAvailableVersions', () => {
         packageType: 'jdk',
         checkLatest: false
       },
-      '?os=windows&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&arch=x86&release_status=ea&availability_types=ca&page=1&page_size=100'
+      '?os=windows&archive_type=zip&java_package_type=jdk&javafx_bundled=false&crac_supported=false&arch=i686&release_status=ea&availability_types=ca&page=1&page_size=100'
     ],
     [
       {
@@ -226,7 +226,7 @@ describe('getAvailableVersions', () => {
 describe('getArchitectureOptions', () => {
   it.each([
     [{architecture: 'x64'}, 'x64'],
-    [{architecture: 'x86'}, 'x86'],
+    [{architecture: 'x86'}, 'i686'],
     [{architecture: 'aarch64'}, 'aarch64'],
     [{architecture: 'arm64'}, 'aarch64'],
     [{architecture: 'arm'}, 'arm']

--- a/src/distributions/zulu/installer.ts
+++ b/src/distributions/zulu/installer.ts
@@ -185,7 +185,11 @@ export class ZuluDistribution extends JavaBase {
       case 'x64':
         return 'x64';
       case 'x86':
-        return 'x86';
+        // The Azul Metadata API's "x86" value returns both 32-bit (i686) and
+        // 64-bit (x64) packages, which are indistinguishable by version and
+        // would let a 32-bit request resolve to a 64-bit JDK. Use "i686" to
+        // target only genuine 32-bit builds, matching the legacy API behavior.
+        return 'i686';
       case 'aarch64':
       case 'arm64':
         return 'aarch64';


### PR DESCRIPTION
## Summary

Follow-up to #1010 (Azul Metadata API migration). Fixes a regression where an explicit `architecture: x86` request for the Zulu distribution could resolve to a **64-bit** JDK.

## Problem

The migration mapped code arch `x86` → API `arch=x86`. However, the Azul Metadata API's `arch=x86` returns **both** 32-bit (`i686`) and 64-bit (`x64`) packages. The two variants share identical `java_version` and `distro_version`, so `findPackageForDownload` cannot distinguish them and picks whichever the API returns first.

Consequences for `architecture: x86`:
- It frequently resolves to a **64-bit** build instead of 32-bit.
- For Java 21+ (where Azul dropped 32-bit), it **silently returns a 64-bit JDK** instead of failing.

The legacy Zulu Discovery API avoided this by using `arch=x86&hw_bitness=32`, which returned only 32-bit builds.

## Fix

Map `x86` → `i686`. The Metadata API's `arch=i686` returns **only** genuine 32-bit builds, with verified full version parity to the legacy 32-bit behavior:

| Platform | legacy `x86` + `hw_bitness=32` | new `i686` | lost |
|---|---|---|---|
| linux | 141 versions | 141 | 0 |
| windows | 143 versions | 143 | 0 |

x64 and aarch64 resolution are unaffected.

## Testing

- Updated the three Zulu installer test suites (URL query params + `getArchitectureOptions` mapping).
- Full suite passes (855 tests).
- `dist/` rebuilt.
