### PR TITLE
Deprecate setup-java v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,7 @@
 name: 'Setup Java JDK'
 description: 'Set up a specific version of the Java JDK and add the
    command-line tools to the PATH'
+deprecationMessage: 'setup-java v4 is deprecated and will no longer receive updates. Please migrate to actions/setup-java@v5.'
 author: 'GitHub'
 inputs:
   java-version:

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -136768,9 +136768,11 @@ const constants = __importStar(__nccwpck_require__(69042));
 const cache_1 = __nccwpck_require__(64810);
 const path = __importStar(__nccwpck_require__(71017));
 const distribution_factory_1 = __nccwpck_require__(10924);
+const DEPRECATION_WARNING = 'setup-java v4 is deprecated and will no longer receive updates. Please migrate to actions/setup-java@v5.';
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
+            core.warning(DEPRECATION_WARNING);
             const versions = core.getMultilineInput(constants.INPUT_JAVA_VERSION);
             const distributionName = core.getInput(constants.INPUT_DISTRIBUTION, {
                 required: true

--- a/src/setup-java.ts
+++ b/src/setup-java.ts
@@ -13,8 +13,13 @@ import * as path from 'path';
 import {getJavaDistribution} from './distributions/distribution-factory';
 import {JavaInstallerOptions} from './distributions/base-models';
 
+const DEPRECATION_WARNING =
+  'setup-java v4 is deprecated and will no longer receive updates. Please migrate to actions/setup-java@v5.';
+
 async function run() {
   try {
+    core.warning(DEPRECATION_WARNING);
+
     const versions = core.getMultilineInput(constants.INPUT_JAVA_VERSION);
     const distributionName = core.getInput(constants.INPUT_DISTRIBUTION, {
       required: true


### PR DESCRIPTION
**Description:**
setup-java v4 is being deprecated, so users should receive clear guidance that this release line will no longer receive updates. This adds GitHub Actions deprecation metadata and emits a runtime warning directing users to migrate to `actions/setup-java@v5`.

The checked-in `dist/setup` bundle is rebuilt so the warning is present when v4 runs.

**Related issue:**
N/A

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.