### PR TITLE
Add Maven compiler problem matcher for javac diagnostics

### DIFF
--- a/.github/java.json
+++ b/.github/java.json
@@ -21,6 +21,19 @@
                     "message": 4
                 }
             ]
+        },
+        {
+            "owner": "maven-javac",
+            "pattern": [
+                {
+                    "regexp": "^\\[(WARNING|ERROR)\\]\\s+(.+?\\.java):\\[(\\d+),(\\d+)\\]\\s+(.+)$",
+                    "severity": 1,
+                    "file": 2,
+                    "line": 3,
+                    "column": 4,
+                    "message": 5
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
**Description:**

The `javac` problem matcher registered by `setup-java` only recognizes javac's native diagnostic format (`File.java:12: warning: msg`). That works for plain `javac` and for Gradle (which passes diagnostics through unchanged), but not for Maven. The `maven-compiler-plugin` reformats every diagnostic to `[WARNING] /path/File.java:[12,5] msg`, so the existing regex never matches and Maven builds produce zero GitHub annotations even though the warnings/errors appear in the log.

This adds a new `maven-javac` problem matcher owner to `.github/java.json` that recognizes the Maven format and captures severity, file, line, column, and message. A separate owner is used because multiple patterns under one owner are treated as a multiline sequence, not as alternatives. Both owners are registered by the same existing `##[add-matcher]` call, so no source change is needed. Maven builds now annotate consistently with Gradle and plain javac.

Notes:
- The existing `java` and `javac` owners are unchanged, so current behavior is preserved.
- `java.json` is loaded at runtime by the runner and is not part of the webpack bundle, so `dist/` does not need regeneration.
- GitHub matches the `severity` value case-insensitively, so capturing the uppercase `WARNING`/`ERROR` labels works.

**Related issue:**

Fixes: #1085

**Check list:**
- [ ] Ran `npm run check` locally (format, lint, build, test) and all checks pass.
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.