### PR TITLE
docs: document seeding the Maven cache for plugin dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,46 @@ steps:
   run: mvn -B package --file pom.xml
 ```
 
+##### Ensuring plugin dependencies are cached
+
+Maven resolves **plugin** dependencies lazily — only for the goals that actually
+run. This means the job that first creates the cache determines what gets saved:
+a run that only executes `mvn compile` never resolves plugins bound to later
+phases (for example `maven-shade-plugin` and its dependencies `plexus-archiver`,
+`commons-compress`, `aircompressor`, `xz`), so those artifacts are missing from
+the cache and get re-downloaded by every subsequent `test`/`verify`/`package`
+job. Because the action does not re-save the cache on a hit, once an incomplete
+cache exists it is never completed.
+
+To populate `~/.m2` as comprehensively as possible on the run that creates the
+cache, add a **seed** step that resolves project *and* plugin dependencies before
+your build:
+
+```yaml
+steps:
+- uses: actions/checkout@v6
+- uses: actions/setup-java@v5
+  with:
+    distribution: 'temurin'
+    java-version: '25'
+    cache: 'maven'
+- name: Seed the Maven cache (resolve project + plugin dependencies)
+  run: mvn -B dependency:go-offline dependency:resolve-plugins
+- name: Build with Maven
+  run: mvn -B verify --file pom.xml
+```
+
+> [!NOTE]
+> The seed only helps on the run that *creates* the cache for the current
+> `pom.xml` hash. On an existing repository whose cache is already incomplete,
+> later runs get a cache hit and the extra downloads are not saved — invalidate
+> the cache once (for example by changing `cache-dependency-path` or clearing the
+> repository's caches) so a complete cache is created. Static resolution is also
+> not exhaustive (profile-gated plugins, conditionally-active modules, and
+> artifacts a plugin fetches at execution time can still be missed). See
+> [Ensuring the Maven cache is complete](docs/advanced-usage.md#ensuring-the-maven-cache-is-complete-plugin-dependencies)
+> in the Advanced usage guide for a fuller explanation and examples.
+
 #### Caching sbt dependencies
 ```yaml
 steps:

--- a/README.md
+++ b/README.md
@@ -189,45 +189,12 @@ steps:
   run: mvn -B package --file pom.xml
 ```
 
-##### Ensuring plugin dependencies are cached
-
-Maven resolves **plugin** dependencies lazily — only for the goals that actually
-run. This means the job that first creates the cache determines what gets saved:
-a run that only executes `mvn compile` never resolves plugins bound to later
-phases (for example `maven-shade-plugin` and its dependencies `plexus-archiver`,
-`commons-compress`, `aircompressor`, `xz`), so those artifacts are missing from
-the cache and get re-downloaded by every subsequent `test`/`verify`/`package`
-job. Because the action does not re-save the cache on a hit, once an incomplete
-cache exists it is never completed.
-
-To populate `~/.m2` as comprehensively as possible on the run that creates the
-cache, add a **seed** step that resolves project *and* plugin dependencies before
-your build:
-
-```yaml
-steps:
-- uses: actions/checkout@v6
-- uses: actions/setup-java@v5
-  with:
-    distribution: 'temurin'
-    java-version: '25'
-    cache: 'maven'
-- name: Seed the Maven cache (resolve project + plugin dependencies)
-  run: mvn -B dependency:go-offline dependency:resolve-plugins
-- name: Build with Maven
-  run: mvn -B verify --file pom.xml
-```
-
 > [!NOTE]
-> The seed only helps on the run that *creates* the cache for the current
-> `pom.xml` hash. On an existing repository whose cache is already incomplete,
-> later runs get a cache hit and the extra downloads are not saved — invalidate
-> the cache once (for example by changing `cache-dependency-path` or clearing the
-> repository's caches) so a complete cache is created. Static resolution is also
-> not exhaustive (profile-gated plugins, conditionally-active modules, and
-> artifacts a plugin fetches at execution time can still be missed). See
+> Maven resolves plugin dependencies lazily, so a cache created by a "thin" goal
+> (e.g. `mvn compile`) can be missing plugin dependencies that later
+> `test`/`verify`/`package` jobs then re-download on every run. See
 > [Ensuring the Maven cache is complete](docs/advanced-usage.md#ensuring-the-maven-cache-is-complete-plugin-dependencies)
-> in the Advanced usage guide for a fuller explanation and examples.
+> for how to seed a complete cache.
 
 #### Caching sbt dependencies
 ```yaml

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -334,8 +334,10 @@ steps:
 ```
 
 Separate seed job — useful for a matrix where different legs run different goals
-(`test`, `verify`, `-Pprofile1`, …) but all share the same `~/.m2` cache. The
-seed job creates a comprehensive cache that the other jobs then reuse:
+(`test`, `check`, `verify`, `-Pprofile1`, ...) but all share the same `~/.m2`
+cache. Without a seed, whichever job finishes first creates the cache from its
+own partial `.m2`, and parallel jobs race to save an equally partial cache; the
+seed job instead creates one comprehensive cache that every other job reuses:
 
 ```yaml
 jobs:

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -385,6 +385,16 @@ jobs:
 - **Multi-module projects:** run the seed at the reactor root so every module's
   plugins are resolved.
 
+> [!NOTE]
+> The same "the cache stores only what the creating run downloaded, and is not
+> re-saved on a hit" behavior applies to `cache: gradle`, since Gradle also
+> resolves dependencies and plugin/buildscript classpaths lazily. Gradle has no
+> direct equivalent of `dependency:go-offline`, so for complete and fine-grained
+> dependency caching on Gradle projects we recommend
+> [`gradle/actions/setup-gradle`](https://github.com/gradle/actions/tree/main/setup-gradle),
+> which provides purpose-built caching (see the
+> [setup-gradle documentation](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md)).
+
 ## Installing custom Java architecture
 
 ```yaml

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -15,6 +15,7 @@
   - [Tencent Kona](#Tencent-Kona)
 - [Installing custom Java package type](#Installing-custom-Java-package-type)
   - [JavaFX Maven project](#JavaFX-Maven-project)
+- [Ensuring the Maven cache is complete (plugin dependencies)](#ensuring-the-maven-cache-is-complete-plugin-dependencies)
 - [Installing custom Java architecture](#Installing-custom-Java-architecture)
 - [Installing JDK without setting as default](#Installing-JDK-without-setting-as-default)
 - [Installing custom Java distribution from local file](#Installing-Java-from-local-file)
@@ -284,6 +285,105 @@ To run the JavaFX application in CI:
 - name: Run with Maven
   run: mvn --no-transfer-progress javafx:run
 ```
+
+## Ensuring the Maven cache is complete (plugin dependencies)
+
+When you enable `cache: maven`, the action caches your local Maven repository
+(`~/.m2/repository`) keyed on a hash of your `pom.xml` files, and — at the end of
+the job — saves whatever was downloaded during that run. It does **not** re-save
+the cache when the key already matches (a cache *hit*).
+
+Maven resolves **plugin** dependencies lazily: it only downloads the plugins and
+plugin dependencies required by the goals that actually execute. As a result, the
+run that first creates the cache determines what is stored. If that run executed a
+"thin" goal such as `mvn compile`, plugins bound to later phases are never
+resolved. For example, `maven-shade-plugin` (bound to `package`) pulls in
+`plexus-archiver`, `commons-compress`, `io.airlift:aircompressor` and
+`org.tukaani:xz` — none of which a `compile` run downloads. Those artifacts are
+therefore absent from the cache, and because the action does not re-save on a
+hit, every later `test`/`verify`/`package` job re-downloads them on every run.
+
+### Seed the cache with a resolution step
+
+To populate `~/.m2` as comprehensively as possible on the run that creates the
+cache, run a dependency-resolution "seed" command before your build. Choose a
+command based on how thorough you need it to be:
+
+| Seed command | Resolves plugin dependencies? | Notes |
+|--------------|:-----------------------------:|-------|
+| `mvn dependency:resolve` | No | Resolves project dependencies only — misses plugin dependencies (e.g. `aircompressor`). |
+| `mvn dependency:resolve-plugins` | Yes | Resolves plugins **and their dependencies**. |
+| `mvn dependency:go-offline` | Yes | Resolves project and plugin dependencies (a superset). |
+| `mvn dependency:go-offline dependency:resolve-plugins` | Yes (most thorough) | Recommended default. Use `dependency:resolve dependency:resolve-plugins` if `go-offline` is flaky or insufficient for your project. |
+
+Single job — seed, then build (the cache saved at the end of this run contains
+the full set):
+
+```yaml
+steps:
+- uses: actions/checkout@v6
+- uses: actions/setup-java@v5
+  with:
+    distribution: 'temurin'
+    java-version: '25'
+    cache: 'maven'
+- name: Seed the Maven cache
+  run: mvn -B dependency:go-offline dependency:resolve-plugins
+- name: Build with Maven
+  run: mvn -B verify --file pom.xml
+```
+
+Separate seed job — useful for a matrix where different legs run different goals
+(`test`, `verify`, `-Pprofile1`, …) but all share the same `~/.m2` cache. The
+seed job creates a comprehensive cache that the other jobs then reuse:
+
+```yaml
+jobs:
+  seed-cache:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-java@v5
+      with:
+        distribution: 'temurin'
+        java-version: '25'
+        cache: 'maven'
+    - name: Seed the Maven cache
+      run: mvn -B dependency:go-offline dependency:resolve-plugins
+
+  build:
+    needs: seed-cache
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goal: ['test', 'verify', 'test -Pprofile1']
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-java@v5
+      with:
+        distribution: 'temurin'
+        java-version: '25'
+        cache: 'maven'
+    - name: Build
+      run: mvn -B ${{ matrix.goal }} --file pom.xml
+```
+
+### Caveats
+
+- **The seed only helps on the run that creates the cache.** Once a cache exists
+  for the current `pom.xml` hash, later runs get a hit and any additional
+  downloads are not saved. On an existing repository whose cache is already
+  incomplete, invalidate it once (for example by changing `cache-dependency-path`
+  or deleting the repository's caches) so a complete cache is created from the
+  seed.
+- **Static resolution is not exhaustive.** `go-offline`/`resolve-plugins` resolve
+  the statically declared plugin set for the *active* profiles and modules.
+  Profile-gated plugins, conditionally-active modules, and artifacts a plugin
+  fetches at execution time may still be missed. For the most complete cache,
+  seed with the fullest goal set your CI actually uses (for example
+  `mvn -B verify` with every profile enabled).
+- **Multi-module projects:** run the seed at the reactor root so every module's
+  plugins are resolved.
 
 ## Installing custom Java architecture
 


### PR DESCRIPTION
**Description:**

With `cache: maven`, the action stores whatever a run downloads into `~/.m2` and does not re-save on a cache hit. Because Maven resolves plugin dependencies lazily (only for the goals that actually execute), a cache first created by a "thin" goal such as `mvn compile` never captures plugins bound to later phases. For example `maven-shade-plugin` and its dependencies (`plexus-archiver`, `commons-compress`, `aircompressor`, `xz`) are missing, so every later `test`/`verify`/`package` job re-downloads them on each run. The same effect hits parallel matrix jobs that each run a partial goal and race to save an incomplete cache (issue #705). This behavior was reproduced and confirmed on the current `main`.

This is a documentation-only change. It explains the behavior and shows how to seed a complete cache; it does not change the action's caching code.

- **README.md:** a short note under "Caching maven dependencies" that states the problem in a couple of lines and links to the advanced guide.
- **docs/advanced-usage.md:** a new "Ensuring the Maven cache is complete (plugin dependencies)" section with the root-cause explanation, a comparison of seed commands (`dependency:resolve` alone is insufficient; `dependency:resolve-plugins` / `dependency:go-offline` cover plugin deps), a single-job example, and a separate-seed-job (matrix) example that addresses the parallel multi-job race in #705, plus caveats.

The recommended seed is `mvn -B dependency:go-offline dependency:resolve-plugins`, verified to produce a superset that lets a subsequent build download nothing.

The section is honest about limits: the seed only helps on the run that creates the cache (an already-incomplete cache must be invalidated once), static resolution is not exhaustive (profile/module/execution-time gaps), and multi-module builds should seed at the reactor root. A closing note flags that `cache: gradle` has the same limitation and points Gradle users to `gradle/actions/setup-gradle` for complete dependency caching.

**Related issue:**
Fixes: #990
Addresses: #705

**Check list:**
- [ ] Ran `npm run check` locally (format, lint, build, test) and all checks pass. (N/A: docs-only; `npm run check` targets `.ts`/`.yml`, not Markdown.)
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes. (N/A: documentation-only change.)