### PR TITLE
Deprecate setup-java v2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,7 @@
 name: 'Setup Java JDK'
 description: 'Set up a specific version of the Java JDK and add the
    command-line tools to the PATH'
+deprecationMessage: 'setup-java v2 is deprecated and will no longer receive updates. Please migrate to actions/setup-java@v5.'
 author: 'GitHub'
 inputs:
   java-version:

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -85156,9 +85156,11 @@ const constants = __importStar(__webpack_require__(694));
 const cache_1 = __webpack_require__(319);
 const path = __importStar(__webpack_require__(622));
 const distribution_factory_1 = __webpack_require__(729);
+const DEPRECATION_WARNING = 'setup-java v2 is deprecated and will no longer receive updates. Please migrate to actions/setup-java@v5.';
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
+            core.warning(DEPRECATION_WARNING);
             const version = core.getInput(constants.INPUT_JAVA_VERSION, { required: true });
             const distributionName = core.getInput(constants.INPUT_DISTRIBUTION, { required: true });
             const architecture = core.getInput(constants.INPUT_ARCHITECTURE);

--- a/src/setup-java.ts
+++ b/src/setup-java.ts
@@ -7,8 +7,13 @@ import * as path from 'path';
 import { getJavaDistribution } from './distributions/distribution-factory';
 import { JavaInstallerOptions } from './distributions/base-models';
 
+const DEPRECATION_WARNING =
+  'setup-java v2 is deprecated and will no longer receive updates. Please migrate to actions/setup-java@v5.';
+
 async function run() {
   try {
+    core.warning(DEPRECATION_WARNING);
+
     const version = core.getInput(constants.INPUT_JAVA_VERSION, { required: true });
     const distributionName = core.getInput(constants.INPUT_DISTRIBUTION, { required: true });
     const architecture = core.getInput(constants.INPUT_ARCHITECTURE);


### PR DESCRIPTION
**Description:**
Deprecates setup-java v2, which will no longer receive updates. Users should migrate to `actions/setup-java@v5`. The action metadata and runtime logs now display the deprecation notice.

**Related issue:**
N/A

**Check list:**
- [x] Documentation changes are not required.
- [x] Existing tests cover the unchanged setup behavior; no test changes are required.