### PR TITLE
Deprecate setup-java v1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,7 @@
 name: 'Setup Java JDK'
 description: 'Set up a specific version of the Java JDK and add the
    command-line tools to the PATH'
+deprecationMessage: 'setup-java v1 is deprecated and will no longer receive updates. Please migrate to actions/setup-java@v5.'
 author: 'GitHub'
 inputs:
   java-version:

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -30603,9 +30603,11 @@ const auth = __importStar(__webpack_require__(331));
 const gpg = __importStar(__webpack_require__(884));
 const constants = __importStar(__webpack_require__(694));
 const path = __importStar(__webpack_require__(622));
+const DEPRECATION_WARNING = 'setup-java v1 is deprecated and will no longer receive updates. Please migrate to actions/setup-java@v5.';
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
+            core.warning(DEPRECATION_WARNING);
             let version = core.getInput(constants.INPUT_VERSION);
             if (!version) {
                 version = core.getInput(constants.INPUT_JAVA_VERSION, { required: true });

--- a/src/setup-java.ts
+++ b/src/setup-java.ts
@@ -5,8 +5,13 @@ import * as gpg from './gpg';
 import * as constants from './constants';
 import * as path from 'path';
 
+const DEPRECATION_WARNING =
+  'setup-java v1 is deprecated and will no longer receive updates. Please migrate to actions/setup-java@v5.';
+
 async function run() {
   try {
+    core.warning(DEPRECATION_WARNING);
+
     let version = core.getInput(constants.INPUT_VERSION);
     if (!version) {
       version = core.getInput(constants.INPUT_JAVA_VERSION, {required: true});


### PR DESCRIPTION
## Description

Deprecates setup-java v1, which will no longer receive updates, and directs users to migrate to `actions/setup-java@v5`. The notice is exposed through action metadata and emitted as a runtime warning in workflow logs.

## Validation

- `NODE_OPTIONS=--openssl-legacy-provider npm run build`
- `npm run format-check`
- `npm test -- --runInBand` (22/24 passed; two legacy installer tests failed because of downloaded JDK fixture/cache behavior in the current environment)