### PR TITLE
Test Temurin 25 on hosted runners

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -45,6 +45,18 @@ jobs:
             distribution: temurin
             version: '25'
             java-package: jdk
+          - os: macos-latest
+            distribution: microsoft
+            version: '25'
+            java-package: jdk
+          - os: windows-latest
+            distribution: microsoft
+            version: '25'
+            java-package: jdk
+          - os: ubuntu-latest
+            distribution: microsoft
+            version: '25'
+            java-package: jdk
           - os: ubuntu-latest
             distribution: zulu
             version: '17'

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -33,6 +33,18 @@ jobs:
             distribution: temurin
             version: '21'
             java-package: jdk
+          - os: macos-latest
+            distribution: temurin
+            version: '25'
+            java-package: jdk
+          - os: windows-latest
+            distribution: temurin
+            version: '25'
+            java-package: jdk
+          - os: ubuntu-latest
+            distribution: temurin
+            version: '25'
+            java-package: jdk
           - os: ubuntu-latest
             distribution: zulu
             version: '17'

--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ In the basic examples above, the `check-latest` flag defaults to `false`. When s
 
 If `check-latest` is set to `true`, the action first checks if the cached version is the latest one. If the locally cached version is not the most up-to-date, the latest version of Java will be downloaded. Set `check-latest` to `true` if you want the most up-to-date version of Java to always be used. Setting `check-latest` to `true` has performance implications as downloading versions of Java is slower than using cached versions.
 
+[GitHub-hosted runners](https://github.com/actions/runner-images) include Eclipse Adoptium's Temurin JDKs in their tool cache. To avoid downloading a JDK and reduce setup time, prefer `distribution: 'temurin'` with the default `check-latest: false` when a cached version meets your needs. Available versions depend on the selected runner image.
+
 For Java distributions that are not cached on Hosted images, `check-latest` always behaves as `true` and downloads Java on the fly. Check out [Hosted Tool Cache](docs/advanced-usage.md#Hosted-Tool-Cache) for more details about pre-cached Java versions.
 
 

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ In the basic examples above, the `check-latest` flag defaults to `false`. When s
 
 If `check-latest` is set to `true`, the action first checks if the cached version is the latest one. If the locally cached version is not the most up-to-date, the latest version of Java will be downloaded. Set `check-latest` to `true` if you want the most up-to-date version of Java to always be used. Setting `check-latest` to `true` has performance implications as downloading versions of Java is slower than using cached versions.
 
-[GitHub-hosted runners](https://github.com/actions/runner-images) include Eclipse Adoptium's Temurin JDKs in their tool cache. To avoid downloading a JDK and reduce setup time, prefer `distribution: 'temurin'` with the default `check-latest: false` when a cached version meets your needs. Available versions depend on the selected runner image.
+[GitHub-hosted runners](https://github.com/actions/runner-images) include Eclipse Temurin JDKs in their tool cache. Selecting Eclipse Temurin (`distribution: 'temurin'`) can save setup time by using a pre-installed JDK instead of downloading one. See the installed Java versions for [Ubuntu](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#java), [Windows](https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md#java), and [macOS](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#java).
 
 For Java distributions that are not cached on Hosted images, `check-latest` always behaves as `true` and downloads Java on the fly. Check out [Hosted Tool Cache](docs/advanced-usage.md#Hosted-Tool-Cache) for more details about pre-cached Java versions.
 

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -890,9 +890,9 @@ See the help docs on [Publishing a Package with Gradle](https://help.github.com/
 ## Hosted Tool Cache
 GitHub Hosted Runners have a tool cache that comes with some Java versions pre-installed. This tool cache helps speed up runs and tool setup by not requiring any new downloads. There is an environment variable called `RUNNER_TOOL_CACHE` on each runner that describes the location of this tools cache and this is where you can find the pre-installed versions of Java. `setup-java` works by taking a specific version of Java in this tool cache and adding it to PATH if the version, architecture and distribution match.
 
-Currently, LTS versions of Eclipse Adoptium's Temurin JDKs (`temurin`) are cached on GitHub-hosted runners. To avoid downloading a JDK, use the `temurin` distribution with the default `check-latest: false` when a cached version meets your needs.
+Currently, LTS versions of Eclipse Temurin (`temurin`) are cached on GitHub-hosted runners. Using a cached version avoids downloading a JDK.
 
-The tools cache gets updated on a weekly basis. For information regarding locally cached versions of Java on GitHub-hosted runners, check out the [GitHub Actions runner images repository](https://github.com/actions/runner-images).
+The tools cache gets updated on a weekly basis. See the installed Java versions for [Ubuntu](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#java), [Windows](https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md#java), and [macOS](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#java).
 
 ## Modifying Maven Toolchains
 The `setup-java` action generates a basic [Maven Toolchains declaration](https://maven.apache.org/guides/mini/guide-using-toolchains.html) for specified Java versions by either creating a minimal toolchains file or extending an existing declaration with the additional JDKs.

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -890,9 +890,9 @@ See the help docs on [Publishing a Package with Gradle](https://help.github.com/
 ## Hosted Tool Cache
 GitHub Hosted Runners have a tool cache that comes with some Java versions pre-installed. This tool cache helps speed up runs and tool setup by not requiring any new downloads. There is an environment variable called `RUNNER_TOOL_CACHE` on each runner that describes the location of this tools cache and this is where you can find the pre-installed versions of Java. `setup-java` works by taking a specific version of Java in this tool cache and adding it to PATH if the version, architecture and distribution match.
 
-Currently, LTS versions of Eclipse Temurin (`temurin`) are cached on the GitHub Hosted Runners.
+Currently, LTS versions of Eclipse Adoptium's Temurin JDKs (`temurin`) are cached on GitHub-hosted runners. To avoid downloading a JDK, use the `temurin` distribution with the default `check-latest: false` when a cached version meets your needs.
 
-The tools cache gets updated on a weekly basis. For information regarding locally cached versions of Java on GitHub hosted runners, check out [GitHub Actions Virtual Environments](https://github.com/actions/virtual-environments).
+The tools cache gets updated on a weekly basis. For information regarding locally cached versions of Java on GitHub-hosted runners, check out the [GitHub Actions runner images repository](https://github.com/actions/runner-images).
 
 ## Modifying Maven Toolchains
 The `setup-java` action generates a basic [Maven Toolchains declaration](https://maven.apache.org/guides/mini/guide-using-toolchains.html) for specified Java versions by either creating a minimal toolchains file or extending an existing declaration with the additional JDKs.


### PR DESCRIPTION
## Summary
- add Eclipse Temurin JDK 25 smoke cases on Ubuntu, Windows, and macOS to exercise the hosted tool-cache path
- add Microsoft Build of OpenJDK 25 cases on the same runners to exercise the download path
- highlight that GitHub-hosted runners include pre-installed Eclipse Temurin JDKs
- link directly to the Java sections of the Ubuntu, Windows, and macOS installed-software lists

## Validation
The hosted smoke workflow confirmed Eclipse Temurin 25 resolved from the tool cache and Microsoft OpenJDK 25 downloaded successfully on Ubuntu, Windows, and macOS.