### PR TITLE
Harden set-default Checkout in e2e-versions.yml (persist-credentials: false)

### DIFF
--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -704,6 +704,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Setup Java 17 as default
         uses: ./
         id: setup-java-17


### PR DESCRIPTION
## Description

Follow-up review of `.github/workflows/e2e-versions.yml` after the template-injection fixes in #1114 and #1120.

A post-merge Copilot review comment on #1114 noted the "Verify Java 21 outputs are set" step still interpolated step outputs directly in a `run:` block. That concern was already resolved in #1120, and a full sweep confirms **no `${{ ... }}` expressions are interpolated directly into any `run:` block** anymore — all step outputs, matrix values, and secrets are routed through step-level `env:`.

While reviewing, `zizmor`'s `artipacked` audit flagged one remaining gap: the `Checkout` step in the *set-default option* job was the **only one of 17** checkout steps in the file missing `persist-credentials: false`. This PR aligns it with the rest of the file.

```yaml
- name: Checkout
  uses: actions/checkout@v7
  with:
    persist-credentials: false
```

After this change, `zizmor .github/workflows/e2e-versions.yml` reports **no findings**.

## Related

- #1114 — Fix template injection (zizmor alert #118)
- #1120 — Fix template injection (zizmor alert #122)

## Check list

- [x] Ran `zizmor` locally; no findings remain for this workflow.
- [ ] Documentation changes required.
- [ ] Tests added or updated.