### PR TITLE
Backport #1111: Preserve Maven toolchains across repeated setup-java runs (#1099)

### DIFF
--- a/__tests__/toolchains.test.ts
+++ b/__tests__/toolchains.test.ts
@@ -842,7 +842,7 @@ describe('toolchains tests', () => {
     // The pre-existing (Sun 1.6) toolchain must be preserved ...
     expect(updated).toContain('<id>sun_1.6</id>');
     expect(updated).toContain('<jdkHome>/opt/jdk/sun/1.6</jdkHome>');
-    // ... and the newly installed JDK must be appended.
+    // ... and the newly installed JDK must be included in the merged result.
     expect(updated).toContain('<id>temurin_17</id>');
     expect(updated).toContain('<vendor>Eclipse Temurin</vendor>');
     expect(updated).toContain(`<jdkHome>${jdkInfo.jdkHome}</jdkHome>`);

--- a/__tests__/toolchains.test.ts
+++ b/__tests__/toolchains.test.ts
@@ -46,8 +46,7 @@ describe('toolchains tests', () => {
 
     await toolchains.createToolchainsSettings({
       jdkInfo,
-      settingsDirectory: altHome,
-      overwriteSettings: true
+      settingsDirectory: altHome
     });
 
     expect(fs.existsSync(m2Dir)).toBe(false);
@@ -95,8 +94,7 @@ describe('toolchains tests', () => {
 
     await toolchains.createToolchainsSettings({
       jdkInfo,
-      settingsDirectory: m2Dir,
-      overwriteSettings: true
+      settingsDirectory: m2Dir
     });
 
     expect(fs.existsSync(m2Dir)).toBe(true);
@@ -177,8 +175,7 @@ describe('toolchains tests', () => {
 
     await toolchains.createToolchainsSettings({
       jdkInfo,
-      settingsDirectory: m2Dir,
-      overwriteSettings: true
+      settingsDirectory: m2Dir
     });
 
     expect(fs.existsSync(m2Dir)).toBe(true);
@@ -263,8 +260,7 @@ describe('toolchains tests', () => {
 
     await toolchains.createToolchainsSettings({
       jdkInfo,
-      settingsDirectory: m2Dir,
-      overwriteSettings: true
+      settingsDirectory: m2Dir
     });
 
     expect(fs.existsSync(m2Dir)).toBe(true);
@@ -341,8 +337,7 @@ describe('toolchains tests', () => {
 
     await toolchains.createToolchainsSettings({
       jdkInfo,
-      settingsDirectory: m2Dir,
-      overwriteSettings: true
+      settingsDirectory: m2Dir
     });
 
     expect(fs.existsSync(m2Dir)).toBe(true);
@@ -412,8 +407,7 @@ describe('toolchains tests', () => {
 
     await toolchains.createToolchainsSettings({
       jdkInfo,
-      settingsDirectory: m2Dir,
-      overwriteSettings: true
+      settingsDirectory: m2Dir
     });
 
     expect(fs.existsSync(m2Dir)).toBe(true);
@@ -505,8 +499,7 @@ describe('toolchains tests', () => {
 
     await toolchains.createToolchainsSettings({
       jdkInfo,
-      settingsDirectory: m2Dir,
-      overwriteSettings: true
+      settingsDirectory: m2Dir
     });
 
     expect(fs.existsSync(m2Dir)).toBe(true);
@@ -565,8 +558,7 @@ describe('toolchains tests', () => {
 
     await toolchains.createToolchainsSettings({
       jdkInfo,
-      settingsDirectory: m2Dir,
-      overwriteSettings: true
+      settingsDirectory: m2Dir
     });
 
     expect(fs.existsSync(m2Dir)).toBe(true);
@@ -624,8 +616,7 @@ describe('toolchains tests', () => {
 
     await toolchains.createToolchainsSettings({
       jdkInfo,
-      settingsDirectory: m2Dir,
-      overwriteSettings: true
+      settingsDirectory: m2Dir
     });
 
     expect(fs.existsSync(m2Dir)).toBe(true);
@@ -708,8 +699,7 @@ describe('toolchains tests', () => {
 
     await toolchains.createToolchainsSettings({
       jdkInfo,
-      settingsDirectory: m2Dir,
-      overwriteSettings: true
+      settingsDirectory: m2Dir
     });
 
     expect(fs.existsSync(m2Dir)).toBe(true);
@@ -788,8 +778,7 @@ describe('toolchains tests', () => {
 
     await toolchains.createToolchainsSettings({
       jdkInfo,
-      settingsDirectory: m2Dir,
-      overwriteSettings: true
+      settingsDirectory: m2Dir
     });
 
     expect(fs.existsSync(m2Dir)).toBe(true);
@@ -814,7 +803,7 @@ describe('toolchains tests', () => {
     ).toEqual(result);
   }, 100000);
 
-  it('does not overwrite existing toolchains.xml files', async () => {
+  it('extends existing toolchains.xml files instead of overwriting them', async () => {
     const jdkInfo = {
       version: '17',
       vendor: 'Eclipse Temurin',
@@ -843,13 +832,20 @@ describe('toolchains tests', () => {
 
     await toolchains.createToolchainsSettings({
       jdkInfo,
-      settingsDirectory: m2Dir,
-      overwriteSettings: false
+      settingsDirectory: m2Dir
     });
 
     expect(fs.existsSync(m2Dir)).toBe(true);
     expect(fs.existsSync(toolchainsFile)).toBe(true);
-    expect(fs.readFileSync(toolchainsFile, 'utf-8')).toEqual(originalFile);
+
+    const updated = fs.readFileSync(toolchainsFile, 'utf-8');
+    // The pre-existing (Sun 1.6) toolchain must be preserved ...
+    expect(updated).toContain('<id>sun_1.6</id>');
+    expect(updated).toContain('<jdkHome>/opt/jdk/sun/1.6</jdkHome>');
+    // ... and the newly installed JDK must be appended.
+    expect(updated).toContain('<id>temurin_17</id>');
+    expect(updated).toContain('<vendor>Eclipse Temurin</vendor>');
+    expect(updated).toContain(`<jdkHome>${jdkInfo.jdkHome}</jdkHome>`);
   }, 100000);
 
   it('generates valid toolchains.xml with minimal configuration', () => {
@@ -913,5 +909,56 @@ describe('toolchains tests', () => {
         jdkHome
       )
     );
+  }, 100000);
+
+  it('preserves toolchains from previous executions across multiple setup-java runs', async () => {
+    // Regression test for https://github.com/actions/setup-java/issues/1099
+    // Running setup-java several times in the same job (e.g. multiple steps / multiple
+    // java-version entries) must accumulate every JDK in toolchains.xml rather
+    // than replacing previously registered entries.
+    jest.spyOn(core, 'getInput').mockImplementation((name: string) => {
+      if (name === 'settings-path') return m2Dir;
+      return '';
+    });
+
+    const runs = [
+      {
+        version: '8',
+        distributionName: 'temurin',
+        id: 'temurin_8',
+        jdkHome: '/opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/8.0.1-12/x64'
+      },
+      {
+        version: '11',
+        distributionName: 'temurin',
+        id: 'temurin_11',
+        jdkHome: '/opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.1-12/x64'
+      },
+      {
+        version: '17',
+        distributionName: 'temurin',
+        id: 'temurin_17',
+        jdkHome: '/opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.1-12/x64'
+      }
+    ];
+
+    for (const run of runs) {
+      await toolchains.configureToolchains(
+        run.version,
+        run.distributionName,
+        run.jdkHome,
+        undefined
+      );
+    }
+
+    expect(fs.existsSync(toolchainsFile)).toBe(true);
+    const contents = fs.readFileSync(toolchainsFile, 'utf-8');
+
+    for (const run of runs) {
+      expect(contents).toContain(`<id>${run.id}</id>`);
+      expect(contents).toContain(`<jdkHome>${run.jdkHome}</jdkHome>`);
+    }
+    // Exactly one <toolchain> entry per run – no duplicates, none dropped.
+    expect((contents.match(/<toolchain>/g) || []).length).toBe(runs.length);
   }, 100000);
 });

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -684,6 +684,8 @@ The `setup-java` action generates a basic [Maven Toolchains declaration](https:/
 ### Installing Multiple JDKs With Toolchains
 Subsequent calls to `setup-java` with distinct distribution and version parameters will continue to extend the toolchains declaration and make all specified Java versions available.
 
+Toolchain entries are always merged non-destructively: existing JDK, custom, and user-managed toolchains are preserved, and only an entry with the exact same `type` and `provides.id` is replaced. This behavior is independent of the `overwrite-settings` input, which only controls regeneration of `settings.xml`. As a result, running `setup-java` several times in the same job (for example in multiple steps or with multiple `java-version` values) accumulates every JDK in `toolchains.xml` instead of dropping previously registered entries.
+
 ```yaml
 steps:
 - uses: actions/setup-java@v5

--- a/src/toolchains.ts
+++ b/src/toolchains.ts
@@ -5,7 +5,6 @@ import * as core from '@actions/core';
 import * as io from '@actions/io';
 import * as constants from './constants';
 
-import {getBooleanInput} from './util';
 import {create as xmlCreate} from 'xmlbuilder2';
 
 interface JdkInfo {
@@ -27,10 +26,6 @@ export async function configureToolchains(
   const settingsDirectory =
     core.getInput(constants.INPUT_SETTINGS_PATH) ||
     path.join(os.homedir(), constants.M2_DIR);
-  const overwriteSettings = getBooleanInput(
-    constants.INPUT_OVERWRITE_SETTINGS,
-    true
-  );
 
   await createToolchainsSettings({
     jdkInfo: {
@@ -39,19 +34,16 @@ export async function configureToolchains(
       id,
       jdkHome
     },
-    settingsDirectory,
-    overwriteSettings
+    settingsDirectory
   });
 }
 
 export async function createToolchainsSettings({
   jdkInfo,
-  settingsDirectory,
-  overwriteSettings
+  settingsDirectory
 }: {
   jdkInfo: JdkInfo;
   settingsDirectory: string;
-  overwriteSettings: boolean;
 }) {
   core.info(
     `Creating ${constants.MVN_TOOLCHAINS_FILE} for JDK version ${jdkInfo.version} from ${jdkInfo.vendor}`
@@ -68,11 +60,7 @@ export async function createToolchainsSettings({
     jdkInfo.id,
     jdkInfo.jdkHome
   );
-  await writeToolchainsFileToDisk(
-    settingsDirectory,
-    updatedToolchains,
-    overwriteSettings
-  );
+  await writeToolchainsFileToDisk(settingsDirectory, updatedToolchains);
 }
 
 // only exported for testing purposes
@@ -172,22 +160,19 @@ async function readExistingToolchainsFile(directory: string) {
   return '';
 }
 
-async function writeToolchainsFileToDisk(
-  directory: string,
-  settings: string,
-  overwriteSettings: boolean
-) {
+async function writeToolchainsFileToDisk(directory: string, settings: string) {
   const location = path.join(directory, constants.MVN_TOOLCHAINS_FILE);
   const settingsExists = fs.existsSync(location);
-  if (settingsExists && overwriteSettings) {
-    core.info(`Overwriting existing file ${location}`);
-  } else if (!settingsExists) {
-    core.info(`Writing to ${location}`);
+  // The toolchains file is produced by a non-destructive merge (existing JDK,
+  // custom, and non-jdk toolchains are preserved – see generateToolchainDefinition),
+  // so it is always safe to write it. Unlike settings.xml, it is therefore not
+  // gated behind the `overwrite-settings` input; that would prevent subsequent
+  // setup-java runs from registering additional JDKs and silently drop the
+  // toolchain entries created by earlier runs.
+  if (settingsExists) {
+    core.info(`Updating existing file ${location}`);
   } else {
-    core.info(
-      `Skipping generation of ${location} because file already exists and overwriting is not enabled`
-    );
-    return;
+    core.info(`Writing to ${location}`);
   }
 
   return fs.writeFileSync(location, settings, {


### PR DESCRIPTION
## Summary

Backport of #1111 to the `releases/v5` branch. Fixes #1099.

Running `setup-java` multiple times in the same job (matrix builds or multiple `java-version` values) could drop toolchain entries registered by earlier runs, leaving only one JDK in `~/.m2/toolchains.xml`.

## Root cause

Toolchains generation was gated behind the `overwrite-settings` input. When `overwrite-settings: false`, `writeToolchainsFileToDisk` skipped writing entirely if the file already existed — so a second `setup-java` run never persisted its JDK, silently discarding the merged result.

This gating was inappropriate because:
- `overwrite-settings` is documented (in `action.yml`) to control regeneration of **`settings.xml`** only.
- `generateToolchainDefinition` already performs a **non-destructive merge**: existing JDK, custom, and user-managed toolchains are preserved, and only an entry with the exact same `type` + `provides.id` is replaced.

So writing the toolchains file is always safe and should not be blocked.

## Changes

- **`src/toolchains.ts`**: Remove `overwriteSettings` from `configureToolchains`, `createToolchainsSettings`, and `writeToolchainsFileToDisk`. The toolchains file is now always written (non-destructively). `settings.xml` behavior in `auth.ts` is unchanged.
- **`__tests__/toolchains.test.ts`**: Update call sites, rewrite the "does not overwrite" test to assert non-destructive extension, and add a regression test that runs `configureToolchains` three times and asserts every JDK is preserved with no duplicates.
- **`docs/advanced-usage.md`**: Clarify that the merge is non-destructive and independent of `overwrite-settings`.
- **`dist/setup/index.js`**: Rebuilt.

## Backport notes

`releases/v5` predates the ESM migration on `main`, so the change was re-applied to v5's CommonJS sources rather than cherry-picked (imports use `./util`/`./constants` without `.js`, and the new regression test uses `jest.spyOn(core, 'getInput')` to match v5's mocking style instead of `unstable_mockModule`). The net behavioral change is identical to #1111.

## Testing

- `npm run build`, format-check, and lint all pass.
- `npm test`: the `toolchains` suite passes (15/15), including the new regression test; full suite passes on clean runs.

Fixes #1099

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>