### PR TITLE
dist: Cover Tencent Kona JDK 25 (#1108) [v5 backport]

### DIFF
--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -55,6 +55,15 @@ jobs:
           - distribution: microsoft
             os: macos-latest
             version: 25
+          - distribution: kona
+            os: windows-latest
+            version: 25
+          - distribution: kona
+            os: ubuntu-latest
+            version: 25
+          - distribution: kona
+            os: macos-latest
+            version: 25
           - distribution: oracle
             os: macos-15-intel
             version: 17

--- a/__tests__/data/kona.json
+++ b/__tests__/data/kona.json
@@ -158,5 +158,45 @@
         }
       ]
     }
+  ],
+  "25": [
+    {
+      "version": "25.0.3",
+      "jdkVersion": "25.0.3",
+      "latest": true,
+      "baseUrl": "https://github.com/Tencent/TencentKona-25/releases/download/TencentKona-25.0.3/",
+      "files": [
+        {
+          "os": "linux",
+          "arch": "aarch64",
+          "filename": "TencentKona-25.0.3.b1-jdk_linux-aarch64.tar.gz",
+          "checksum": "2fb77e3ba9c00045ca497ea22210f18dae4bf7df4c87029f5abadd42a5daf8c7"
+        },
+        {
+          "os": "linux",
+          "arch": "x86_64",
+          "filename": "TencentKona-25.0.3.b1-jdk_linux-x86_64.tar.gz",
+          "checksum": "47445e6fad020e834055a705bb48fa3cd0727a2c57ad6f1c5206a45f4efb2d67"
+        },
+        {
+          "os": "macos",
+          "arch": "aarch64",
+          "filename": "TencentKona-25.0.3.b1_jdk_macosx-aarch64_notarized.tar.gz",
+          "checksum": "e29405eff95da412ed7ecc890e6ef5ebbfcd9ab334005b3d32d1700bbe4204d2"
+        },
+        {
+          "os": "macos",
+          "arch": "x86_64",
+          "filename": "TencentKona-25.0.3.b1_jdk_macosx-x86_64_notarized.tar.gz",
+          "checksum": "d512db5c079db16bd3a9c86d9cb979808994e90e4de29e17d27e5219fe488659"
+        },
+        {
+          "os": "windows",
+          "arch": "x86_64",
+          "filename": "TencentKona-25.0.3.b1_jdk_windows-x86_64_signed.zip",
+          "checksum": "865bce92ccbbca75115076e618a98baa1d0f30fcccdce954c0a22bee33d6ae83"
+        }
+      ]
+    }
   ]
 }

--- a/__tests__/distributors/kona-installer.test.ts
+++ b/__tests__/distributors/kona-installer.test.ts
@@ -28,7 +28,9 @@ describe('Check getAvailableReleases', () => {
     ['11', 'linux', 'x86_64', 'linux-x86_64'],
     ['11.0.25', 'macos', 'aarch64', 'macosx-aarch64'],
     ['17.0.13', 'windows', 'x86_64', 'windows-x86_64'],
-    ['21.0.5', 'linux', 'x86_64', 'linux-x86_64']
+    ['21.0.5', 'linux', 'x86_64', 'linux-x86_64'],
+    ['25', 'linux', 'aarch64', 'linux-aarch64'],
+    ['25.0.3', 'macos', 'x86_64', 'macosx-x86_64']
   ])(
     'should get releases with the specified version "%s", OS "%s" and arch "%s"',
     async (
@@ -41,7 +43,7 @@ describe('Check getAvailableReleases', () => {
 
       const releases = await distribution['getAvailableReleases']();
       expect(releases).not.toBeNull();
-      expect(releases.length).toBe(4);
+      expect(releases.length).toBe(5);
       releases.forEach(release =>
         expect(release.downloadUrl).toContain(expectedPattern)
       );
@@ -173,6 +175,37 @@ describe('Check findPackageForDownload', () => {
       'windows',
       'x86_64',
       'https://github.com/Tencent/TencentKona-21/releases/download/TencentKona-21.0.5/TencentKona-21.0.5.b1_jdk_windows-x86_64_signed.zip'
+    ],
+
+    [
+      '25',
+      'linux',
+      'aarch64',
+      'https://github.com/Tencent/TencentKona-25/releases/download/TencentKona-25.0.3/TencentKona-25.0.3.b1-jdk_linux-aarch64.tar.gz'
+    ],
+    [
+      '25.0.3',
+      'linux',
+      'x86_64',
+      'https://github.com/Tencent/TencentKona-25/releases/download/TencentKona-25.0.3/TencentKona-25.0.3.b1-jdk_linux-x86_64.tar.gz'
+    ],
+    [
+      '25.0.3',
+      'macos',
+      'aarch64',
+      'https://github.com/Tencent/TencentKona-25/releases/download/TencentKona-25.0.3/TencentKona-25.0.3.b1_jdk_macosx-aarch64_notarized.tar.gz'
+    ],
+    [
+      '25.0.3',
+      'macos',
+      'x86_64',
+      'https://github.com/Tencent/TencentKona-25/releases/download/TencentKona-25.0.3/TencentKona-25.0.3.b1_jdk_macosx-x86_64_notarized.tar.gz'
+    ],
+    [
+      '25.0.3',
+      'windows',
+      'x86_64',
+      'https://github.com/Tencent/TencentKona-25/releases/download/TencentKona-25.0.3/TencentKona-25.0.3.b1_jdk_windows-x86_64_signed.zip'
     ]
   ])(
     'should return the download URL with the specified version "%s", OS "%s" and arch "%s"',

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -237,7 +237,7 @@ The available package types are:
 - `jre+ft` - JBR (FreeType)
 
 ### Tencent Kona
-**NOTE:** Tencent Kona supports major versions 8, 11, 17 and 21, and provides jdk only.
+**NOTE:** Tencent Kona supports major versions 8, 11, 17, 21 and 25, and provides jdk only.
 
 ```yaml
 steps:


### PR DESCRIPTION
**Description:**
Backport of #1108 to the `releases/v5` branch.

Tencent Kona has published version 25, so it would be better to clarify this point in the document and add tests accordingly.
- Update Tencent Kona documentation to list JDK 25 as supported
- Add Kona 25 to the e2e verification matrix (ubuntu, windows, macos)
- Extend Kona test fixture with real Kona 25.0.3 release entries
- Add unit tests covering Kona 25 selection across all platforms

**Related issue:**
#1107

**Original PR:**
#1108

**Check list:**
- [X] Ran `npm run check` locally (format, lint, build, test) and all checks pass.
- [X] Mark if documentation changes are required.
- [X] Mark if tests were added or updated to cover the changes.
