### PR TITLE
Deprecate legacy Adopt distributions in v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ Currently, the following distributions are supported:
 |-|-|-|-|
 | `temurin` | Eclipse Temurin | [Link](https://adoptium.net/) | [Link](https://adoptium.net/about.html)
 | `zulu` | Azul Zulu OpenJDK | [Link](https://www.azul.com/downloads/zulu-community/?package=jdk) | [Link](https://www.azul.com/products/zulu-and-zulu-enterprise/zulu-terms-of-use/) |
-| `adopt` or `adopt-hotspot` | AdoptOpenJDK Hotspot | [Link](https://adoptopenjdk.net/) | [Link](https://adoptopenjdk.net/about.html) |
-| `adopt-openj9` | AdoptOpenJDK OpenJ9 | [Link](https://adoptopenjdk.net/) | [Link](https://adoptopenjdk.net/about.html) |
+| `adopt` or `adopt-hotspot` (deprecated; use `temurin`) | AdoptOpenJDK Hotspot | [Link](https://adoptopenjdk.net/) | [Link](https://adoptopenjdk.net/about.html) |
+| `adopt-openj9` (deprecated; use `semeru`) | AdoptOpenJDK OpenJ9 | [Link](https://adoptopenjdk.net/) | [Link](https://adoptopenjdk.net/about.html) |
 | `liberica` | Liberica JDK | [Link](https://bell-sw.com/) | [Link](https://bell-sw.com/liberica_eula/) |
 | `microsoft` | Microsoft Build of OpenJDK | [Link](https://www.microsoft.com/openjdk) | [Link](https://docs.microsoft.com/java/openjdk/faq)
 | `corretto` | Amazon Corretto Build of OpenJDK | [Link](https://aws.amazon.com/corretto/) | [Link](https://aws.amazon.com/corretto/faqs/)
@@ -114,7 +114,7 @@ Currently, the following distributions are supported:
 
 **NOTE:** The different distributors can provide discrepant list of available versions / supported configurations. Please refer to the official documentation to see the list of supported versions.
 
-**NOTE:** AdoptOpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from `adopt` and `adopt-openj9`, to `temurin` and `semeru` respectively, to keep receiving software and security updates. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).
+**NOTE:** The legacy AdoptOpenJDK distributions are deprecated and will be removed in setup-java v6. Migrate `adopt` and `adopt-hotspot` to `temurin`, and `adopt-openj9` to `semeru`, to keep receiving software and security updates. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).
 
 **NOTE:** For Azul Zulu OpenJDK architectures x64 and arm64 are mapped to x86 / arm with proper hw_bitness.
 

--- a/__tests__/distributors/distribution-factory.test.ts
+++ b/__tests__/distributors/distribution-factory.test.ts
@@ -1,0 +1,51 @@
+import * as core from '@actions/core';
+import {
+  AdoptDistribution,
+  AdoptImplementation
+} from '../../src/distributions/adopt/installer';
+import {JavaInstallerOptions} from '../../src/distributions/base-models';
+import {getJavaDistribution} from '../../src/distributions/distribution-factory';
+
+describe('getJavaDistribution', () => {
+  const installerOptions: JavaInstallerOptions = {
+    version: '11',
+    architecture: 'x64',
+    packageType: 'jdk',
+    checkLatest: false
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    ['adopt', AdoptImplementation.Hotspot, 'temurin'],
+    ['adopt-hotspot', AdoptImplementation.Hotspot, 'temurin'],
+    ['adopt-openj9', AdoptImplementation.OpenJ9, 'semeru']
+  ])(
+    'warns that %s is deprecated while preserving its installer',
+    (
+      distributionName: string,
+      implementation: AdoptImplementation,
+      replacement: string
+    ) => {
+      const warningSpy = jest
+        .spyOn(core, 'warning')
+        .mockImplementation(() => {});
+
+      const distribution = getJavaDistribution(
+        distributionName,
+        installerOptions
+      );
+
+      expect(distribution).toBeInstanceOf(AdoptDistribution);
+      if (!(distribution instanceof AdoptDistribution)) {
+        throw new Error(`Expected an Adopt installer for ${distributionName}`);
+      }
+      expect(distribution['jvmImpl']).toBe(implementation);
+      expect(warningSpy).toHaveBeenCalledWith(
+        `The '${distributionName}' legacy AdoptOpenJDK distribution is deprecated and will be removed in setup-java v6. Please migrate to the '${replacement}' distribution.`
+      );
+    }
+  );
+});

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   java-version-file:
     description: 'The path to the `.java-version` file. See examples of supported syntax in README file'
   distribution:
-    description: 'Java distribution. See the list of supported distributions in README file'
+    description: 'Java distribution. See the list of supported distributions in README file. Legacy AdoptOpenJDK values (adopt, adopt-hotspot, adopt-openj9) are deprecated and will be removed in setup-java v6.'
     required: true
   java-package:
     description: 'The package type (jdk, jre, jdk+fx, jre+fx)'

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -134594,12 +134594,36 @@ exports.CorrettoDistribution = CorrettoDistribution;
 /***/ }),
 
 /***/ 10924:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getJavaDistribution = void 0;
+const core = __importStar(__nccwpck_require__(42186));
 const installer_1 = __nccwpck_require__(19917);
 const installer_2 = __nccwpck_require__(82005);
 const installer_3 = __nccwpck_require__(68766);
@@ -134637,8 +134661,10 @@ function getJavaDistribution(distributionName, installerOptions, jdkFile) {
             return new installer_1.LocalDistribution(installerOptions, jdkFile);
         case JavaDistribution.Adopt:
         case JavaDistribution.AdoptHotspot:
+            warnIfAdoptDistributionIsDeprecated(distributionName, 'temurin');
             return new installer_3.AdoptDistribution(installerOptions, installer_3.AdoptImplementation.Hotspot);
         case JavaDistribution.AdoptOpenJ9:
+            warnIfAdoptDistributionIsDeprecated(distributionName, 'semeru');
             return new installer_3.AdoptDistribution(installerOptions, installer_3.AdoptImplementation.OpenJ9);
         case JavaDistribution.Temurin:
             return new installer_4.TemurinDistribution(installerOptions, installer_4.TemurinImplementation.Hotspot);
@@ -134667,6 +134693,9 @@ function getJavaDistribution(distributionName, installerOptions, jdkFile) {
     }
 }
 exports.getJavaDistribution = getJavaDistribution;
+function warnIfAdoptDistributionIsDeprecated(distributionName, replacement) {
+    core.warning(`The '${distributionName}' legacy AdoptOpenJDK distribution is deprecated and will be removed in setup-java v6. Please migrate to the '${replacement}' distribution.`);
+}
 
 
 /***/ }),

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -40,7 +40,7 @@ steps:
 ```
 
 ### Adopt
-**NOTE:** Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from `adopt` to `temurin` to keep receiving software and security updates. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).
+**NOTE:** The legacy `adopt`, `adopt-hotspot`, and `adopt-openj9` distributions are deprecated and will be removed in setup-java v6. Migrate `adopt` and `adopt-hotspot` to `temurin`, and `adopt-openj9` to `semeru`, to keep receiving software and security updates. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).
 
 ```yaml
 steps:

--- a/src/distributions/distribution-factory.ts
+++ b/src/distributions/distribution-factory.ts
@@ -1,3 +1,4 @@
+import * as core from '@actions/core';
 import {JavaBase} from './base-installer';
 import {JavaInstallerOptions} from './base-models';
 import {LocalDistribution} from './local/installer';
@@ -42,11 +43,13 @@ export function getJavaDistribution(
       return new LocalDistribution(installerOptions, jdkFile);
     case JavaDistribution.Adopt:
     case JavaDistribution.AdoptHotspot:
+      warnIfAdoptDistributionIsDeprecated(distributionName, 'temurin');
       return new AdoptDistribution(
         installerOptions,
         AdoptImplementation.Hotspot
       );
     case JavaDistribution.AdoptOpenJ9:
+      warnIfAdoptDistributionIsDeprecated(distributionName, 'semeru');
       return new AdoptDistribution(
         installerOptions,
         AdoptImplementation.OpenJ9
@@ -79,4 +82,13 @@ export function getJavaDistribution(
     default:
       return null;
   }
+}
+
+function warnIfAdoptDistributionIsDeprecated(
+  distributionName: string,
+  replacement: string
+): void {
+  core.warning(
+    `The '${distributionName}' legacy AdoptOpenJDK distribution is deprecated and will be removed in setup-java v6. Please migrate to the '${replacement}' distribution.`
+  );
 }


### PR DESCRIPTION
## Summary
- preserve runtime support for `adopt`, `adopt-hotspot`, and `adopt-openj9`
- warn that these legacy distributions will be removed in v6 and recommend `temurin` or `semeru`
- document the deprecation and regenerate the bundled action

Rebased onto `releases/v4` after #1188 restored the dependency audit checks.

## Testing
- `npm test -- --runInBand __tests__/distributors/distribution-factory.test.ts`
- `npm run format-check`
- `npm run lint`
- `npm run build`
- `npm audit --audit-level=high`
- `npm test -- --runInBand --forceExit`