### PR TITLE
Backport #1151: Fix missing wrapper cache distributions

### DIFF
--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -377,6 +377,10 @@ describe('dependency cache', () => {
       ReturnType<typeof cache.saveCache>,
       Parameters<typeof cache.saveCache>
     >;
+    let spyGlobCreate: jest.SpyInstance<
+      ReturnType<typeof glob.create>,
+      Parameters<typeof glob.create>
+    >;
 
     beforeEach(() => {
       spyCacheSave = jest
@@ -384,6 +388,9 @@ describe('dependency cache', () => {
         .mockImplementation((paths: string[], key: string) =>
           Promise.resolve(0)
         );
+      spyGlobCreate = jest
+        .spyOn(glob, 'create')
+        .mockResolvedValue(createGlobber(['wrapper-path']));
       spyWarning.mockImplementation(() => null);
     });
 
@@ -469,17 +476,24 @@ describe('dependency cache', () => {
       });
       it('does not fail the post step when the wrapper distribution path is missing', async () => {
         createFile(join(workspace, 'pom.xml'));
+        createDirectory(join(workspace, '.mvn'));
+        createDirectory(join(workspace, '.mvn', 'wrapper'));
+        createFile(
+          join(workspace, '.mvn', 'wrapper', 'maven-wrapper.properties')
+        );
         createStateForWrapperRestore('maven-wrapper', false);
-        spyCacheSave.mockImplementation((paths: string[], key: string) => {
-          if (paths.includes(join(os.homedir(), '.m2', 'wrapper', 'dists'))) {
-            return Promise.reject(
-              new cache.ValidationError('Path Validation Error')
-            );
-          }
-          return Promise.resolve(0);
-        });
+        spyGlobCreate.mockResolvedValue(createGlobber([]));
 
-        await expect(save('maven')).resolves.not.toThrow();
+        await expect(save('maven')).resolves.toBeUndefined();
+        expect(spyCacheSave).not.toHaveBeenCalledWith(
+          [join(os.homedir(), '.m2', 'wrapper', 'dists')],
+          expect.any(String)
+        );
+        expect(spyCacheSave).toHaveBeenCalledWith(
+          [join(os.homedir(), '.m2', 'repository')],
+          'setup-java-cache-primary-key'
+        );
+        expect(spyWarning).not.toHaveBeenCalled();
       });
     });
     describe('for gradle', () => {
@@ -552,6 +566,23 @@ describe('dependency cache', () => {
           [join(os.homedir(), '.gradle', 'wrapper')],
           expect.any(String)
         );
+      });
+      it('does not fail the post step when the wrapper distribution path is missing', async () => {
+        createFile(join(workspace, 'build.gradle'));
+        createFile(join(workspace, 'gradle-wrapper.properties'));
+        createStateForWrapperRestore('gradle-wrapper', false);
+        spyGlobCreate.mockResolvedValue(createGlobber([]));
+
+        await expect(save('gradle')).resolves.toBeUndefined();
+        expect(spyCacheSave).not.toHaveBeenCalledWith(
+          [join(os.homedir(), '.gradle', 'wrapper')],
+          expect.any(String)
+        );
+        expect(spyCacheSave).toHaveBeenCalledWith(
+          [join(os.homedir(), '.gradle', 'caches')],
+          'setup-java-cache-primary-key'
+        );
+        expect(spyWarning).not.toHaveBeenCalled();
       });
     });
     describe('for sbt', () => {
@@ -661,6 +692,20 @@ function createFile(path: string) {
 function createDirectory(path: string) {
   core.info(`created a directory at ${path}`);
   fs.mkdirSync(path);
+}
+
+function createGlobber(
+  paths: string[]
+): Awaited<ReturnType<typeof glob.create>> {
+  return {
+    getSearchPaths: () => [],
+    glob: () => Promise.resolve(paths),
+    globGenerator: async function* () {
+      for (const path of paths) {
+        yield path;
+      }
+    }
+  };
 }
 
 function projectRoot(workspace: string): string {

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -52207,6 +52207,14 @@ function saveAdditionalCache(packageManager, additionalCache) {
             core.info(`Cache hit occurred on the ${additionalCache.name} primary key ${primaryKey}, not saving cache.`);
             return;
         }
+        const globber = yield glob.create(additionalCache.path.join('\n'), {
+            implicitDescendants: false
+        });
+        const cachePaths = yield globber.glob();
+        if (cachePaths.length === 0) {
+            core.debug(`${additionalCache.name} cache paths do not exist, not saving cache.`);
+            return;
+        }
         try {
             const cacheId = yield cache.saveCache(additionalCache.path, primaryKey);
             if (cacheId === -1) {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -78072,6 +78072,14 @@ function saveAdditionalCache(packageManager, additionalCache) {
             core.info(`Cache hit occurred on the ${additionalCache.name} primary key ${primaryKey}, not saving cache.`);
             return;
         }
+        const globber = yield glob.create(additionalCache.path.join('\n'), {
+            implicitDescendants: false
+        });
+        const cachePaths = yield globber.glob();
+        if (cachePaths.length === 0) {
+            core.debug(`${additionalCache.name} cache paths do not exist, not saving cache.`);
+            return;
+        }
         try {
             const cacheId = yield cache.saveCache(additionalCache.path, primaryKey);
             if (cacheId === -1) {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -319,6 +319,18 @@ async function saveAdditionalCache(
     );
     return;
   }
+
+  const globber = await glob.create(additionalCache.path.join('\n'), {
+    implicitDescendants: false
+  });
+  const cachePaths = await globber.glob();
+  if (cachePaths.length === 0) {
+    core.debug(
+      `${additionalCache.name} cache paths do not exist, not saving cache.`
+    );
+    return;
+  }
+
   try {
     const cacheId = await cache.saveCache(additionalCache.path, primaryKey);
     if (cacheId === -1) {


### PR DESCRIPTION
**Description:**
Backports #1151 from `main` to `releases/v5`.

Projects can keep Maven or Gradle wrapper metadata while intentionally using the system build tool, leaving the wrapper distribution directory absent. The post action now resolves optional wrapper-cache paths before calling `@actions/cache`; when no path exists, it skips only that wrapper cache and continues saving the main dependency cache.

Regression tests cover both Maven and Gradle and verify that the main cache is still saved. The generated setup and cleanup bundles are rebuilt with the fix.

**Related issue:**
Source backport: #1151

Fixes: #1150

**Check list:**
- [x] Ran `npm run check` locally (format, lint, build, test) and all checks pass.
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.
