### PR TITLE
Reduce change-time Java E2E matrix

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,0 +1,63 @@
+name: Validate Java e2e smoke
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+
+permissions:
+  contents: read
+
+jobs:
+  setup-java:
+    name: ${{ matrix.distribution }} ${{ matrix.version }} (${{ matrix.java-package }}) - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            distribution: temurin
+            version: '11'
+            java-package: jdk
+          - os: windows-latest
+            distribution: temurin
+            version: '17'
+            java-package: jdk
+          - os: ubuntu-latest
+            distribution: temurin
+            version: '21'
+            java-package: jdk
+          - os: ubuntu-latest
+            distribution: zulu
+            version: '17'
+            java-package: jre
+          - os: ubuntu-latest
+            distribution: liberica
+            version: '21'
+            java-package: jdk+fx
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: setup-java
+        uses: ./
+        id: setup-java
+        with:
+          java-version: ${{ matrix.version }}
+          java-package: ${{ matrix.java-package }}
+          distribution: ${{ matrix.distribution }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify Java
+        env:
+          JAVA_VERSION: ${{ matrix.version }}
+          JAVA_PATH: ${{ steps.setup-java.outputs.path }}
+        run: bash __tests__/verify-java.sh "$JAVA_VERSION" "$JAVA_PATH"
+        shell: bash

--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -3,11 +3,7 @@ name: Validate Java e2e
 on:
   push:
     branches:
-      - main
       - releases/*
-    paths-ignore:
-      - '**.md'
-  pull_request:
     paths-ignore:
       - '**.md'
   schedule:


### PR DESCRIPTION
## Summary
- run a representative Java installation smoke matrix on pull requests and main
- keep the exhaustive distribution, version, OS, and package matrix on its 12-hour schedule
- preserve full validation for manual runs and release branches

## Validation
- Prettier workflow formatting check
- YAML syntax parsing
- required status checks remain provided by the existing validation workflows