### PR TITLE
docs: clarify V6 ESM migration is not a user-facing breaking change

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The `setup-java` action provides the following functionality for GitHub Actions 
 
 This action allows you to work with Java and Scala projects.
 
-## Breaking changes in V6
+## What's new in V6
 
-- **Migrated to ESM** to enable support for the latest `@actions/*` package versions.
+- **Migrated to ESM** to enable support for the latest `@actions/*` package versions. This is an internal implementation change only. No changes are required to your workflow configuration, and the action's behavior is unchanged. Existing builds continue to work as before.
 
 ## Breaking changes in V5
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This action allows you to work with Java and Scala projects.
 
 ## What's new in V6
 
-- **Migrated to ESM** to enable support for the latest `@actions/*` package versions. This is an internal implementation change only. No changes are required to your workflow configuration, and the action's behavior is unchanged. Existing builds continue to work as before.
+- **Migrated to ESM** to enable support for the latest `@actions/*` package versions. This is an internal implementation change only. No changes are required to your workflow configuration, and the action's behavior is unchanged. Existing workflows continue to work as before.
 
 ## Breaking changes in V5
 


### PR DESCRIPTION
**Description:**
The README previously labeled V6 under "Breaking changes," but the ESM migration is purely an internal implementation detail. It enables support for the latest `@actions/*` package versions without requiring any changes to user workflow configuration or altering the action's behavior. Existing builds continue to work exactly as before.

This change renames the section to "What's new in V6" and adds a clarifying note so users don't mistakenly believe they need to update their workflows.

**Related issue:**
N/A

**Check list:**
- [ ] Ran `npm run check` locally (format, lint, build, test) and all checks pass.
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.