### PR TITLE
Fix CodeQL comment tag filter finding

### DIFF
--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -60140,7 +60140,7 @@ const XML_PATTERNS = [
   {
     id: 'xml-comment-close',
     description: '--> closes an enclosing XML comment',
-    pattern: /-->/,
+    pattern: /--!?>/,
   },
   {
     id: 'xml-pi-close',

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -91195,7 +91195,7 @@ const XML_PATTERNS = [
   {
     id: 'xml-comment-close',
     description: '--> closes an enclosing XML comment',
-    pattern: /-->/,
+    pattern: /--!?>/,
   },
   {
     id: 'xml-pi-close',

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "node": ">=24.0.0"
   },
   "scripts": {
-    "build": "ncc build -o dist/setup src/setup-java.ts && ncc build -o dist/cleanup src/cleanup-java.ts",
+    "build": "node scripts/patch-is-unsafe.mjs && ncc build -o dist/setup src/setup-java.ts && ncc build -o dist/cleanup src/cleanup-java.ts",
     "format": "prettier --no-error-on-unmatched-pattern --write \"**/*.{ts,yml,yaml}\"",
     "format-check": "prettier --no-error-on-unmatched-pattern --check \"**/*.{ts,yml,yaml}\"",
     "lint": "eslint \"**/*.ts\"",

--- a/scripts/patch-is-unsafe.mjs
+++ b/scripts/patch-is-unsafe.mjs
@@ -1,0 +1,20 @@
+import {readFile, writeFile} from 'node:fs/promises';
+
+const sourcePath = new URL('../node_modules/is-unsafe/src/contexts/xml.js', import.meta.url);
+const vulnerablePattern = 'pattern: /-->/,';
+const safePattern = 'pattern: /--!?>/,';
+const source = await readFile(sourcePath, 'utf8');
+
+// CodeQL treats this XML detector as an incomplete HTML comment-end filter.
+if (source.includes(safePattern)) {
+  process.exit(0);
+}
+
+const occurrences = source.split(vulnerablePattern).length - 1;
+if (occurrences !== 1) {
+  throw new Error(
+    `Expected one ${JSON.stringify(vulnerablePattern)} in ${sourcePath.pathname}, found ${occurrences}`
+  );
+}
+
+await writeFile(sourcePath, source.replace(vulnerablePattern, safePattern));


### PR DESCRIPTION
## Summary
- patch the transitive `is-unsafe` XML comment-close detector during builds to recognize `--!>` as well as `-->`
- fail fast if the dependency source changes unexpectedly
- regenerate setup and cleanup distributions

## Dependency path
`@actions/cache` → `@azure/storage-blob` → `@azure/core-xml` → `fast-xml-parser` → `is-unsafe`

## Validation
- `npm run check`
- verified both generated bundles contain `/--!?>/` and no longer contain `/-->/`