### PR TITLE
chore(deps): ignore TypeScript major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: 'weekly'
+    ignore:
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: 'github-actions'


### PR DESCRIPTION
## Summary

- ignore semver-major Dependabot updates for `typescript`
- continue allowing TypeScript 6 minor and patch updates

TypeScript 7 does not currently expose the compiler API required by typescript-eslint and ncc. This suppresses major upgrade PRs until the TypeScript 7 tooling ecosystem is ready.