### PR TITLE
Support multi-field Java versions like `18.0.1.1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ steps:
 The `java-version` input supports an exact version or a version range using [SemVer](https://semver.org/) notation. The values below are examples, not an exhaustive list:
 - major versions, such as: `8`, `11`, `16`, `17`, `21`, `25`
 - more specific versions: `8.0.282+8`, `8.0.232`, `11.0`, `11.0.4`, `17.0`
+- multi-field Java versions (JEP 322), such as: `11.0.9.1`, `18.0.1.1`
 - early access (EA) versions: `15-ea`, `15.0.0-ea`
 
 #### Supported distributions

--- a/__tests__/distributors/base-installer.test.ts
+++ b/__tests__/distributors/base-installer.test.ts
@@ -748,7 +748,11 @@ describe('normalizeVersion', () => {
     ['11.0', {version: '11.0', stable: true}],
     ['11.0.10', {version: '11.0.10', stable: true}],
     ['11-ea', {version: '11', stable: false}],
-    ['11.0.2-ea', {version: '11.0.2', stable: false}]
+    ['11.0.2-ea', {version: '11.0.2', stable: false}],
+    ['18.0.1.1', {version: '18.0.1+1', stable: true}],
+    ['11.0.9.1', {version: '11.0.9+1', stable: true}],
+    ['12.0.2.1.0', {version: '12.0.2+1.0', stable: true}],
+    ['18.0.1.1-ea', {version: '18.0.1+1', stable: false}]
   ])('normalizeVersion from %s to %s', (input, expected) => {
     expect(DummyJavaBase.prototype.normalizeVersion.call(null, input)).toEqual(
       expected

--- a/src/distributions/base-installer.ts
+++ b/src/distributions/base-installer.ts
@@ -4,7 +4,11 @@ import * as fs from 'fs';
 import semver from 'semver';
 import path from 'path';
 import * as httpm from '@actions/http-client';
-import {getToolcachePath, isVersionSatisfies} from '../util.js';
+import {
+  convertVersionToSemver,
+  getToolcachePath,
+  isVersionSatisfies
+} from '../util.js';
 import {
   JavaDownloadRelease,
   JavaInstallerOptions,
@@ -271,6 +275,15 @@ export abstract class JavaBase {
       // transform '11.0.3-ea.2' -> '11.0.3+2'
       version = version.replace('-ea.', '+');
       stable = false;
+    }
+
+    // Java uses a versioning scheme (JEP 322) that can contain more numeric
+    // fields than SemVer allows, e.g. '18.0.1.1' or '11.0.9.1'. Convert such
+    // exact versions to SemVer build notation ('18.0.1+1') so they are
+    // accepted. Ranges and versions that already carry build metadata are
+    // left untouched.
+    if (/^\d+(\.\d+){3,}$/.test(version)) {
+      version = convertVersionToSemver(version);
     }
 
     if (!semver.validRange(version)) {


### PR DESCRIPTION
**Description:**

Java's version scheme ([JEP 322](https://openjdk.org/jeps/322)) can contain more than the three numeric fields that SemVer allows, for example `18.0.1.1` or `11.0.9.1` (the re-released `11.0.9` urgent fix). Passing such a value to `java-version` failed with `The string '18.0.1.1' is not valid SemVer notation for a Java version`, even though the README examples imply these exact/specific versions are supported.

This change normalizes exact multi-field versions into SemVer build notation before validation, reusing the existing `convertVersionToSemver()` helper (already used when parsing remote version lists): `18.0.1.1` becomes `18.0.1+1`. The conversion is guarded by a strict regex (`/^\d+(\.\d+){3,}$/`) so version ranges, EA tags, and inputs that already carry `+build` metadata are left untouched. No downstream changes were needed: `isVersionSatisfies()` already compares build-metadata versions via `semver.compareBuild`, and the tool-cache path naming already maps `+` to `-`.

**Related issue:**
Fixes: #326

**Check list:**
- [x] Ran `npm run check` locally (format, lint, build, test) and all checks pass.
- [x] Mark if documentation changes are required. (README "Supported version syntax" updated to list multi-field versions.)
- [x] Mark if tests were added or updated to cover the changes. (Added `normalizeVersion` cases for `18.0.1.1`, `11.0.9.1`, `12.0.2.1.0`, and an EA variant.)