### PR TITLE
Cache Gradle wrapper distribution separately from the dependency cache

### DIFF
--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -316,6 +316,43 @@ describe('dependency cache', () => {
         expect(spyWarning).not.toHaveBeenCalled();
         expect(spyInfo).toHaveBeenCalledWith('gradle cache is not found');
       });
+      it('restores the gradle wrapper distribution cache independently of the main cache', async () => {
+        createFile(join(workspace, 'build.gradle'));
+
+        await restore('gradle', '');
+        // Main dependency cache no longer carries the wrapper path.
+        expect(spyCacheRestore).toHaveBeenCalledWith(
+          [join(os.homedir(), '.gradle', 'caches')],
+          expect.any(String)
+        );
+        // Wrapper distribution is restored on its own, keyed only on the
+        // wrapper properties file.
+        expect(spyCacheRestore).toHaveBeenCalledWith(
+          [join(os.homedir(), '.gradle', 'wrapper')],
+          expect.stringContaining('setup-java-')
+        );
+        expect(spyGlobHashFiles).toHaveBeenCalledWith(
+          '**/gradle-wrapper.properties'
+        );
+      });
+      it('skips the gradle wrapper cache when no wrapper properties exist', async () => {
+        createFile(join(workspace, 'build.gradle'));
+        spyGlobHashFiles.mockImplementation((pattern: string) =>
+          Promise.resolve(
+            pattern === '**/gradle-wrapper.properties' ? '' : 'hash-stub'
+          )
+        );
+
+        await restore('gradle', '');
+        // Only the main dependency cache is restored; the wrapper cache path is
+        // never touched because the project does not use the gradle wrapper.
+        expect(spyCacheRestore).toHaveBeenCalledTimes(1);
+        expect(spyCacheRestore).toHaveBeenCalledWith(
+          [join(os.homedir(), '.gradle', 'caches')],
+          expect.any(String)
+        );
+        expect(spyWarning).not.toHaveBeenCalled();
+      });
     });
     describe('for sbt', () => {
       it('throws error if no build.sbt found', async () => {
@@ -585,6 +622,50 @@ describe('dependency cache', () => {
         expect(spyWarning).not.toHaveBeenCalled();
         expect(spyInfo).toHaveBeenCalledWith(
           expect.stringMatching(/^Cache saved with the key:.*/)
+        );
+      });
+      it('saves the gradle wrapper distribution cache under its own key', async () => {
+        createFile(join(workspace, 'build.gradle'));
+        (core.getState as jest.Mock<any>).mockImplementation((name: any) => {
+          switch (name) {
+            case 'cache-primary-key':
+              return 'setup-java-cache-primary-key';
+            case 'cache-matched-key':
+              return 'setup-java-cache-matched-key';
+            case 'cache-primary-key-gradle-wrapper':
+              return 'setup-java-gradle-wrapper-key';
+            default:
+              return '';
+          }
+        });
+
+        await save('gradle');
+        expect(spyCacheSave).toHaveBeenCalledWith(
+          [join(os.homedir(), '.gradle', 'wrapper')],
+          'setup-java-gradle-wrapper-key'
+        );
+        expect(spyWarning).not.toHaveBeenCalled();
+      });
+      it('does not save the gradle wrapper cache on an exact wrapper hit', async () => {
+        createFile(join(workspace, 'build.gradle'));
+        (core.getState as jest.Mock<any>).mockImplementation((name: any) => {
+          switch (name) {
+            case 'cache-primary-key':
+              return 'setup-java-cache-primary-key';
+            case 'cache-matched-key':
+              return 'setup-java-cache-matched-key';
+            case 'cache-primary-key-gradle-wrapper':
+            case 'cache-matched-key-gradle-wrapper':
+              return 'setup-java-gradle-wrapper-key';
+            default:
+              return '';
+          }
+        });
+
+        await save('gradle');
+        expect(spyCacheSave).not.toHaveBeenCalledWith(
+          [join(os.homedir(), '.gradle', 'wrapper')],
+          expect.any(String)
         );
       });
     });

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -99687,10 +99687,7 @@ const supportedPackageManager = [
     },
     {
         id: 'gradle',
-        path: [
-            (0,external_path_.join)(external_os_default().homedir(), '.gradle', 'caches'),
-            (0,external_path_.join)(external_os_default().homedir(), '.gradle', 'wrapper')
-        ],
+        path: [(0,external_path_.join)(external_os_default().homedir(), '.gradle', 'caches')],
         // https://github.com/actions/cache/blob/0638051e9af2c23d10bb70fa9beffcad6cff9ce3/examples.md#java---gradle
         pattern: [
             '**/*.gradle*',
@@ -99699,6 +99696,17 @@ const supportedPackageManager = [
             'buildSrc/**/Dependencies.kt',
             'gradle/*.versions.toml',
             '**/versions.properties'
+        ],
+        // The Gradle wrapper distribution only depends on the wrapper properties,
+        // which change very rarely, so it is cached separately from the Gradle
+        // caches. This keeps it available across the frequent *.gradle* changes
+        // that rotate the main cache key. See issue #1095.
+        additionalCaches: [
+            {
+                name: 'gradle-wrapper',
+                path: [(0,external_path_.join)(external_os_default().homedir(), '.gradle', 'wrapper')],
+                pattern: ['**/gradle-wrapper.properties']
+            }
         ]
     },
     {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -72,10 +72,7 @@ const supportedPackageManager: PackageManager[] = [
   },
   {
     id: 'gradle',
-    path: [
-      join(os.homedir(), '.gradle', 'caches'),
-      join(os.homedir(), '.gradle', 'wrapper')
-    ],
+    path: [join(os.homedir(), '.gradle', 'caches')],
     // https://github.com/actions/cache/blob/0638051e9af2c23d10bb70fa9beffcad6cff9ce3/examples.md#java---gradle
     pattern: [
       '**/*.gradle*',
@@ -84,6 +81,17 @@ const supportedPackageManager: PackageManager[] = [
       'buildSrc/**/Dependencies.kt',
       'gradle/*.versions.toml',
       '**/versions.properties'
+    ],
+    // The Gradle wrapper distribution only depends on the wrapper properties,
+    // which change very rarely, so it is cached separately from the Gradle
+    // caches. This keeps it available across the frequent *.gradle* changes
+    // that rotate the main cache key. See issue #1095.
+    additionalCaches: [
+      {
+        name: 'gradle-wrapper',
+        path: [join(os.homedir(), '.gradle', 'wrapper')],
+        pattern: ['**/gradle-wrapper.properties']
+      }
     ]
   },
   {


### PR DESCRIPTION
**Description:**
The Gradle wrapper distribution (`~/.gradle/wrapper`) is downloaded by `gradlew` and depends only on `gradle/wrapper/gradle-wrapper.properties`, which changes very rarely. However, it was previously stored in the **same cache entry** as the Gradle dependency caches (`~/.gradle/caches`), whose key is computed from volatile files such as `**/*.gradle*`. Because there are intentionally no `restoreKeys` (see #269), almost every dependency change is a full cache miss, so the rarely-changing wrapper distribution was re-downloaded on every build.

This is the same root cause fixed for the Maven wrapper in #1097. This PR applies the identical treatment to Gradle:

- Move `~/.gradle/wrapper` out of the main Gradle cache `path` (leaving `~/.gradle/caches`).
- Add a dedicated `gradle-wrapper` **additional cache** keyed only on `**/gradle-wrapper.properties`.

This keeps the wrapper distribution cached across the frequent `**/*.gradle*` changes that rotate the main cache key. The main Gradle cache key computation is unchanged (its pattern still lists `**/gradle-wrapper.properties`, among others).

This is a **stacked follow-up to #1097** and depends on the generic `additionalCaches` infrastructure introduced there (`AdditionalCache` interface, `computeAdditionalCacheKey`, `restoreAdditionalCache`, `saveAdditionalCache`, and name-scoped restore→save state keys). It reuses that infrastructure without modifying Maven or sbt.

**Related issue:**
Related context: #1095 (the closing `Fixes #1095` reference belongs to #1097).

**Check list:**
- [x] Ran `npm run check` locally (format, lint, build, test) and all checks pass.
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.
