### PR TITLE
docs: clarify Maven cache paths and key hash inputs

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -289,9 +289,14 @@ To run the JavaFX application in CI:
 ## Ensuring the Maven cache is complete (plugin dependencies)
 
 When you enable `cache: maven`, the action caches your local Maven repository
-(`~/.m2/repository`) keyed on a hash of your `pom.xml` files, and — at the end of
-the job — saves whatever was downloaded during that run. It does **not** re-save
-the cache when the key already matches (a cache *hit*).
+(`~/.m2/repository`) and downloaded Maven Wrapper distributions
+(`~/.m2/wrapper/dists`). The cache key is a hash of your Maven inputs — every
+`**/pom.xml`, plus `**/.mvn/wrapper/maven-wrapper.properties` and
+`**/.mvn/extensions.xml` — so changing any of those files (for example bumping
+the wrapper version or editing core extensions) produces a new key and
+invalidates the cache. At the end of the job the action saves whatever was
+downloaded during that run. It does **not** re-save the cache when the key
+already matches (a cache *hit*).
 
 Maven resolves **plugin** dependencies lazily: it only downloads the plugins and
 plugin dependencies required by the goals that actually execute. As a result, the


### PR DESCRIPTION
**Description:**
Follow-up to post-merge review feedback on #1094. The intro paragraph of the "Ensuring the Maven cache is complete" section described the `cache: maven` behavior too narrowly, which could leave readers unsure why changing wrapper/extensions files invalidates the cache or why wrapper downloads are cached too.

Updated the paragraph to match what the action actually does (verified against `src/cache.ts`):
- Caches both `~/.m2/repository` and the Maven Wrapper distributions in `~/.m2/wrapper/dists`.
- The cache key hashes all Maven inputs: `**/pom.xml`, `**/.mvn/wrapper/maven-wrapper.properties`, and `**/.mvn/extensions.xml`, so editing any of those (e.g. bumping the wrapper version or core extensions) produces a new key.

Docs-only change; no behavior changes.

**Related issue:**
Addresses review feedback: https://github.com/actions/setup-java/pull/1094#discussion_r3554460054

**Check list:**
- [ ] Ran `npm run check` locally (format, lint, build, test) and all checks pass.
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.