### PR TITLE
Deprecate legacy Adopt distributions in v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ Currently, the following distributions are supported:
 |-|-|-|
 | `temurin` | [Eclipse Temurin](https://adoptium.net/) | [`temurin` license](https://adoptium.net/about.html)
 | `zulu` | [Azul Zulu OpenJDK](https://www.azul.com/downloads/zulu-community/?package=jdk) | [`zulu` license](https://www.azul.com/products/zulu-and-zulu-enterprise/zulu-terms-of-use/) |
-| `adopt` or `adopt-hotspot` | [AdoptOpenJDK Hotspot](https://adoptopenjdk.net/) | [`adopt-hotspot` license](https://adoptopenjdk.net/about.html) |
-| `adopt-openj9` | [AdoptOpenJDK OpenJ9](https://adoptopenjdk.net/) | [`adopt-openj9` license](https://adoptopenjdk.net/about.html) |
+| `adopt` or `adopt-hotspot` (deprecated; use `temurin`) | [AdoptOpenJDK Hotspot](https://adoptopenjdk.net/) | [`adopt-hotspot` license](https://adoptopenjdk.net/about.html) |
+| `adopt-openj9` (deprecated; use `semeru`) | [AdoptOpenJDK OpenJ9](https://adoptopenjdk.net/) | [`adopt-openj9` license](https://adoptopenjdk.net/about.html) |
 | `liberica` | [Liberica JDK](https://bell-sw.com/) | [`liberica` license](https://bell-sw.com/liberica_eula/) |
 | `microsoft` | [Microsoft Build of OpenJDK](https://www.microsoft.com/openjdk) | [`microsoft` license](https://docs.microsoft.com/java/openjdk/faq)
 | `corretto` | [Amazon Corretto Build of OpenJDK](https://aws.amazon.com/corretto/) | [`corretto` license](https://aws.amazon.com/corretto/faqs/)
@@ -125,7 +125,7 @@ Currently, the following distributions are supported:
 
 > [!NOTE]
 > - The different distributors can provide discrepant list of available versions / supported configurations. Please refer to the official documentation to see the list of supported versions.
-> - AdoptOpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from `adopt` and `adopt-openj9`, to `temurin` and `semeru` respectively, to keep receiving software and security updates. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).
+> - The legacy AdoptOpenJDK distributions are deprecated in setup-java v5 and will be removed in setup-java v6. Migrate `adopt` and `adopt-hotspot` to `temurin`, and `adopt-openj9` to `semeru`, to keep receiving software and security updates. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).
 > - For Azul Zulu OpenJDK, architecture `arm64` is mapped to `aarch64` when querying the Azul Metadata API.
 > - To comply with the GraalVM Free Terms and Conditions (GFTC) license, it is recommended to use GraalVM JDK 17 version 17.0.12, as this is the only version of GraalVM JDK 17 available under the GFTC license. Additionally, it is encouraged to consider upgrading to GraalVM JDK 21, which offers the latest features and improvements.
 > - GraalVM Community is available as `distribution: 'graalvm-community'` for stable JDK 17 and later releases published on GitHub.

--- a/__tests__/distributors/distribution-factory.test.ts
+++ b/__tests__/distributors/distribution-factory.test.ts
@@ -1,0 +1,51 @@
+import * as core from '@actions/core';
+import {
+  AdoptDistribution,
+  AdoptImplementation
+} from '../../src/distributions/adopt/installer';
+import {JavaInstallerOptions} from '../../src/distributions/base-models';
+import {getJavaDistribution} from '../../src/distributions/distribution-factory';
+
+describe('getJavaDistribution', () => {
+  const installerOptions: JavaInstallerOptions = {
+    version: '11',
+    architecture: 'x64',
+    packageType: 'jdk',
+    checkLatest: false
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    ['adopt', AdoptImplementation.Hotspot, 'temurin'],
+    ['adopt-hotspot', AdoptImplementation.Hotspot, 'temurin'],
+    ['adopt-openj9', AdoptImplementation.OpenJ9, 'semeru']
+  ])(
+    'warns that %s is deprecated while preserving its installer',
+    (
+      distributionName: string,
+      implementation: AdoptImplementation,
+      replacement: string
+    ) => {
+      const warningSpy = jest
+        .spyOn(core, 'warning')
+        .mockImplementation(() => {});
+
+      const distribution = getJavaDistribution(
+        distributionName,
+        installerOptions
+      );
+
+      expect(distribution).toBeInstanceOf(AdoptDistribution);
+      if (!(distribution instanceof AdoptDistribution)) {
+        throw new Error(`Expected an Adopt installer for ${distributionName}`);
+      }
+      expect(distribution['jvmImpl']).toBe(implementation);
+      expect(warningSpy).toHaveBeenCalledWith(
+        `The '${distributionName}' legacy AdoptOpenJDK distribution is deprecated and will be removed in setup-java v6. Please migrate to the '${replacement}' distribution.`
+      );
+    }
+  );
+});

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: 'The path to a file containing the Java version to set up (.java-version, .tool-versions, .sdkmanrc). Used when java-version is not set. See examples of supported syntax in README file'
     required: false
   distribution:
-    description: 'Java distribution. See the list of supported distributions in README file. This input is required except when java-version-file points to .sdkmanrc with a recognized distribution suffix (e.g., java=21.0.5-tem).'
+    description: 'Java distribution. See the list of supported distributions in README file. Legacy AdoptOpenJDK values (adopt, adopt-hotspot, adopt-openj9) are deprecated and will be removed in setup-java v6. This input is required except when java-version-file points to .sdkmanrc with a recognized distribution suffix (e.g., java=21.0.5-tem).'
     required: false
   java-package:
     description: 'The package type (jdk, jre, jdk+fx, jre+fx, jdk+crac, jre+crac)'

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -76905,9 +76905,6 @@ class AdoptDistribution extends base_installer_1.JavaBase {
     }
     findPackageForDownload(version) {
         return __awaiter(this, void 0, void 0, function* () {
-            if (this.jvmImpl === AdoptImplementation.Hotspot) {
-                core.notice("AdoptOpenJDK has moved to Eclipse Temurin https://github.com/actions/setup-java#supported-distributions please consider changing to the 'temurin' distribution type in your setup-java configuration.");
-            }
             if (this.jvmImpl === AdoptImplementation.Hotspot &&
                 this.temurinDistribution !== null) {
                 try {
@@ -77560,12 +77557,36 @@ exports.CorrettoDistribution = CorrettoDistribution;
 /***/ }),
 
 /***/ 2970:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getJavaDistribution = void 0;
+const core = __importStar(__nccwpck_require__(37484));
 const installer_1 = __nccwpck_require__(21019);
 const installer_2 = __nccwpck_require__(41978);
 const installer_3 = __nccwpck_require__(37874);
@@ -77606,8 +77627,10 @@ function getJavaDistribution(distributionName, installerOptions, jdkFile) {
             return new installer_1.LocalDistribution(installerOptions, jdkFile);
         case JavaDistribution.Adopt:
         case JavaDistribution.AdoptHotspot:
+            warnIfAdoptDistributionIsDeprecated(distributionName, 'temurin');
             return new installer_3.AdoptDistribution(installerOptions, installer_3.AdoptImplementation.Hotspot);
         case JavaDistribution.AdoptOpenJ9:
+            warnIfAdoptDistributionIsDeprecated(distributionName, 'semeru');
             return new installer_3.AdoptDistribution(installerOptions, installer_3.AdoptImplementation.OpenJ9);
         case JavaDistribution.Temurin:
             return new installer_4.TemurinDistribution(installerOptions, installer_4.TemurinImplementation.Hotspot);
@@ -77640,6 +77663,9 @@ function getJavaDistribution(distributionName, installerOptions, jdkFile) {
     }
 }
 exports.getJavaDistribution = getJavaDistribution;
+function warnIfAdoptDistributionIsDeprecated(distributionName, replacement) {
+    core.warning(`The '${distributionName}' legacy AdoptOpenJDK distribution is deprecated and will be removed in setup-java v6. Please migrate to the '${replacement}' distribution.`);
+}
 
 
 /***/ }),

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -46,7 +46,7 @@ steps:
 ```
 
 ### Adopt
-**NOTE:** Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from `adopt` to `temurin` to keep receiving software and security updates. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).
+**NOTE:** The legacy `adopt`, `adopt-hotspot`, and `adopt-openj9` distributions are deprecated in setup-java v5 and will be removed in setup-java v6. Migrate `adopt` and `adopt-hotspot` to `temurin`, and `adopt-openj9` to `semeru`, to keep receiving software and security updates. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).
 
 ```yaml
 steps:
@@ -953,4 +953,3 @@ Notes and caveats:
 - Prefer giving the certificate a stable, descriptive `-alias` so re-runs are idempotent (re-importing the same alias will fail; add `keytool -delete -alias internal-ca ...` first if you re-run within a long-lived runner).
 
 This documents the post-install workflow; there is no dedicated action input for supplying a custom `cacerts` file.
-

--- a/src/distributions/adopt/installer.ts
+++ b/src/distributions/adopt/installer.ts
@@ -59,12 +59,6 @@ export class AdoptDistribution extends JavaBase {
   protected async findPackageForDownload(
     version: string
   ): Promise<JavaDownloadRelease> {
-    if (this.jvmImpl === AdoptImplementation.Hotspot) {
-      core.notice(
-        "AdoptOpenJDK has moved to Eclipse Temurin https://github.com/actions/setup-java#supported-distributions please consider changing to the 'temurin' distribution type in your setup-java configuration."
-      );
-    }
-
     if (
       this.jvmImpl === AdoptImplementation.Hotspot &&
       this.temurinDistribution !== null

--- a/src/distributions/distribution-factory.ts
+++ b/src/distributions/distribution-factory.ts
@@ -1,3 +1,4 @@
+import * as core from '@actions/core';
 import {JavaBase} from './base-installer';
 import {JavaInstallerOptions} from './base-models';
 import {LocalDistribution} from './local/installer';
@@ -48,11 +49,13 @@ export function getJavaDistribution(
       return new LocalDistribution(installerOptions, jdkFile);
     case JavaDistribution.Adopt:
     case JavaDistribution.AdoptHotspot:
+      warnIfAdoptDistributionIsDeprecated(distributionName, 'temurin');
       return new AdoptDistribution(
         installerOptions,
         AdoptImplementation.Hotspot
       );
     case JavaDistribution.AdoptOpenJ9:
+      warnIfAdoptDistributionIsDeprecated(distributionName, 'semeru');
       return new AdoptDistribution(
         installerOptions,
         AdoptImplementation.OpenJ9
@@ -89,4 +92,13 @@ export function getJavaDistribution(
     default:
       return null;
   }
+}
+
+function warnIfAdoptDistributionIsDeprecated(
+  distributionName: string,
+  replacement: string
+): void {
+  core.warning(
+    `The '${distributionName}' legacy AdoptOpenJDK distribution is deprecated and will be removed in setup-java v6. Please migrate to the '${replacement}' distribution.`
+  );
 }


### PR DESCRIPTION
## Summary
- preserve `adopt`, `adopt-hotspot`, and `adopt-openj9` runtime support
- warn that the legacy distributions will be removed in v6 and recommend `temurin` or `semeru`
- document the v5 deprecation and regenerate the bundled action

## Testing
- `npm test -- --runInBand`
- `npm run format-check`
- `npm run lint`
- `npm run build`