### PR TITLE
dist: Support Liberica NIK (#878)

### DIFF
--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -37,7 +37,8 @@ jobs:
             'dragonwell',
             'sapmachine',
             'jetbrains',
-            'kona'
+            'kona',
+            'liberica-nik'
           ] # internally 'adopt-hotspot' is the same as 'adopt'
         version: ['21', '11', '17']
         exclude:
@@ -62,6 +63,15 @@ jobs:
             os: ubuntu-latest
             version: 25
           - distribution: kona
+            os: macos-latest
+            version: 25
+          - distribution: liberica-nik
+            os: windows-latest
+            version: 25
+          - distribution: liberica-nik
+            os: ubuntu-latest
+            version: 25
+          - distribution: liberica-nik
             os: macos-latest
             version: 25
           - distribution: oracle
@@ -449,6 +459,10 @@ jobs:
           - distribution: 'liberica'
             java-package: jre+fx
             version: '11'
+            os: ubuntu-latest
+          - distribution: 'liberica-nik'
+            java-package: jdk+fx
+            version: '21'
             os: ubuntu-latest
           - distribution: 'corretto'
             java-package: jre

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Currently, the following distributions are supported:
 | `adopt` or `adopt-hotspot` | [AdoptOpenJDK Hotspot](https://adoptopenjdk.net/) | [`adopt-hotspot` license](https://adoptopenjdk.net/about.html) |
 | `adopt-openj9` | [AdoptOpenJDK OpenJ9](https://adoptopenjdk.net/) | [`adopt-openj9` license](https://adoptopenjdk.net/about.html) |
 | `liberica` | [Liberica JDK](https://bell-sw.com/) | [`liberica` license](https://bell-sw.com/liberica_eula/) |
+| `liberica-nik` | [Liberica Native Image Kit](https://bell-sw.com/pages/downloads/native-image-kit/) | [`liberica-nik` license](https://bell-sw.com/liberica_nik_eula/) |
 | `microsoft` | [Microsoft Build of OpenJDK](https://www.microsoft.com/openjdk) | [`microsoft` license](https://docs.microsoft.com/java/openjdk/faq)
 | `corretto` | [Amazon Corretto Build of OpenJDK](https://aws.amazon.com/corretto/) | [`corretto` license](https://aws.amazon.com/corretto/faqs/)
 | `semeru` | [IBM Semeru Runtime Open Edition](https://developer.ibm.com/languages/java/semeru-runtimes/downloads/) | [`semeru` license](https://openjdk.java.net/legal/gplv2+ce.html) |
@@ -301,6 +302,7 @@ In the example above multiple JDKs are installed for the same job. The result af
   - [Adopt](docs/advanced-usage.md#Adopt)
   - [Zulu](docs/advanced-usage.md#Zulu)
   - [Liberica](docs/advanced-usage.md#Liberica)
+  - [Liberica Native Image Kit](docs/advanced-usage.md#Liberica-Native-Image-Kit)
   - [Microsoft](docs/advanced-usage.md#Microsoft)
   - [Amazon Corretto](docs/advanced-usage.md#Amazon-Corretto)
   - [Oracle](docs/advanced-usage.md#Oracle)

--- a/__tests__/data/liberica-nik.json
+++ b/__tests__/data/liberica-nik.json
@@ -1,0 +1,739 @@
+[
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/25.0.1+3-25.0.1+16/bellsoft-liberica-vm-openjdk25.0.1+16-25.0.1+3-linux-amd64.tar.gz",
+    "version": "25.0.1+3",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "25.0.1+16",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/24.1.0+1-23+38/bellsoft-liberica-vm-openjdk23+38-24.1.0+1-linux-amd64.tar.gz",
+    "version": "24.1.0+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "23+38",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11.0.15.1+2-21.3.2+2-linux-amd64.tar.gz",
+    "version": "21.3.2+2",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "11.0.15.1+2",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/22.3.0/bellsoft-liberica-vm-openjdk17.0.5+8-22.3.0+2-linux-amd64.tar.gz",
+    "version": "22.3.0+2",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "17.0.5+8",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/23.0.9+1-17.0.16+13/bellsoft-liberica-vm-openjdk17.0.16+13-23.0.9+1-linux-amd64.tar.gz",
+    "version": "23.0.9+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "17.0.16+13",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-openjdk17.0.7+7-23.0.0+1-src.tar.gz",
+    "version": "23.0.0+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "17.0.7+7",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/25.0.2+1-25.0.2+13/bellsoft-liberica-vm-openjdk25.0.2+13-25.0.2+1-linux-amd64.tar.gz",
+    "version": "25.0.2+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "25.0.2+13",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/24.1.1+1-23.0.1+13/bellsoft-liberica-vm-openjdk23.0.1+13-24.1.1+1-linux-amd64.tar.gz",
+    "version": "24.1.1+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "23.0.1+13",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/23.0.12+1-17.0.19+12/bellsoft-liberica-vm-openjdk17.0.19+12-23.0.12+1-linux-amd64.tar.gz",
+    "version": "23.0.12+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "17.0.19+12",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/23.0.3+1-17.0.10+13/bellsoft-liberica-vm-openjdk17.0.10+13-23.0.3+1-linux-amd64.tar.gz",
+    "version": "23.0.3+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "17.0.10+13",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk11-21.3.2-src.tar.gz",
+    "version": "21.3.2+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "11.0.15+10",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20+8-22.3.3+1-src.tar.gz",
+    "version": "22.3.3+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "11.0.20+8",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/23.0.8+1-17.0.15+10/bellsoft-liberica-vm-openjdk17.0.15+10-23.0.8+1-linux-amd64.tar.gz",
+    "version": "23.0.8+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "17.0.15+10",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4-21.3.3-src.tar.gz",
+    "version": "21.3.3+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "17.0.4+8",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/23.1.7+1-21.0.7+9/bellsoft-liberica-vm-openjdk21.0.7+9-23.1.7+1-linux-amd64.tar.gz",
+    "version": "23.1.7+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "21.0.7+9",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/23.1.8+1-21.0.8+13/bellsoft-liberica-vm-openjdk21.0.8+13-23.1.8+1-linux-amd64.tar.gz",
+    "version": "23.1.8+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "21.0.8+13",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/21.0.0.2/bellsoft-liberica-vm-openjdk11-21.0.0.2-src.tar.gz",
+    "version": "21.0.0.2",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "11.0.10+9",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-openjdk17.0.8+7-23.0.1+1-linux-amd64.tar.gz",
+    "version": "23.0.1+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "17.0.8+7",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/24.0.0+1-22+37/bellsoft-liberica-vm-openjdk22+37-24.0.0+1-linux-amd64.tar.gz",
+    "version": "24.0.0+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "22+37",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/22.1.0/bellsoft-liberica-vm-openjdk17-22.1.0-src.tar.gz",
+    "version": "22.1.0+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "17.0.3+7",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/24.0.2+1-22.0.2+11/bellsoft-liberica-vm-openjdk22.0.2+11-24.0.2+1-linux-amd64.tar.gz",
+    "version": "24.0.2+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "22.0.2+11",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/23.0.1/bellsoft-liberica-vm-openjdk20.0.2+10-23.0.1+1-src.tar.gz",
+    "version": "23.0.1+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "20.0.2+10",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/23.1.0/bellsoft-liberica-vm-openjdk21+37-23.1.0+1-linux-amd64.tar.gz",
+    "version": "23.1.0+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "21+37",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/23.1.4+3-21.0.4+9/bellsoft-liberica-vm-openjdk21.0.4+9-23.1.4+3-linux-amd64.tar.gz",
+    "version": "23.1.4+3",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "21.0.4+9",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk11.0.20.1+1-22.3.3+2-linux-amd64.tar.gz",
+    "version": "22.3.3+2",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "11.0.20.1+1",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/23.0.4+1-17.0.11+10/bellsoft-liberica-vm-openjdk17.0.11+10-23.0.4+1-linux-amd64.tar.gz",
+    "version": "23.0.4+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "17.0.11+10",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/24.1.2+1-23.0.2+9/bellsoft-liberica-vm-openjdk23.0.2+9-24.1.2+1-linux-amd64.tar.gz",
+    "version": "24.1.2+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "23.0.2+9",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/23.0.10+1-17.0.17+12/bellsoft-liberica-vm-openjdk17.0.17+12-23.0.10+1-linux-amd64.tar.gz",
+    "version": "23.0.10+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "17.0.17+12",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk11.0.18+10-22.3.1+1-src.tar.gz",
+    "version": "22.3.1+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "11.0.18+10",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/22.0.0.2/bellsoft-liberica-vm-openjdk17-22.0.0.2-src.tar.gz",
+    "version": "22.0.0.2",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "17.0.2+9",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/22.0.0.2/bellsoft-liberica-vm-openjdk11-22.0.0.2-linux-amd64.tar.gz",
+    "version": "22.0.0.2",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "11.0.14.1+1",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/25.0.1+2-25.0.1+14/bellsoft-liberica-vm-openjdk25.0.1+14-25.0.1+2-linux-amd64.tar.gz",
+    "version": "25.0.1+2",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "25.0.1+14",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk11.0.16-21.3.3-src.tar.gz",
+    "version": "21.3.3+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "11.0.16+8",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/23.1.5+1-21.0.5+11/bellsoft-liberica-vm-openjdk21.0.5+11-23.1.5+1-linux-amd64.tar.gz",
+    "version": "23.1.5+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "21.0.5+11",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk17.0.9+11-22.3.4+1-linux-amd64.tar.gz",
+    "version": "22.3.4+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "17.0.9+11",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/25.0.0+1-25+37/bellsoft-liberica-vm-openjdk25+37-25.0.0+1-linux-amd64.tar.gz",
+    "version": "25.0.0+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "25+37",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/22.3.3/bellsoft-liberica-vm-openjdk17.0.8.1+1-22.3.3+2-linux-amd64.tar.gz",
+    "version": "22.3.3+2",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "17.0.8.1+1",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/23.1.3+1-21.0.3+10/bellsoft-liberica-vm-openjdk21.0.3+10-23.1.3+1-linux-amd64.tar.gz",
+    "version": "23.1.3+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "21.0.3+10",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/24.2.0+1-24+37/bellsoft-liberica-vm-openjdk24+37-24.2.0+1-linux-amd64.tar.gz",
+    "version": "24.2.0+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "24+37",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/23.1.1/bellsoft-liberica-vm-openjdk21.0.1+12-23.1.1+1-linux-amd64.tar.gz",
+    "version": "23.1.1+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "21.0.1+12",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/21.3.3/bellsoft-liberica-vm-openjdk17.0.4.1-21.3.3-src.tar.gz",
+    "version": "21.3.3+2",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "17.0.4.1+1",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/23.1.11+2-21.0.11+12/bellsoft-liberica-vm-openjdk21.0.11+12-23.1.11+2-linux-amd64.tar.gz",
+    "version": "23.1.11+2",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "21.0.11+12",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/22.3.2/bellsoft-liberica-vm-openjdk11.0.19+7-22.3.2+1-src.tar.gz",
+    "version": "22.3.2+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "11.0.19+7",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/22.3.4/bellsoft-liberica-vm-openjdk11.0.21+10-22.3.4+1-src.tar.gz",
+    "version": "22.3.4+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "11.0.21+10",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/25.0.3+2-25.0.3+12/bellsoft-liberica-vm-openjdk25.0.3+12-25.0.3+2-linux-amd64.tar.gz",
+    "version": "25.0.3+2",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "25.0.3+12",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/21.3.2/bellsoft-liberica-vm-openjdk17.0.3.1+2-21.3.2+2-linux-amd64.tar.gz",
+    "version": "21.3.2+2",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "17.0.3.1+2",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/24.2.1+1-24.0.1+11/bellsoft-liberica-vm-openjdk24.0.1+11-24.2.1+1-linux-amd64.tar.gz",
+    "version": "24.2.1+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "24.0.1+11",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/22.2.0/bellsoft-liberica-vm-openjdk11.0.16.1+1-22.2.0+3-linux-amd64.tar.gz",
+    "version": "22.2.0+3",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "11.0.16.1+1",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/23.0.6+1-17.0.13+12/bellsoft-liberica-vm-openjdk17.0.13+12-23.0.6+1-linux-amd64.tar.gz",
+    "version": "23.0.6+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "17.0.13+12",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/23.0.0/bellsoft-liberica-vm-openjdk20.0.1+10-23.0.0+1-linux-amd64.tar.gz",
+    "version": "23.0.0+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "20.0.1+10",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/23.1.10+1-21.0.10+11/bellsoft-liberica-vm-openjdk21.0.10+11-23.1.10+1-linux-amd64.tar.gz",
+    "version": "23.1.10+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "21.0.10+11",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/22.3.1/bellsoft-liberica-vm-openjdk17.0.6+10-22.3.1+1-src.tar.gz",
+    "version": "22.3.1+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "17.0.6+10",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk17-21.3.0-src.tar.gz",
+    "version": "21.3.0",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "17.0.1+12",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/21.3.0/bellsoft-liberica-vm-openjdk11-21.3.0-src.tar.gz",
+    "version": "21.3.0",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "11.0.13+8",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/24.0.1+1-22.0.1+10/bellsoft-liberica-vm-openjdk22.0.1+10-24.0.1+1-linux-amd64.tar.gz",
+    "version": "24.0.1+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "22.0.1+10",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/23.0.7+1-17.0.14+10/bellsoft-liberica-vm-openjdk17.0.14+10-23.0.7+1-linux-amd64.tar.gz",
+    "version": "23.0.7+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "17.0.14+10",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/21.1.0/bellsoft-liberica-vm-openjdk11-21.1.0-src.tar.gz",
+    "version": "21.1.0",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "11.0.11+9",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/23.1.6+1-21.0.6+10/bellsoft-liberica-vm-openjdk21.0.6+10-23.1.6+1-linux-amd64.tar.gz",
+    "version": "23.1.6+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "21.0.6+10",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/25.0.1+1-25.0.1+12/bellsoft-liberica-vm-openjdk25.0.1+12-25.0.1+1-linux-amd64.tar.gz",
+    "version": "25.0.1+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "25.0.1+12",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/23.1.9+1-21.0.9+12/bellsoft-liberica-vm-openjdk21.0.9+12-23.1.9+1-linux-amd64.tar.gz",
+    "version": "23.1.9+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "21.0.9+12",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/22.3.5+1-11.0.22+12/bellsoft-liberica-vm-openjdk11.0.22+12-22.3.5+1-linux-amd64.tar.gz",
+    "version": "22.3.5+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "11.0.22+12",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/23.0.5+1-17.0.12+10/bellsoft-liberica-vm-openjdk17.0.12+10-23.0.5+1-linux-amd64.tar.gz",
+    "version": "23.0.5+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "17.0.12+10",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/21.3.3.1/bellsoft-liberica-vm-openjdk11.0.17+7-21.3.3.1+1-linux-amd64.tar.gz",
+    "version": "21.3.3.1+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "11.0.17+7",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://download.bell-sw.com/vm/21.2.0/bellsoft-liberica-vm-openjdk11-21.2.0-linux-amd64.tar.gz",
+    "version": "21.2.0",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "11.0.12+7",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/23.0.11+1-17.0.18+11/bellsoft-liberica-vm-openjdk17.0.18+11-23.0.11+1-linux-amd64.tar.gz",
+    "version": "23.0.11+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "17.0.18+11",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/23.1.2+1-21.0.2+14/bellsoft-liberica-vm-openjdk21.0.2+14-23.1.2+1-linux-amd64.tar.gz",
+    "version": "23.1.2+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "21.0.2+14",
+        "embedded": true
+      }
+    ]
+  },
+  {
+    "downloadUrl": "https://github.com/bell-sw/LibericaNIK/releases/download/24.2.2+1-24.0.2+13/bellsoft-liberica-vm-openjdk24.0.2+13-24.2.2+1-linux-amd64.tar.gz",
+    "version": "24.2.2+1",
+    "components": [
+      {
+        "component": "liberica",
+        "version": "24.0.2+13",
+        "embedded": true
+      }
+    ]
+  }
+]

--- a/__tests__/distributors/liberica-nik-installer.test.ts
+++ b/__tests__/distributors/liberica-nik-installer.test.ts
@@ -1,0 +1,219 @@
+import {jest, describe, it, expect, beforeEach, afterEach} from '@jest/globals';
+import type {
+  ArchitectureOptions,
+  NikVersion
+} from '../../src/distributions/liberica-nik/models.js';
+import {HttpClient} from '@actions/http-client';
+
+import manifestData from '../data/liberica-nik.json' with {type: 'json'};
+
+// Mock @actions/core before importing source modules that depend on it
+jest.unstable_mockModule('@actions/core', () => ({
+  info: jest.fn(),
+  warning: jest.fn(),
+  debug: jest.fn(),
+  error: jest.fn(),
+  notice: jest.fn(),
+  setFailed: jest.fn(),
+  setOutput: jest.fn(),
+  getInput: jest.fn(),
+  getBooleanInput: jest.fn(),
+  getMultilineInput: jest.fn(),
+  addPath: jest.fn(),
+  exportVariable: jest.fn(),
+  saveState: jest.fn(),
+  getState: jest.fn(),
+  setSecret: jest.fn(),
+  isDebug: jest.fn(() => false),
+  startGroup: jest.fn(),
+  endGroup: jest.fn(),
+  group: jest.fn((_name: string, fn: () => Promise<unknown>) => fn()),
+  toPlatformPath: jest.fn((p: string) => p),
+  toWin32Path: jest.fn((p: string) => p),
+  toPosixPath: jest.fn((p: string) => p)
+}));
+
+// Dynamic imports after mocking
+const {LibericaNikDistributions} =
+  await import('../../src/distributions/liberica-nik/installer.js');
+
+const ADDITIONAL_PARAMS =
+  '&installation-type=archive&fields=downloadUrl%2Cversion%2Ccomponents%2Ccomponent%2Cembedded';
+
+describe('getAvailableVersions', () => {
+  let spyHttpClient: any;
+
+  beforeEach(() => {
+    spyHttpClient = jest.spyOn(HttpClient.prototype, 'getJson');
+    spyHttpClient.mockReturnValue({
+      statusCode: 200,
+      headers: {},
+      result: manifestData as NikVersion[]
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    [
+      {version: '21', architecture: 'x64', packageType: 'jdk'},
+      'bundle-type=standard&bitness=64&arch=x86&build-type=all'
+    ],
+    [
+      {version: '21-ea', architecture: 'x64', packageType: 'jdk'},
+      'bundle-type=standard&bitness=64&arch=x86&build-type=ea'
+    ],
+    [
+      {version: '21', architecture: 'aarch64', packageType: 'jdk'},
+      'bundle-type=standard&bitness=64&arch=arm&build-type=all'
+    ],
+    [
+      {version: '21', architecture: 'x64', packageType: 'jdk+fx'},
+      'bundle-type=full&bitness=64&arch=x86&build-type=all'
+    ]
+  ])('build correct url for %s -> %s', async (input, urlParams) => {
+    const distribution = new LibericaNikDistributions({
+      ...input,
+      checkLatest: false
+    });
+    distribution['getPlatformOption'] = () => 'linux';
+    const buildUrl = `https://api.bell-sw.com/v1/nik/releases?os=linux&${urlParams}${ADDITIONAL_PARAMS}`;
+
+    await distribution['getAvailableVersions']();
+
+    expect(spyHttpClient.mock.calls).toHaveLength(1);
+    expect(spyHttpClient.mock.calls[0][0]).toBe(buildUrl);
+  });
+
+  it('load available versions', async () => {
+    const distribution = new LibericaNikDistributions({
+      version: '21',
+      architecture: 'x64',
+      packageType: 'jdk',
+      checkLatest: false
+    });
+    const availableVersions = await distribution['getAvailableVersions']();
+    expect(availableVersions).toEqual(manifestData);
+  });
+});
+
+describe('getArchitectureOptions', () => {
+  it.each([
+    ['x64', {bitness: '64', arch: 'x86'}],
+    ['aarch64', {bitness: '64', arch: 'arm'}]
+  ] as [string, ArchitectureOptions][])(
+    'parse architecture %s -> %s',
+    (input, expected) => {
+      const distributions = new LibericaNikDistributions({
+        architecture: input,
+        checkLatest: false,
+        packageType: 'jdk',
+        version: '21'
+      });
+
+      expect(distributions['getArchitectureOptions']()).toEqual(expected);
+    }
+  );
+
+  it.each(['x86', 'armv7', 's390x'])('not support architecture %s', input => {
+    const distributions = new LibericaNikDistributions({
+      architecture: input,
+      checkLatest: false,
+      packageType: 'jdk',
+      version: '21'
+    });
+
+    expect(() => distributions['getArchitectureOptions']()).toThrow(
+      /Architecture '\w+' is not supported\. Supported architectures: .*/
+    );
+  });
+});
+
+describe('findPackageForDownload', () => {
+  let distribution: InstanceType<typeof LibericaNikDistributions>;
+
+  beforeEach(() => {
+    distribution = new LibericaNikDistributions({
+      version: '',
+      architecture: 'x64',
+      packageType: 'jdk',
+      checkLatest: false
+    });
+    distribution['getAvailableVersions'] = async () => manifestData;
+  });
+
+  // The user's java-version resolves against the embedded JDK version, not
+  // NIK's own GraalVM version.
+  it.each([
+    ['21', '21.0.11+12'],
+    ['17', '17.0.19+12'],
+    ['25', '25.0.3+12'],
+    ['11', '11.0.22+12'],
+    ['21.0.2', '21.0.2+14'],
+    ['23', '23.0.2+9'],
+    ['20.x', '20.0.2+10'],
+    ['25.0.1', '25.0.1+16']
+  ])('version is %s -> %s', async (input, expected) => {
+    const result = await distribution['findPackageForDownload'](input);
+    expect(result.version).toBe(expected);
+  });
+
+  it('should throw an error', async () => {
+    await expect(distribution['findPackageForDownload']('7')).rejects.toThrow(
+      /No matching version found for SemVer/
+    );
+  });
+});
+
+describe('getPlatformOption', () => {
+  const distributions = new LibericaNikDistributions({
+    architecture: 'x64',
+    version: '21',
+    packageType: 'jdk',
+    checkLatest: false
+  });
+
+  it.each([
+    ['linux', 'linux'],
+    ['darwin', 'macos'],
+    ['win32', 'windows'],
+    ['cygwin', 'windows']
+  ])('os version %s -> %s', (input, expected) => {
+    const actual = distributions['getPlatformOption'](input as NodeJS.Platform);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it.each(['sunos', 'aix', 'android', 'freebsd'])(
+    'not support os version %s',
+    input => {
+      expect(() =>
+        distributions['getPlatformOption'](input as NodeJS.Platform)
+      ).toThrow(/Platform '\w+' is not supported\. Supported platforms: .+/);
+    }
+  );
+});
+
+describe('convertVersionToSemver', () => {
+  const distributions = new LibericaNikDistributions({
+    architecture: 'x64',
+    version: '21',
+    packageType: 'jdk',
+    checkLatest: false
+  });
+
+  it.each([
+    ['25.0.1+16', '25.0.1+16'],
+    ['21+37', '21.0.0+37'],
+    ['23+38', '23.0.0+38'],
+    ['11.0.15.1+2', '11.0.15+1.2'],
+    ['17.0.5', '17.0.5']
+  ])('%s -> %s', (input, expected) => {
+    const actual = distributions['convertVersionToSemver'](input);
+    expect(actual).toEqual(expected);
+  });
+});

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -4,6 +4,7 @@
   - [Adopt](#Adopt)
   - [Zulu](#Zulu)
   - [Liberica](#Liberica)
+  - [Liberica Native Image Kit](#Liberica-Native-Image-Kit)
   - [Microsoft](#Microsoft)
   - [Amazon Corretto](#Amazon-Corretto)
   - [Oracle](#Oracle)
@@ -83,6 +84,20 @@ steps:
     java-version: '25'
     java-package: jdk # optional (jdk, jre, jdk+fx or jre+fx) - defaults to jdk
 - run: java --version
+```
+
+### Liberica Native Image Kit
+Liberica Native Image Kit (NIK) is a GraalVM-based distribution. `java-version` selects the underlying JDK version (e.g. `17`, `21`, `25`). Use `java-package: jdk+fx` to get the `full` bundle with JavaFX/Swing support; otherwise the `standard` bundle (with extra languages) is installed. Available on Linux, macOS and Windows for `x64` and `aarch64`.
+
+```yaml
+steps:
+- uses: actions/checkout@v6
+- uses: actions/setup-java@v5
+  with:
+    distribution: 'liberica-nik'
+    java-version: '25'
+    java-package: jdk # optional (jdk or jdk+fx) - defaults to jdk
+- run: native-image --version
 ```
 
 ### Microsoft

--- a/src/distributions/distribution-factory.ts
+++ b/src/distributions/distribution-factory.ts
@@ -8,6 +8,7 @@ import {
   TemurinImplementation
 } from './temurin/installer.js';
 import {LibericaDistributions} from './liberica/installer.js';
+import {LibericaNikDistributions} from './liberica-nik/installer.js';
 import {MicrosoftDistributions} from './microsoft/installer.js';
 import {SemeruDistribution} from './semeru/installer.js';
 import {CorrettoDistribution} from './corretto/installer.js';
@@ -28,6 +29,7 @@ enum JavaDistribution {
   Temurin = 'temurin',
   Zulu = 'zulu',
   Liberica = 'liberica',
+  LibericaNik = 'liberica-nik',
   JdkFile = 'jdkfile',
   Microsoft = 'microsoft',
   Semeru = 'semeru',
@@ -69,6 +71,8 @@ export function getJavaDistribution(
       return new ZuluDistribution(installerOptions);
     case JavaDistribution.Liberica:
       return new LibericaDistributions(installerOptions);
+    case JavaDistribution.LibericaNik:
+      return new LibericaNikDistributions(installerOptions);
     case JavaDistribution.Microsoft:
       return new MicrosoftDistributions(installerOptions);
     case JavaDistribution.Semeru:

--- a/src/distributions/liberica-nik/installer.ts
+++ b/src/distributions/liberica-nik/installer.ts
@@ -1,0 +1,180 @@
+import {JavaBase} from '../base-installer.js';
+import {
+  JavaDownloadRelease,
+  JavaInstallerOptions,
+  JavaInstallerResults
+} from '../base-models.js';
+import semver from 'semver';
+import {
+  extractJdkFile,
+  getDownloadArchiveExtension,
+  isVersionSatisfies,
+  renameWinArchive
+} from '../../util.js';
+import * as core from '@actions/core';
+import {ArchitectureOptions, NikVersion, OsVersions} from './models.js';
+import * as tc from '@actions/tool-cache';
+import fs from 'fs';
+import path from 'path';
+
+const supportedPlatform = `'linux', 'macos', 'windows'`;
+
+const supportedArchitectures = `'x64', 'aarch64'`;
+
+export class LibericaNikDistributions extends JavaBase {
+  constructor(installerOptions: JavaInstallerOptions) {
+    super('Liberica_NIK', installerOptions);
+  }
+
+  protected async downloadTool(
+    javaRelease: JavaDownloadRelease
+  ): Promise<JavaInstallerResults> {
+    core.info(
+      `Downloading Java ${javaRelease.version} (${this.distribution}) from ${javaRelease.url} ...`
+    );
+    let javaArchivePath = await tc.downloadTool(javaRelease.url);
+
+    core.info(`Extracting Java archive...`);
+    const extension = getDownloadArchiveExtension();
+    if (process.platform === 'win32') {
+      javaArchivePath = renameWinArchive(javaArchivePath);
+    }
+    const extractedJavaPath = await extractJdkFile(javaArchivePath, extension);
+
+    const archiveName = fs.readdirSync(extractedJavaPath)[0];
+    const archivePath = path.join(extractedJavaPath, archiveName);
+
+    const javaPath = await tc.cacheDir(
+      archivePath,
+      this.toolcacheFolderName,
+      this.getToolcacheVersionName(javaRelease.version),
+      this.architecture
+    );
+
+    return {version: javaRelease.version, path: javaPath};
+  }
+
+  protected async findPackageForDownload(
+    range: string
+  ): Promise<JavaDownloadRelease> {
+    const availableVersionsRaw = await this.getAvailableVersions();
+
+    const availableVersions = availableVersionsRaw
+      .map(item => {
+        const jdkVersion = this.getJdkVersion(item);
+        return jdkVersion ? {url: item.downloadUrl, version: jdkVersion} : null;
+      })
+      .filter((item): item is {url: string; version: string} => item !== null);
+
+    const satisfiedVersion = availableVersions
+      .filter(item => isVersionSatisfies(range, item.version))
+      .sort((a, b) => -semver.compareBuild(a.version, b.version))[0];
+
+    if (!satisfiedVersion) {
+      const availableVersionStrings = availableVersions.map(
+        item => item.version
+      );
+      throw this.createVersionNotFoundError(range, availableVersionStrings);
+    }
+
+    return satisfiedVersion;
+  }
+
+  private async getAvailableVersions(): Promise<NikVersion[]> {
+    if (core.isDebug()) {
+      console.time('Retrieving available versions for Liberica NIK took'); // eslint-disable-line no-console
+    }
+    const url = this.prepareAvailableVersionsUrl();
+
+    core.debug(`Gathering available versions from '${url}'`);
+
+    const availableVersions =
+      (await this.http.getJson<NikVersion[]>(url)).result ?? [];
+
+    if (core.isDebug()) {
+      core.startGroup('Print information about available versions');
+      console.timeEnd('Retrieving available versions for Liberica NIK took'); // eslint-disable-line no-console
+      core.debug(`Available versions: [${availableVersions.length}]`);
+      core.debug(availableVersions.map(item => item.version).join(', '));
+      core.endGroup();
+    }
+
+    return availableVersions;
+  }
+
+  private prepareAvailableVersionsUrl() {
+    const urlOptions = {
+      os: this.getPlatformOption(),
+      'bundle-type': this.getBundleType(),
+      ...this.getArchitectureOptions(),
+      'build-type': this.stable ? 'all' : 'ea',
+      'installation-type': 'archive',
+      fields: 'downloadUrl,version,components,component,embedded'
+    };
+
+    const searchParams = new URLSearchParams(urlOptions).toString();
+
+    return `https://api.bell-sw.com/v1/nik/releases?${searchParams}`;
+  }
+
+  // NIK's top-level `version` is the GraalVM/NIK version; the JDK version that
+  // users select on lives in the embedded `liberica` component.
+  private getJdkVersion(release: NikVersion): string | null {
+    const liberica = release.components?.find(
+      component => component.component === 'liberica'
+    );
+    return liberica ? this.convertVersionToSemver(liberica.version) : null;
+  }
+
+  // The `full` bundle adds JavaFX/Swing GUI support; otherwise use `standard`.
+  private getBundleType(): string {
+    const [, feature] = this.packageType.split('+');
+    return feature?.includes('fx') ? 'full' : 'standard';
+  }
+
+  private getArchitectureOptions(): ArchitectureOptions {
+    const arch = this.distributionArchitecture();
+    switch (arch) {
+      case 'x64':
+        return {bitness: '64', arch: 'x86'};
+      case 'aarch64':
+        return {bitness: '64', arch: 'arm'};
+      default:
+        throw new Error(
+          `Architecture '${this.architecture}' is not supported. Supported architectures: ${supportedArchitectures}`
+        );
+    }
+  }
+
+  private getPlatformOption(
+    platform: NodeJS.Platform = process.platform
+  ): OsVersions {
+    switch (platform) {
+      case 'darwin':
+        return 'macos';
+      case 'win32':
+      case 'cygwin':
+        return 'windows';
+      case 'linux':
+        return 'linux';
+      default:
+        throw new Error(
+          `Platform '${platform}' is not supported. Supported platforms: ${supportedPlatform}`
+        );
+    }
+  }
+
+  // JDK versions come as strings like '25.0.1+16', '23+38' or '11.0.15.1+2'.
+  // Normalize them to valid SemVer while preserving build metadata so newer
+  // NIK builds of the same JDK sort ahead of older ones.
+  private convertVersionToSemver(jdkVersion: string): string {
+    const [main, build] = jdkVersion.split('+');
+    const parts = main.split('.');
+    while (parts.length < 3) {
+      parts.push('0');
+    }
+    const base = parts.slice(0, 3).join('.');
+    const buildMeta = [...parts.slice(3), ...(build ? [build] : [])];
+    return buildMeta.length ? `${base}+${buildMeta.join('.')}` : base;
+  }
+}

--- a/src/distributions/liberica-nik/models.ts
+++ b/src/distributions/liberica-nik/models.ts
@@ -1,0 +1,26 @@
+// Models from https://api.bell-sw.com/api.html (NIK product)
+
+export type Bitness = '32' | '64';
+export type ArchType = 'arm' | 'ppc' | 'sparc' | 'x86';
+
+export type OsVersions = 'linux' | 'linux-musl' | 'macos' | 'windows';
+
+export interface ArchitectureOptions {
+  bitness: Bitness;
+  arch: ArchType;
+}
+
+export interface NikComponent {
+  component: string;
+  version: string;
+  embedded?: boolean;
+}
+
+export interface NikVersion {
+  // The main Liberica NIK VM bundle download URL.
+  downloadUrl: string;
+  // NIK/GraalVM version (e.g. '24.1.0+1'), kept for logging only.
+  version: string;
+  // The embedded `liberica` component carries the actual JDK version.
+  components: NikComponent[];
+}


### PR DESCRIPTION
**Description:**

Adds a new distribution `liberica-nik` for the [Liberica Native Image Kit (NIK)](https://bell-sw.com/pages/downloads/native-image-kit/), BellSoft's GraalVM-based build. It reuses the same download/extract mechanics as the existing `liberica` distribution but resolves releases through the Bell-SW `/v1/nik/releases` API.

Just like `liberica` (regular vs. JavaFX), **both NIK flavors are supported** via `java-package`:
- `java-package: jdk` (default) — the standard NIK bundle (native-image + extra languages), no JavaFX.
- `java-package: jdk+fx` — the `full` NIK bundle, which adds JavaFX support.

```yaml
- uses: actions/setup-java@v5
  with:
    distribution: 'liberica-nik'
    java-version: '25'
    java-package: jdk # optional (jdk or jdk+fx) - defaults to jdk
- run: native-image --version
```

Design notes:
- **Version resolution matches the embedded JDK version**, not NIK's own GraalVM version. Each NIK release carries a top-level GraalVM version (e.g. `24.1.0`) plus a `components` array; the embedded `liberica` component holds the JDK version (e.g. `21.0.4`). `java-version` matches the latter, so `java-version: 21` behaves the same as for every other distribution.
- Supported on Linux, macOS and Windows for `x64` and `aarch64` (NIK ships 64-bit only).

Changes:
- `src/distributions/liberica-nik/{installer,models}.ts` — new distribution.
- `src/distributions/distribution-factory.ts` — register `liberica-nik`.
- `__tests__/distributors/liberica-nik-installer.test.ts` + `__tests__/data/liberica-nik.json` — unit tests (URL building, arch/platform mapping, version resolution, SemVer normalization).
- `README.md`, `docs/advanced-usage.md` — documentation.
- `.github/workflows/e2e-versions.yml` — e2e coverage (11/17/21/25 across OSes, plus a `jdk+fx` case).
- `dist/` — rebuilt via `npm run build`.

**Related issue:**

Closes #878

**Download URL:**

Releases are resolved via the Bell-SW API: `https://api.bell-sw.com/v1/nik/releases`
Downloads page: https://bell-sw.com/pages/downloads/native-image-kit/

**License:**

[Liberica Native Image Kit EULA](https://bell-sw.com/liberica_nik_eula/)

**Check list:**
- [x] Ran `npm run check` locally (format, lint, build, test) and all checks pass.
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.
- [x] Mark if new distribution is being added.

---

**AI Disclosure:** This PR was prepared with the assistance of Claude Code (Anthropic). The distribution implementation, tests, documentation, and e2e configuration were AI-assisted; the design decisions (JDK-version matching, `jdk`/`jdk+fx` → `standard`/`full` bundle mapping, distribution id) were made by the human contributor, who reviewed every line before submission.
