### PR TITLE
feat: expose cache-primary-key output (#597)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ When the option `cache-dependency-path` is specified, the hash is based on the m
 
 The workflow output `cache-hit` is set to indicate if an exact match was found for the key [as actions/cache does](https://github.com/actions/cache/tree/main#outputs).
 
-The workflow output `cache-primary-key` exposes the primary cache key computed by the action for the configured build tool. It is useful for composing with [`actions/cache`](https://github.com/actions/cache) or [`actions/cache/restore`](https://github.com/actions/cache/tree/main/restore) in later steps or dependent jobs that need to reuse the exact same key. It is empty when caching is not enabled.
+The workflow output `cache-primary-key` exposes the primary cache key computed by the action for the configured build tool. It is useful for composing with [`actions/cache`](https://github.com/actions/cache) or [`actions/cache/restore`](https://github.com/actions/cache/tree/main/restore) in later steps or dependent jobs that need to reuse the exact same key. It is empty when caching is not enabled or when caching is skipped (for example, when the cache service is unavailable).
 
 The cache input is optional, and caching is turned off by default.
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ When the option `cache-dependency-path` is specified, the hash is based on the m
 
 The workflow output `cache-hit` is set to indicate if an exact match was found for the key [as actions/cache does](https://github.com/actions/cache/tree/main#outputs).
 
+The workflow output `cache-primary-key` exposes the primary cache key computed by the action for the configured build tool. It is useful for composing with [`actions/cache`](https://github.com/actions/cache) or [`actions/cache/restore`](https://github.com/actions/cache/tree/main/restore) in later steps or dependent jobs that need to reuse the exact same key. It is empty when caching is not enabled.
+
 The cache input is optional, and caching is turned off by default.
 
 **Maven Wrapper:** when `cache: 'maven'` is enabled, the action also caches and restores the Maven Wrapper distribution downloaded to `~/.m2/wrapper/dists` (in addition to the local repository), so wrapper-based (`./mvnw`) builds don't re-download the wrapper on every run. This is keyed on `**/.mvn/wrapper/maven-wrapper.properties` as shown above.

--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -133,6 +133,7 @@ describe('dependency cache', () => {
   describe('restore', () => {
     let spyCacheRestore: any;
     let spyGlobHashFiles: any;
+    let spySetOutput: any;
 
     beforeEach(() => {
       spyCacheRestore = (cache.restoreCache as any).mockImplementation(
@@ -140,6 +141,8 @@ describe('dependency cache', () => {
       );
       spyGlobHashFiles = glob.hashFiles as jest.Mock;
       spyGlobHashFiles.mockResolvedValue('hash-stub');
+      spySetOutput = core.setOutput as jest.Mock;
+      spySetOutput.mockImplementation(() => null);
       spyWarning.mockImplementation(() => null);
     });
 
@@ -174,6 +177,15 @@ describe('dependency cache', () => {
         );
         expect(spyWarning).not.toHaveBeenCalled();
         expect(spyInfo).toHaveBeenCalledWith('maven cache is not found');
+      });
+      it('sets the cache-primary-key output', async () => {
+        createFile(join(workspace, 'pom.xml'));
+
+        await restore('maven', '');
+        expect(spySetOutput).toHaveBeenCalledWith(
+          'cache-primary-key',
+          expect.stringContaining('setup-java-')
+        );
       });
       it('downloads cache based on maven-wrapper.properties', async () => {
         createDirectory(join(workspace, '.mvn'));

--- a/action.yml
+++ b/action.yml
@@ -104,7 +104,7 @@ outputs:
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'
   cache-primary-key:
-    description: 'The primary cache key computed by the action for the configured build tool. Empty when caching is not enabled. Useful for composing with actions/cache or actions/cache/restore across jobs.'
+    description: 'The primary cache key computed by the action for the configured build tool. Empty when caching is not enabled or when caching is skipped (e.g. cache service unavailable). Useful for composing with actions/cache or actions/cache/restore across jobs.'
 runs:
   using: 'node24'
   main: 'dist/setup/index.js'

--- a/action.yml
+++ b/action.yml
@@ -103,6 +103,8 @@ outputs:
     description: 'Path to where the java environment has been installed (same as $JAVA_HOME)'
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'
+  cache-primary-key:
+    description: 'The primary cache key computed by the action for the configured build tool. Empty when caching is not enabled. Useful for composing with actions/cache or actions/cache/restore across jobs.'
 runs:
   using: 'node24'
   main: 'dist/setup/index.js'

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -99735,7 +99735,7 @@ async function restore(id, cacheDependencyPath) {
     const primaryKey = await computeCacheKey(packageManager, cacheDependencyPath);
     core.debug(`primary key is ${primaryKey}`);
     core.saveState(STATE_CACHE_PRIMARY_KEY, primaryKey);
-    core.setOutput('cache-primary-key', primaryKey);
+    core.setOutput(STATE_CACHE_PRIMARY_KEY, primaryKey);
     // No "restoreKeys" is set, to start with a clear cache after dependency update (see https://github.com/actions/setup-java/issues/269)
     const matchedKey = await cache.restoreCache(packageManager.path, primaryKey);
     if (matchedKey) {

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -99735,6 +99735,7 @@ async function restore(id, cacheDependencyPath) {
     const primaryKey = await computeCacheKey(packageManager, cacheDependencyPath);
     core.debug(`primary key is ${primaryKey}`);
     core.saveState(STATE_CACHE_PRIMARY_KEY, primaryKey);
+    core.setOutput('cache-primary-key', primaryKey);
     // No "restoreKeys" is set, to start with a clear cache after dependency update (see https://github.com/actions/setup-java/issues/269)
     const matchedKey = await cache.restoreCache(packageManager.path, primaryKey);
     if (matchedKey) {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -118,7 +118,7 @@ export async function restore(id: string, cacheDependencyPath: string) {
   const primaryKey = await computeCacheKey(packageManager, cacheDependencyPath);
   core.debug(`primary key is ${primaryKey}`);
   core.saveState(STATE_CACHE_PRIMARY_KEY, primaryKey);
-  core.setOutput('cache-primary-key', primaryKey);
+  core.setOutput(STATE_CACHE_PRIMARY_KEY, primaryKey);
 
   // No "restoreKeys" is set, to start with a clear cache after dependency update (see https://github.com/actions/setup-java/issues/269)
   const matchedKey = await cache.restoreCache(packageManager.path, primaryKey);

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -118,6 +118,7 @@ export async function restore(id: string, cacheDependencyPath: string) {
   const primaryKey = await computeCacheKey(packageManager, cacheDependencyPath);
   core.debug(`primary key is ${primaryKey}`);
   core.saveState(STATE_CACHE_PRIMARY_KEY, primaryKey);
+  core.setOutput('cache-primary-key', primaryKey);
 
   // No "restoreKeys" is set, to start with a clear cache after dependency update (see https://github.com/actions/setup-java/issues/269)
   const matchedKey = await cache.restoreCache(packageManager.path, primaryKey);


### PR DESCRIPTION
## What

Exposes the primary cache key computed by the caching logic as a new `cache-primary-key` action output.

Closes #597.

## Why

Today the action computes a primary cache key internally (`setup-java-<os>-<arch>-<packageManager>-<hash>`) but never surfaces it. Users who want to compose the built-in setup-java caching with [`actions/cache`](https://github.com/actions/cache) / [`actions/cache/restore`](https://github.com/actions/cache/tree/main/restore) — e.g. to force the same key across dependent jobs — have no way to reference it. This exposes it as an output, mirroring what `actions/setup-node` and `actions/cache` already do.

## Changes

- `src/cache.ts`: set the `cache-primary-key` output in `restore()`
- `action.yml`: declare the new `cache-primary-key` output
- `README.md`: document the new output
- `__tests__/cache.test.ts`: assert the output is set
- `dist/`: rebuild

## Notes

- Non-breaking, purely additive.
- The output is empty when caching is not enabled (the action only computes/sets it inside `restore()`, which runs only when `cache:` is set).
- A backport of this change to `releases/v5` is in a separate PR.

## Testing

- `npm test` (cache suite: 32/32 passing)
- lint + format-check clean