### PR TITLE
feat: expose cache-primary-key output (#597) [v5 backport]

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ When the option `cache-dependency-path` is specified, the hash is based on the m
 
 The workflow output `cache-hit` is set to indicate if an exact match was found for the key [as actions/cache does](https://github.com/actions/cache/tree/main#outputs).
 
-The workflow output `cache-primary-key` exposes the primary cache key computed by the action for the configured build tool. It is useful for composing with [`actions/cache`](https://github.com/actions/cache) or [`actions/cache/restore`](https://github.com/actions/cache/tree/main/restore) in later steps or dependent jobs that need to reuse the exact same key. It is empty when caching is not enabled.
+The workflow output `cache-primary-key` exposes the primary cache key computed by the action for the configured build tool. It is useful for composing with [`actions/cache`](https://github.com/actions/cache) or [`actions/cache/restore`](https://github.com/actions/cache/tree/main/restore) in later steps or dependent jobs that need to reuse the exact same key. It is empty when caching is not enabled or when caching is skipped (for example, when the cache service is unavailable).
 
 The cache input is optional, and caching is turned off by default.
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ When the option `cache-dependency-path` is specified, the hash is based on the m
 
 The workflow output `cache-hit` is set to indicate if an exact match was found for the key [as actions/cache does](https://github.com/actions/cache/tree/main#outputs).
 
+The workflow output `cache-primary-key` exposes the primary cache key computed by the action for the configured build tool. It is useful for composing with [`actions/cache`](https://github.com/actions/cache) or [`actions/cache/restore`](https://github.com/actions/cache/tree/main/restore) in later steps or dependent jobs that need to reuse the exact same key. It is empty when caching is not enabled.
+
 The cache input is optional, and caching is turned off by default.
 
 **Maven Wrapper:** when `cache: 'maven'` is enabled, the action also caches and restores the Maven Wrapper distribution downloaded to `~/.m2/wrapper/dists` (in addition to the local repository), so wrapper-based (`./mvnw`) builds don't re-download the wrapper on every run. This is keyed on `**/.mvn/wrapper/maven-wrapper.properties` as shown above.

--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -78,6 +78,10 @@ describe('dependency cache', () => {
       ReturnType<typeof glob.hashFiles>,
       Parameters<typeof glob.hashFiles>
     >;
+    let spySetOutput: jest.SpyInstance<
+      ReturnType<typeof core.setOutput>,
+      Parameters<typeof core.setOutput>
+    >;
 
     beforeEach(() => {
       spyCacheRestore = jest
@@ -86,6 +90,7 @@ describe('dependency cache', () => {
           Promise.resolve(undefined)
         );
       spyGlobHashFiles = jest.spyOn(glob, 'hashFiles');
+      spySetOutput = jest.spyOn(core, 'setOutput').mockImplementation(() => {});
       spyWarning.mockImplementation(() => null);
     });
 
@@ -119,6 +124,15 @@ describe('dependency cache', () => {
         );
         expect(spyWarning).not.toHaveBeenCalled();
         expect(spyInfo).toHaveBeenCalledWith('maven cache is not found');
+      });
+      it('sets the cache-primary-key output', async () => {
+        createFile(join(workspace, 'pom.xml'));
+
+        await restore('maven', '');
+        expect(spySetOutput).toHaveBeenCalledWith(
+          'cache-primary-key',
+          expect.stringContaining('setup-java-')
+        );
       });
       it('downloads cache based on maven-wrapper.properties', async () => {
         createDirectory(join(workspace, '.mvn'));

--- a/action.yml
+++ b/action.yml
@@ -104,7 +104,7 @@ outputs:
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'
   cache-primary-key:
-    description: 'The primary cache key computed by the action for the configured build tool. Empty when caching is not enabled. Useful for composing with actions/cache or actions/cache/restore across jobs.'
+    description: 'The primary cache key computed by the action for the configured build tool. Empty when caching is not enabled or when caching is skipped (e.g. cache service unavailable). Useful for composing with actions/cache or actions/cache/restore across jobs.'
 runs:
   using: 'node24'
   main: 'dist/setup/index.js'

--- a/action.yml
+++ b/action.yml
@@ -103,6 +103,8 @@ outputs:
     description: 'Path to where the java environment has been installed (same as $JAVA_HOME)'
   cache-hit:
     description: 'A boolean value to indicate an exact match was found for the primary key'
+  cache-primary-key:
+    description: 'The primary cache key computed by the action for the configured build tool. Empty when caching is not enabled. Useful for composing with actions/cache or actions/cache/restore across jobs.'
 runs:
   using: 'node24'
   main: 'dist/setup/index.js'

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -52056,6 +52056,7 @@ function restore(id, cacheDependencyPath) {
         const primaryKey = yield computeCacheKey(packageManager, cacheDependencyPath);
         core.debug(`primary key is ${primaryKey}`);
         core.saveState(STATE_CACHE_PRIMARY_KEY, primaryKey);
+        core.setOutput('cache-primary-key', primaryKey);
         // No "restoreKeys" is set, to start with a clear cache after dependency update (see https://github.com/actions/setup-java/issues/269)
         const matchedKey = yield cache.restoreCache(packageManager.path, primaryKey);
         if (matchedKey) {

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -52056,7 +52056,7 @@ function restore(id, cacheDependencyPath) {
         const primaryKey = yield computeCacheKey(packageManager, cacheDependencyPath);
         core.debug(`primary key is ${primaryKey}`);
         core.saveState(STATE_CACHE_PRIMARY_KEY, primaryKey);
-        core.setOutput('cache-primary-key', primaryKey);
+        core.setOutput(STATE_CACHE_PRIMARY_KEY, primaryKey);
         // No "restoreKeys" is set, to start with a clear cache after dependency update (see https://github.com/actions/setup-java/issues/269)
         const matchedKey = yield cache.restoreCache(packageManager.path, primaryKey);
         if (matchedKey) {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -118,7 +118,7 @@ export async function restore(id: string, cacheDependencyPath: string) {
   const primaryKey = await computeCacheKey(packageManager, cacheDependencyPath);
   core.debug(`primary key is ${primaryKey}`);
   core.saveState(STATE_CACHE_PRIMARY_KEY, primaryKey);
-  core.setOutput('cache-primary-key', primaryKey);
+  core.setOutput(STATE_CACHE_PRIMARY_KEY, primaryKey);
 
   // No "restoreKeys" is set, to start with a clear cache after dependency update (see https://github.com/actions/setup-java/issues/269)
   const matchedKey = await cache.restoreCache(packageManager.path, primaryKey);

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -118,6 +118,7 @@ export async function restore(id: string, cacheDependencyPath: string) {
   const primaryKey = await computeCacheKey(packageManager, cacheDependencyPath);
   core.debug(`primary key is ${primaryKey}`);
   core.saveState(STATE_CACHE_PRIMARY_KEY, primaryKey);
+  core.setOutput('cache-primary-key', primaryKey);
 
   // No "restoreKeys" is set, to start with a clear cache after dependency update (see https://github.com/actions/setup-java/issues/269)
   const matchedKey = await cache.restoreCache(packageManager.path, primaryKey);


### PR DESCRIPTION
## What

Backport of the `cache-primary-key` output to the **v5 release line**. Companion to the `main` PR #1088.

Closes #597 for the v5 line.

## Why

Exposes the primary cache key computed by the caching logic as a new `cache-primary-key` action output, so workflows can compose the built-in setup-java cache key with [`actions/cache`](https://github.com/actions/cache) / [`actions/cache/restore`](https://github.com/actions/cache/tree/main/restore) across steps and dependent jobs.

## Changes

- `src/cache.ts`: set the `cache-primary-key` output in `restore()`
- `action.yml`: declare the new `cache-primary-key` output
- `README.md`: document the new output
- `__tests__/cache.test.ts`: assert the output is set
- `dist/`: rebuild (CommonJS — the v5 line predates the ESM migration in #1078)

## Notes

- Non-breaking, purely additive.
- Authored against the v5 CommonJS / jest-29 test style (this line intentionally does **not** include the ESM migration #1078).
- Empty when caching is not enabled.

## Testing

- `npm test` (cache suite: 32/32 passing)
- lint + format-check clean