### PR TITLE
Reject invalid boolean input values

### DIFF
--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -57,8 +57,72 @@ const {
   isCacheFeatureAvailable,
   isGhes,
   validatePaginationUrl,
-  getLatestMajorVersion
+  getLatestMajorVersion,
+  getBooleanInput
 } = await import('../src/util.js');
+
+describe('getBooleanInput', () => {
+  let inputs: Record<string, string>;
+
+  beforeEach(() => {
+    inputs = {};
+    (core.getInput as jest.Mock).mockImplementation(
+      (name: string) => inputs[name] ?? ''
+    );
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it.each([
+    ['true', true],
+    ['TRUE', true],
+    ['TrUe', true],
+    [' true ', true],
+    ['false', false],
+    ['FALSE', false],
+    ['FaLsE', false],
+    [' false ', false]
+  ])('parses %j as %s', (value: string, expected: boolean) => {
+    inputs['boolean-input'] = value;
+
+    expect(getBooleanInput('boolean-input')).toBe(expected);
+  });
+
+  it.each([
+    [undefined, false],
+    [false, false],
+    [true, true]
+  ])(
+    'uses the configured default %s when the input is omitted',
+    (defaultValue: boolean | undefined, expected: boolean) => {
+      expect(getBooleanInput('boolean-input', defaultValue)).toBe(expected);
+    }
+  );
+
+  it('uses the configured default for a whitespace-only input', () => {
+    inputs['boolean-input'] = '   ';
+
+    expect(getBooleanInput('boolean-input', true)).toBe(true);
+  });
+
+  it.each([
+    'check-latest',
+    'force-download',
+    'set-default',
+    'verify-signature',
+    'overwrite-settings',
+    'show-download-progress',
+    'problem-matcher'
+  ])('rejects an invalid value for %s', inputName => {
+    inputs[inputName] = 'ture';
+
+    expect(() => getBooleanInput(inputName)).toThrow(
+      `Invalid value 'ture' for boolean input '${inputName}'. Expected 'true' or 'false'.`
+    );
+  });
+});
 
 describe('isVersionSatisfies', () => {
   it.each([

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -97365,7 +97365,18 @@ function getTempDir() {
     return tempDirectory;
 }
 function util_getBooleanInput(inputName, defaultValue = false) {
-    return ((core.getInput(inputName) || String(defaultValue)).toUpperCase() === 'TRUE');
+    const inputValue = core.getInput(inputName);
+    const normalizedValue = inputValue.trim().toLowerCase();
+    if (!normalizedValue) {
+        return defaultValue;
+    }
+    if (normalizedValue === 'true') {
+        return true;
+    }
+    if (normalizedValue === 'false') {
+        return false;
+    }
+    throw new Error(`Invalid value '${inputValue}' for boolean input '${inputName}'. Expected 'true' or 'false'.`);
 }
 function getVersionFromToolcachePath(toolPath) {
     if (toolPath) {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -128364,7 +128364,18 @@ function getTempDir() {
     return tempDirectory;
 }
 function util_getBooleanInput(inputName, defaultValue = false) {
-    return ((getInput(inputName) || String(defaultValue)).toUpperCase() === 'TRUE');
+    const inputValue = getInput(inputName);
+    const normalizedValue = inputValue.trim().toLowerCase();
+    if (!normalizedValue) {
+        return defaultValue;
+    }
+    if (normalizedValue === 'true') {
+        return true;
+    }
+    if (normalizedValue === 'false') {
+        return false;
+    }
+    throw new Error(`Invalid value '${inputValue}' for boolean input '${inputName}'. Expected 'true' or 'false'.`);
 }
 function getVersionFromToolcachePath(toolPath) {
     if (toolPath) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -20,8 +20,21 @@ export function getTempDir() {
 }
 
 export function getBooleanInput(inputName: string, defaultValue = false) {
-  return (
-    (core.getInput(inputName) || String(defaultValue)).toUpperCase() === 'TRUE'
+  const inputValue = core.getInput(inputName);
+  const normalizedValue = inputValue.trim().toLowerCase();
+
+  if (!normalizedValue) {
+    return defaultValue;
+  }
+  if (normalizedValue === 'true') {
+    return true;
+  }
+  if (normalizedValue === 'false') {
+    return false;
+  }
+
+  throw new Error(
+    `Invalid value '${inputValue}' for boolean input '${inputName}'. Expected 'true' or 'false'.`
   );
 }
 


### PR DESCRIPTION
**Description:**
Boolean input typos currently fall through as `false`, which can silently disable requested behavior. This change makes the shared parser accept only case-insensitive `true` or `false`, preserves existing defaults and whitespace handling, and reports the input name and invalid value for unsupported values.

The stricter behavior applies consistently to all seven boolean inputs that use the helper. The checked-in setup and cleanup bundles are rebuilt to match the TypeScript source.

**Related issue:**
Fixes: #1157

**Check list:**
- [x] Ran `npm run check` locally (format, lint, build, test) and all checks pass.
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.