### PR TITLE
feat: Add input option add-toolchain-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For more details,  see the full release notes on the [releases page](https://git
 
   - `check-latest`: Setting this option makes the action to check for the latest available version for the version spec.
 
-  - `set-default`: Set to `false` to install a JDK without making it the default. When `false`, `JAVA_HOME` and `PATH` are not updated, but `JAVA_HOME_<major>_<arch>` is still set so the JDK remains discoverable. Default value: `true`. See [Installing JDK without setting as default](docs/advanced-usage.md#Installing-JDK-without-setting-as-default) for more details.
+  - `set-default`: Set to `false` to install a JDK without making it the default. When `false`, `JAVA_HOME` and `PATH` are not updated, but `JAVA_HOME_<major>_<arch>` is still set so the JDK remains discoverable. Default value: `!add-toolchain-only`. If explcitly set `true`, it will update JAVA_HOME and PATH regardless of `add-toolchain-only`. See [Installing JDK without setting as default](docs/advanced-usage.md#Installing-JDK-without-setting-as-default) for more details.
 
   - `verify-signature`: Verifies downloaded Java package signatures when supported by the selected distribution. Currently supported for `temurin` and `microsoft`. If set to `true` for unsupported distributions, the action fails.
 
@@ -58,7 +58,9 @@ For more details,  see the full release notes on the [releases page](https://git
   #### Maven options
   The action has a bunch of inputs to generate maven's [settings.xml](https://maven.apache.org/settings.html) on the fly and pass the values to Apache Maven GPG Plugin as well as Apache Maven Toolchains. See [advanced usage](docs/advanced-usage.md) for more.
 
-  - `overwrite-settings`: By default action overwrites the settings.xml. In order to skip generation of file if it exists, set this to `false`.
+  - `overwrite-settings`: Overwrite the settings.xml file if it exists. Default is `!add-toolchain-only`. If explcitly set `true`, it will update settings.xml regardless of `add-toolchain-only`.
+
+  - `add-toolchain-only`: Update toolchains.xml only. Default is `false`. No update of settings.xml, no update of JAVA_HOME and PATH unless `overwrite-settings` or `set-default` are explicitly set `true`.
 
   - `server-id`: ID of the distributionManagement repository in the pom.xml file. Default is `github`.
 

--- a/__tests__/toolchains.test.ts
+++ b/__tests__/toolchains.test.ts
@@ -87,7 +87,7 @@ describe('toolchains tests', () => {
     await toolchains.createToolchainsSettings({
       jdkInfo,
       settingsDirectory: altHome,
-      overwriteSettings: true
+      addToolchain: true
     });
 
     expect(fs.existsSync(m2Dir)).toBe(false);
@@ -136,7 +136,7 @@ describe('toolchains tests', () => {
     await toolchains.createToolchainsSettings({
       jdkInfo,
       settingsDirectory: m2Dir,
-      overwriteSettings: true
+      addToolchain: true
     });
 
     expect(fs.existsSync(m2Dir)).toBe(true);
@@ -218,7 +218,7 @@ describe('toolchains tests', () => {
     await toolchains.createToolchainsSettings({
       jdkInfo,
       settingsDirectory: m2Dir,
-      overwriteSettings: true
+      addToolchain: true
     });
 
     expect(fs.existsSync(m2Dir)).toBe(true);
@@ -304,7 +304,7 @@ describe('toolchains tests', () => {
     await toolchains.createToolchainsSettings({
       jdkInfo,
       settingsDirectory: m2Dir,
-      overwriteSettings: true
+      addToolchain: true
     });
 
     expect(fs.existsSync(m2Dir)).toBe(true);
@@ -382,7 +382,7 @@ describe('toolchains tests', () => {
     await toolchains.createToolchainsSettings({
       jdkInfo,
       settingsDirectory: m2Dir,
-      overwriteSettings: true
+      addToolchain: true
     });
 
     expect(fs.existsSync(m2Dir)).toBe(true);
@@ -453,7 +453,7 @@ describe('toolchains tests', () => {
     await toolchains.createToolchainsSettings({
       jdkInfo,
       settingsDirectory: m2Dir,
-      overwriteSettings: true
+      addToolchain: true
     });
 
     expect(fs.existsSync(m2Dir)).toBe(true);
@@ -546,7 +546,7 @@ describe('toolchains tests', () => {
     await toolchains.createToolchainsSettings({
       jdkInfo,
       settingsDirectory: m2Dir,
-      overwriteSettings: true
+      addToolchain: true
     });
 
     expect(fs.existsSync(m2Dir)).toBe(true);
@@ -606,7 +606,7 @@ describe('toolchains tests', () => {
     await toolchains.createToolchainsSettings({
       jdkInfo,
       settingsDirectory: m2Dir,
-      overwriteSettings: true
+      addToolchain: true
     });
 
     expect(fs.existsSync(m2Dir)).toBe(true);
@@ -665,7 +665,7 @@ describe('toolchains tests', () => {
     await toolchains.createToolchainsSettings({
       jdkInfo,
       settingsDirectory: m2Dir,
-      overwriteSettings: true
+      addToolchain: true
     });
 
     expect(fs.existsSync(m2Dir)).toBe(true);
@@ -749,7 +749,7 @@ describe('toolchains tests', () => {
     await toolchains.createToolchainsSettings({
       jdkInfo,
       settingsDirectory: m2Dir,
-      overwriteSettings: true
+      addToolchain: true
     });
 
     expect(fs.existsSync(m2Dir)).toBe(true);
@@ -829,7 +829,7 @@ describe('toolchains tests', () => {
     await toolchains.createToolchainsSettings({
       jdkInfo,
       settingsDirectory: m2Dir,
-      overwriteSettings: true
+      addToolchain: true
     });
 
     expect(fs.existsSync(m2Dir)).toBe(true);
@@ -884,7 +884,7 @@ describe('toolchains tests', () => {
     await toolchains.createToolchainsSettings({
       jdkInfo,
       settingsDirectory: m2Dir,
-      overwriteSettings: false
+      addToolchain: false
     });
 
     expect(fs.existsSync(m2Dir)).toBe(true);
@@ -944,6 +944,7 @@ describe('toolchains tests', () => {
       version,
       distributionName,
       jdkHome,
+      true,
       undefined
     );
 

--- a/action.yml
+++ b/action.yml
@@ -31,9 +31,9 @@ inputs:
     required: false
     default: false
   set-default:
-    description: 'Set this option to false if you want to install a JDK but not make it the default. When false, JAVA_HOME and PATH are not updated, but JAVA_HOME_<major>_<arch> is still set.'
+    description: 'Set this option to false if you want to install a JDK but not make it the default. When false, JAVA_HOME and PATH are not updated, but JAVA_HOME_<major>_<arch> is still set. Default is "!add-toolchain-only". If explcitly set "true", it will update JAVA_HOME and PATH regardless of "add-toolchain-only".'
     required: false
-    default: true
+    # DO NOT set a default here! If not explicitly set, the default will be propagated from input 'add-toolchain-only'!
   verify-signature:
     description: 'Verify downloaded Java package signatures when supported by the selected distribution'
     required: false
@@ -60,9 +60,13 @@ inputs:
     description: 'Path to where the settings.xml file will be written. Default is ~/.m2.'
     required: false
   overwrite-settings:
-    description: 'Overwrite the settings.xml file if it exists. Default is "true".'
+    description: 'Overwrite the settings.xml file if it exists. Default is "!add-toolchain-only". If explcitly set "true", it will update settings.xml regardless of "add-toolchain-only".'
     required: false
-    default: true
+    # DO NOT set a default here! If not explicitly set, the default will be propagated from input 'add-toolchain-only'!
+  add-toolchain-only:
+    description: 'Update toolchains.xml only. Default is "false". No update of settings.xml, no update of JAVA_HOME and PATH unless "overwrite-settings" or "set-default" are explicitly set "true".'
+    required: false
+    default: false
   gpg-private-key:
     description: 'GPG private key to import. Default is empty string.'
     required: false

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -95845,6 +95845,7 @@ const INPUT_SERVER_USERNAME = 'server-username';
 const INPUT_SERVER_PASSWORD = 'server-password';
 const INPUT_SETTINGS_PATH = 'settings-path';
 const INPUT_OVERWRITE_SETTINGS = 'overwrite-settings';
+const INPUT_ADD_TOOLCHAIN_ONLY = 'add-toolchain-only';
 const INPUT_GPG_PRIVATE_KEY = 'gpg-private-key';
 const INPUT_GPG_PASSPHRASE = 'gpg-passphrase';
 const INPUT_DEFAULT_GPG_PRIVATE_KEY = (/* unused pure expression or super */ null && (undefined));

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -832,6 +832,64 @@ The result is a Toolchain with entries for JDKs 8, 11 and 15. You can even combi
 
 This will generate a Toolchains entry with the following values: `version: 1.6`, `vendor: jdkfile`, `id: Oracle_1.6`.
 
+### Installing Multiple JDKs With Updating Toolchains Only
+When installing multiple JDKs in the same workflow run, the `add-toolchain-only` input lets you add the new JDK to Maven's `toolchains.xml` without changing the active environment (JAVA_HOME, PATH) or updating Maven `settings.xml` — unless you explicitly request those changes.
+
+Important defaults introduced with `add-toolchain-only`:
+- If `add-toolchain-only: true` then, unless explicitly overridden:
+  - `set-default` defaults to `false` (the newly installed JDK will not become the process default).
+  - `overwrite-settings` defaults to `false` (Maven `settings.xml` will not be modified by default).
+- You can still explicitly set `set-default: true` or `overwrite-settings: true` to override these defaults.
+
+Simple workflow example
+```yaml
+steps:
+  # First install: make JDK 11 the default for the job
+  - name: Setup JDK 11 (default)
+    uses: actions/setup-java@v3
+    with:
+      distribution: 'temurin'
+      java-version: '11'
+      set-default: true          # JAVA_HOME and PATH will point to this JDK
+
+  # Second install: register JDK 17 in Maven toolchains only
+  - name: Add JDK 17 to Maven toolchains only
+    uses: actions/setup-java@v3
+    with:
+      distribution: 'temurin'
+      java-version: '17'
+      add-toolchain-only: true   # Only add to ~/.m2/toolchains.xml
+      # set-default: false       # implied default when add-toolchain-only: true
+      # overwrite-settings: false# implied default when add-toolchain-only: true
+```
+
+Expected behavior from the example above
+- After the first step:
+  - JAVA_HOME and PATH are updated to point to JDK 11 (because `set-default: true`).
+  - Maven configuration may be updated according to your global defaults / previous options.
+- After the second step:
+  - The JDK 17 entry is added to `~/.m2/toolchains.xml` so Maven toolchain-aware builds can select it.
+  - JAVA_HOME and PATH remain pointing at JDK 11 (no change), because `add-toolchain-only: true` keeps the environment untouched by default.
+  - `~/.m2/settings.xml` is not modified unless you explicitly set `overwrite-settings: true`.
+
+Quick checks you can run in a job to validate
+```bash
+# Check which JAVA_HOME is active
+echo "JAVA_HOME=$JAVA_HOME"
+java -version
+
+# Verify Maven toolchains file contains entries for both JDKs
+cat ~/.m2/toolchains.xml || true
+
+# If you expected settings.xml to be changed:
+cat ~/.m2/settings.xml || true
+```
+
+**Notes and tips**
+- If you want an added JDK to become the runtime default for subsequent steps, set `set-default: true` on that particular `setup-java` invocation (even when `add-toolchain-only` is used).
+- If you rely on a modified `settings.xml` (for example to add servers or mirrors), explicitly set `overwrite-settings: true` on the run that should update it.
+- The `add-toolchain-only` mode is helpful when provisioning multiple JDKs for multi-JDK testing while leaving the job's primary Java environment stable.
+
 ### Modifying The Toolchain Vendor For JDKs
 Each JDK provider will receive a default `vendor` using the `distribution` input value but this can be overridden with the `mvn-toolchain-vendor` parameter as follows.
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -8,19 +8,14 @@ import * as os from 'os';
 import {create as xmlCreate} from 'xmlbuilder2';
 import * as constants from './constants.js';
 import * as gpg from './gpg.js';
-import {getBooleanInput} from './util.js';
 
-export async function configureAuthentication() {
+export async function configureAuthentication(overwriteSettings: boolean) {
   const id = core.getInput(constants.INPUT_SERVER_ID);
   const username = core.getInput(constants.INPUT_SERVER_USERNAME);
   const password = core.getInput(constants.INPUT_SERVER_PASSWORD);
   const settingsDirectory =
     core.getInput(constants.INPUT_SETTINGS_PATH) ||
     path.join(os.homedir(), constants.M2_DIR);
-  const overwriteSettings = getBooleanInput(
-    constants.INPUT_OVERWRITE_SETTINGS,
-    true
-  );
   const gpgPrivateKey =
     core.getInput(constants.INPUT_GPG_PRIVATE_KEY) ||
     constants.INPUT_DEFAULT_GPG_PRIVATE_KEY;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,7 @@ export const INPUT_SERVER_USERNAME = 'server-username';
 export const INPUT_SERVER_PASSWORD = 'server-password';
 export const INPUT_SETTINGS_PATH = 'settings-path';
 export const INPUT_OVERWRITE_SETTINGS = 'overwrite-settings';
+export const INPUT_ADD_TOOLCHAIN_ONLY = 'add-toolchain-only';
 export const INPUT_GPG_PRIVATE_KEY = 'gpg-private-key';
 export const INPUT_GPG_PASSPHRASE = 'gpg-passphrase';
 

--- a/src/setup-java.ts
+++ b/src/setup-java.ts
@@ -15,6 +15,20 @@ import {getJavaDistribution} from './distributions/distribution-factory.js';
 import {JavaInstallerOptions} from './distributions/base-models.js';
 import {configureMavenArgs} from './maven-args.js';
 
+interface IInstallerInputsOptions {
+  architecture: string;
+  packageType: string;
+  checkLatest: boolean;
+  setDefault: boolean;
+  overwriteSettings: boolean;
+  addToolchainOnly: boolean;
+  verifySignature: boolean;
+  verifySignaturePublicKey: string | undefined;
+  distributionName: string;
+  jdkFile: string;
+  toolchainIds: Array<string>;
+}
+
 async function run() {
   try {
     const versions = core.getMultilineInput(constants.INPUT_JAVA_VERSION);
@@ -28,7 +42,18 @@ async function run() {
       constants.INPUT_CACHE_DEPENDENCY_PATH
     );
     const checkLatest = getBooleanInput(constants.INPUT_CHECK_LATEST, false);
-    const setDefault = getBooleanInput(constants.INPUT_SET_DEFAULT, true);
+    const addToolchainOnly = getBooleanInput(
+      constants.INPUT_ADD_TOOLCHAIN_ONLY,
+      false
+    );
+    const setDefault = getBooleanInput(
+      constants.INPUT_SET_DEFAULT,
+      !addToolchainOnly
+    );
+    const overwriteSettings = getBooleanInput(
+      constants.INPUT_OVERWRITE_SETTINGS,
+      !addToolchainOnly
+    );
     const verifySignature = getBooleanInput(
       constants.INPUT_VERIFY_SIGNATURE,
       false
@@ -78,16 +103,18 @@ async function run() {
         );
       }
 
-      const installerInputsOptions: installerInputsOptions = {
-        architecture,
-        packageType,
-        checkLatest,
-        setDefault,
-        verifySignature,
-        verifySignaturePublicKey,
-        distributionName,
-        jdkFile,
-        toolchainIds
+      const installerInputsOptions: IInstallerInputsOptions = {
+        architecture: architecture,
+        packageType: packageType,
+        checkLatest: checkLatest,
+        setDefault: setDefault,
+        overwriteSettings: overwriteSettings,
+        addToolchainOnly: addToolchainOnly,
+        verifySignature: verifySignature,
+        verifySignaturePublicKey: verifySignaturePublicKey,
+        distributionName: distributionName,
+        jdkFile: jdkFile,
+        toolchainIds: toolchainIds
       };
 
       await installVersion(versionInfo.version, installerInputsOptions);
@@ -97,16 +124,18 @@ async function run() {
         throw new Error('distribution input is required');
       }
 
-      const installerInputsOptions: installerInputsOptions = {
-        architecture,
-        packageType,
-        checkLatest,
-        setDefault,
-        verifySignature,
-        verifySignaturePublicKey,
-        distributionName,
-        jdkFile,
-        toolchainIds
+      const installerInputsOptions: IInstallerInputsOptions = {
+        architecture: architecture,
+        packageType: packageType,
+        checkLatest: checkLatest,
+        setDefault: setDefault,
+        overwriteSettings: overwriteSettings,
+        addToolchainOnly: addToolchainOnly,
+        verifySignature: verifySignature,
+        verifySignaturePublicKey: verifySignaturePublicKey,
+        distributionName: distributionName,
+        jdkFile: jdkFile,
+        toolchainIds: toolchainIds
       };
 
       for (const [index, version] of versions.entries()) {
@@ -122,7 +151,7 @@ async function run() {
     );
     core.info(`##[add-matcher]${path.join(matchersPath, 'java.json')}`);
 
-    await auth.configureAuthentication();
+    await auth.configureAuthentication(overwriteSettings);
     configureMavenArgs();
     if (cache && isCacheFeatureAvailable()) {
       await restore(cache, cacheDependencyPath);
@@ -149,39 +178,27 @@ function getJdkFileInput(): string {
 
 async function installVersion(
   version: string,
-  options: installerInputsOptions,
+  options: IInstallerInputsOptions,
   toolchainId = 0
 ) {
-  const {
-    distributionName,
-    jdkFile,
-    architecture,
-    packageType,
-    checkLatest,
-    setDefault,
-    verifySignature,
-    verifySignaturePublicKey,
-    toolchainIds
-  } = options;
-
   const installerOptions: JavaInstallerOptions = {
-    architecture,
-    packageType,
-    checkLatest,
-    setDefault,
-    verifySignature,
-    verifySignaturePublicKey,
+    architecture: options.architecture,
+    packageType: options.packageType,
+    checkLatest: options.checkLatest,
+    setDefault: options.setDefault,
+    verifySignature: options.verifySignature,
+    verifySignaturePublicKey: options.verifySignaturePublicKey,
     version
   };
 
   const distribution = getJavaDistribution(
-    distributionName,
+    options.distributionName,
     installerOptions,
-    jdkFile
+    options.jdkFile
   );
   if (!distribution) {
     throw new Error(
-      `No supported distribution was found for input ${distributionName}`
+      `No supported distribution was found for input ${options.distributionName}`
     );
   }
 
@@ -194,27 +211,16 @@ async function installVersion(
 
   await toolchains.configureToolchains(
     toolchainVersion,
-    distributionName,
+    options.distributionName,
     result.path,
-    toolchainIds[toolchainId]
+    options.overwriteSettings || options.addToolchainOnly,
+    options.toolchainIds[toolchainId]
   );
 
   core.info('');
   core.info('Java configuration:');
-  core.info(`  Distribution: ${distributionName}`);
+  core.info(`  Distribution: ${options.distributionName}`);
   core.info(`  Version: ${result.version}`);
   core.info(`  Path: ${result.path}`);
   core.info('');
-}
-
-interface installerInputsOptions {
-  architecture: string;
-  packageType: string;
-  checkLatest: boolean;
-  setDefault: boolean;
-  verifySignature: boolean;
-  verifySignaturePublicKey: string | undefined;
-  distributionName: string;
-  jdkFile: string;
-  toolchainIds: Array<string>;
 }

--- a/src/toolchains.ts
+++ b/src/toolchains.ts
@@ -5,7 +5,6 @@ import * as core from '@actions/core';
 import * as io from '@actions/io';
 import * as constants from './constants.js';
 
-import {getBooleanInput} from './util.js';
 import {create as xmlCreate} from 'xmlbuilder2';
 
 interface JdkInfo {
@@ -19,6 +18,7 @@ export async function configureToolchains(
   version: string,
   distributionName: string,
   jdkHome: string,
+  addToolchain: boolean,
   toolchainId?: string
 ) {
   const vendor =
@@ -27,10 +27,6 @@ export async function configureToolchains(
   const settingsDirectory =
     core.getInput(constants.INPUT_SETTINGS_PATH) ||
     path.join(os.homedir(), constants.M2_DIR);
-  const overwriteSettings = getBooleanInput(
-    constants.INPUT_OVERWRITE_SETTINGS,
-    true
-  );
 
   await createToolchainsSettings({
     jdkInfo: {
@@ -40,18 +36,18 @@ export async function configureToolchains(
       jdkHome
     },
     settingsDirectory,
-    overwriteSettings
+    addToolchain
   });
 }
 
 export async function createToolchainsSettings({
   jdkInfo,
   settingsDirectory,
-  overwriteSettings
+  addToolchain
 }: {
   jdkInfo: JdkInfo;
   settingsDirectory: string;
-  overwriteSettings: boolean;
+  addToolchain: boolean;
 }) {
   core.info(
     `Creating ${constants.MVN_TOOLCHAINS_FILE} for JDK version ${jdkInfo.version} from ${jdkInfo.vendor}`
@@ -71,7 +67,7 @@ export async function createToolchainsSettings({
   await writeToolchainsFileToDisk(
     settingsDirectory,
     updatedToolchains,
-    overwriteSettings
+    addToolchain
   );
 }
 
@@ -175,11 +171,11 @@ async function readExistingToolchainsFile(directory: string) {
 async function writeToolchainsFileToDisk(
   directory: string,
   settings: string,
-  overwriteSettings: boolean
+  addToolchain: boolean
 ) {
   const location = path.join(directory, constants.MVN_TOOLCHAINS_FILE);
   const settingsExists = fs.existsSync(location);
-  if (settingsExists && overwriteSettings) {
+  if (settingsExists && addToolchain) {
     core.info(`Overwriting existing file ${location}`);
   } else if (!settingsExists) {
     core.info(`Writing to ${location}`);


### PR DESCRIPTION
**Description:**
In case of installing multiple Java versions, this option will add a subsequent installed JDK to the Maven toolchains.xml only without updating Maven settings.xml nor updating environment vars JAVA_HOME and PATH.

**Changes**
- Add input option `add-toolchain-only` - default: `false`
- Propagate default values for `set-default` and `overwrite-settings` from `add-toolchain-only`
- setup-java.ts:
  - couple of code improvements for less error prone interface instancing
  - single place for reading input of `overwrite-settings`
- toolchain.ts, auth.ts:
  - replace reading of input `overwrite-setting` by passing `overwriteSettings` and `addToolchain` as method parameters
- __tests__/toolchains.test.ts: followup previous changes
- documentation updated in `README.md` and `docs/advanced-usage.md`.


**Related issue:**
Closes #1047 - Followup Issue of #553

@brunoborges - many thanks for having created #1047.

**Check list:**
- [x] Ran `npm run check` locally (format, lint, build, test) and all checks pass.
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.