### PR TITLE
Fix macOS e2e workflow assertions

### DIFF
--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -290,10 +290,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify Java env variables
         run: |
+          $javaArch = if ($env:RUNNER_ARCH -eq "ARM64") { "AARCH64" } else { $env:RUNNER_ARCH }
           $versionsArr = "11","17"
           foreach ($version in $versionsArr)
           {
-            $envName = "JAVA_HOME_${version}_${env:RUNNER_ARCH}"
+            $envName = "JAVA_HOME_${version}_${javaArch}"
             $JavaVersionPath = [Environment]::GetEnvironmentVariable($envName)
             if (-not (Test-Path "$JavaVersionPath")) {
               Write-Host "$envName is not found"
@@ -582,6 +583,9 @@ jobs:
         os: *default_os
         distribution: ['adopt', 'adopt-openj9', 'zulu']
         java-version-file: ['.java-version', '.tool-versions']
+        exclude:
+          - os: macos-latest
+            distribution: adopt-openj9
     steps:
       - *checkout_step
       - name: Create .java-version file
@@ -683,7 +687,8 @@ jobs:
         shell: bash
       - name: Verify JAVA_HOME_21 env var is set
         run: |
-          $envName = "JAVA_HOME_21_${env:RUNNER_ARCH}"
+          $javaArch = if ($env:RUNNER_ARCH -eq "ARM64") { "AARCH64" } else { $env:RUNNER_ARCH }
+          $envName = "JAVA_HOME_21_${javaArch}"
           $JavaVersionPath = [Environment]::GetEnvironmentVariable($envName)
           if (-not $JavaVersionPath) {
             Write-Host "$envName is not set"


### PR DESCRIPTION
**Description:**
The macOS e2e workflow was failing after `macos-latest` resolved to an arm64 runner. The action exports Java home variables using `AARCH64`, while the workflow assertions used the runner label `ARM64`, so the checks looked for the wrong environment variable names.

This normalizes the workflow assertions from `ARM64` to `AARCH64` before checking `JAVA_HOME_*` variables. It also excludes the unsupported `adopt-openj9` + `macos-latest` version-file matrix entry, since adopt-openj9 does not provide macOS arm64 builds for that Java version.

**Related issue:**
N/A

**Check list:**
- [ ] Ran `npm run check` locally (format, lint, build, test) and all checks pass.
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.