### PR TITLE
Fix caching when wrapper distributions are absent

### DIFF
--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -548,7 +548,7 @@ describe('dependency cache', () => {
 
         await save('maven');
         expect(spyCacheSave).toHaveBeenCalledWith(
-          [join(os.homedir(), '.m2', 'wrapper', 'dists')],
+          ['wrapper-path'],
           'setup-java-maven-wrapper-key'
         );
         expect(spyWarning).not.toHaveBeenCalled();
@@ -678,7 +678,7 @@ describe('dependency cache', () => {
 
         await save('gradle');
         expect(spyCacheSave).toHaveBeenCalledWith(
-          [join(os.homedir(), '.gradle', 'wrapper')],
+          ['wrapper-path'],
           'setup-java-gradle-wrapper-key'
         );
         expect(spyWarning).not.toHaveBeenCalled();

--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -458,11 +458,16 @@ describe('dependency cache', () => {
   });
   describe('save', () => {
     let spyCacheSave: any;
+    let spyGlobCreate: jest.Mock;
 
     beforeEach(() => {
       spyCacheSave = (cache.saveCache as any).mockImplementation(
         (paths: string[], key: string) => Promise.resolve(0)
       );
+      spyGlobCreate = glob.create as jest.Mock;
+      spyGlobCreate.mockResolvedValue({
+        glob: jest.fn(() => Promise.resolve(['wrapper-path']))
+      });
       spyWarning.mockImplementation(() => null);
     });
 
@@ -572,6 +577,11 @@ describe('dependency cache', () => {
       });
       it('does not fail the post step when the wrapper distribution path is missing', async () => {
         createFile(join(workspace, 'pom.xml'));
+        createDirectory(join(workspace, '.mvn'));
+        createDirectory(join(workspace, '.mvn', 'wrapper'));
+        createFile(
+          join(workspace, '.mvn', 'wrapper', 'maven-wrapper.properties')
+        );
         (core.getState as jest.Mock<any>).mockImplementation((name: any) => {
           switch (name) {
             case 'cache-primary-key':
@@ -584,17 +594,19 @@ describe('dependency cache', () => {
               return '';
           }
         });
-        spyCacheSave.mockImplementation((paths: string[]) =>
-          paths.includes(join(os.homedir(), '.m2', 'wrapper', 'dists'))
-            ? Promise.reject(
-                new cache.ValidationError(
-                  'Path Validation Error: Path(s) specified in the action for caching do(es) not exist'
-                )
-              )
-            : Promise.resolve(0)
-        );
+        spyGlobCreate.mockResolvedValue({
+          glob: jest.fn(() => Promise.resolve([]))
+        });
 
         await expect(save('maven')).resolves.toBeUndefined();
+        expect(spyCacheSave).not.toHaveBeenCalledWith(
+          [join(os.homedir(), '.m2', 'wrapper', 'dists')],
+          expect.any(String)
+        );
+        expect(spyCacheSave).toHaveBeenCalledWith(
+          [join(os.homedir(), '.m2', 'repository')],
+          'setup-java-cache-primary-key'
+        );
         expect(spyWarning).not.toHaveBeenCalled();
       });
     });
@@ -692,6 +704,36 @@ describe('dependency cache', () => {
           [join(os.homedir(), '.gradle', 'wrapper')],
           expect.any(String)
         );
+      });
+      it('does not fail the post step when the wrapper distribution path is missing', async () => {
+        createFile(join(workspace, 'build.gradle'));
+        createFile(join(workspace, 'gradle-wrapper.properties'));
+        (core.getState as jest.Mock<any>).mockImplementation((name: any) => {
+          switch (name) {
+            case 'cache-primary-key':
+              return 'setup-java-cache-primary-key';
+            case 'cache-matched-key':
+              return 'setup-java-cache-matched-key';
+            case 'cache-primary-key-gradle-wrapper':
+              return 'setup-java-gradle-wrapper-key';
+            default:
+              return '';
+          }
+        });
+        spyGlobCreate.mockResolvedValue({
+          glob: jest.fn(() => Promise.resolve([]))
+        });
+
+        await expect(save('gradle')).resolves.toBeUndefined();
+        expect(spyCacheSave).not.toHaveBeenCalledWith(
+          [join(os.homedir(), '.gradle', 'wrapper')],
+          expect.any(String)
+        );
+        expect(spyCacheSave).toHaveBeenCalledWith(
+          [join(os.homedir(), '.gradle', 'caches')],
+          'setup-java-cache-primary-key'
+        );
+        expect(spyWarning).not.toHaveBeenCalled();
       });
     });
     describe('for sbt', () => {

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -97988,6 +97988,14 @@ async function saveAdditionalCache(packageManager, additionalCache) {
         info(`Cache hit occurred on the ${additionalCache.name} primary key ${primaryKey}, not saving cache.`);
         return;
     }
+    const globber = await create(additionalCache.path.join('\n'), {
+        implicitDescendants: false
+    });
+    const cachePaths = await globber.glob();
+    if (cachePaths.length === 0) {
+        core_debug(`${additionalCache.name} cache paths do not exist, not saving cache.`);
+        return;
+    }
     try {
         const cacheId = await cache_saveCache(additionalCache.path, primaryKey);
         if (cacheId === -1) {

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -97997,7 +97997,7 @@ async function saveAdditionalCache(packageManager, additionalCache) {
         return;
     }
     try {
-        const cacheId = await cache_saveCache(additionalCache.path, primaryKey);
+        const cacheId = await cache_saveCache(cachePaths, primaryKey);
         if (cacheId === -1) {
             core_debug(`${additionalCache.name} cache was not saved for the key: ${primaryKey}`);
             return;

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -129238,7 +129238,7 @@ async function saveAdditionalCache(packageManager, additionalCache) {
         return;
     }
     try {
-        const cacheId = await cache.saveCache(additionalCache.path, primaryKey);
+        const cacheId = await cache.saveCache(cachePaths, primaryKey);
         if (cacheId === -1) {
             core.debug(`${additionalCache.name} cache was not saved for the key: ${primaryKey}`);
             return;

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -129229,6 +129229,14 @@ async function saveAdditionalCache(packageManager, additionalCache) {
         core.info(`Cache hit occurred on the ${additionalCache.name} primary key ${primaryKey}, not saving cache.`);
         return;
     }
+    const globber = await glob.create(additionalCache.path.join('\n'), {
+        implicitDescendants: false
+    });
+    const cachePaths = await globber.glob();
+    if (cachePaths.length === 0) {
+        core.debug(`${additionalCache.name} cache paths do not exist, not saving cache.`);
+        return;
+    }
     try {
         const cacheId = await cache.saveCache(additionalCache.path, primaryKey);
         if (cacheId === -1) {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -332,7 +332,7 @@ async function saveAdditionalCache(
   }
 
   try {
-    const cacheId = await cache.saveCache(additionalCache.path, primaryKey);
+    const cacheId = await cache.saveCache(cachePaths, primaryKey);
     if (cacheId === -1) {
       core.debug(
         `${additionalCache.name} cache was not saved for the key: ${primaryKey}`

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -319,6 +319,18 @@ async function saveAdditionalCache(
     );
     return;
   }
+
+  const globber = await glob.create(additionalCache.path.join('\n'), {
+    implicitDescendants: false
+  });
+  const cachePaths = await globber.glob();
+  if (cachePaths.length === 0) {
+    core.debug(
+      `${additionalCache.name} cache paths do not exist, not saving cache.`
+    );
+    return;
+  }
+
   try {
     const cacheId = await cache.saveCache(additionalCache.path, primaryKey);
     if (cacheId === -1) {


### PR DESCRIPTION
**Description:**
Projects can keep Maven or Gradle wrapper metadata while intentionally using the system build tool, leaving the wrapper distribution directory absent. The post action now resolves optional wrapper-cache paths before calling `@actions/cache`; when no path exists, it skips only that wrapper cache and continues saving the main dependency cache.

Regression tests cover both Maven and Gradle and verify that the main cache is still saved. The generated setup and cleanup bundles are rebuilt with the fix.

**Related issue:**
Fixes: #1150

**Check list:**
- [x] Ran `npm run check` locally (format, lint, build, test) and all checks pass.
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.