### PR TITLE
Highlight major changes in setup-java v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ steps:
 ### V6 (in development)
 
 - Migrated the action implementation to ESM to support the latest `@actions/*` packages.
-- Added the `oracle-openjdk` distribution and `java-version: latest` for resolving the newest stable GA release.
-- JDK downloads now automatically verify vendor-published checksums.
+- Added the `oracle-openjdk` distribution for OpenJDK builds from Oracle.
+- Added `java-version: latest` to resolve the newest stable GA release from the distribution's remote metadata.
+- JDK downloads now automatically verify authoritative checksums for [supported distributions](#download-integrity-and-signatures).
 - Added `force-download: true` to bypass the tool cache and perform a reproducible fresh install.
 - Dependency caching now supports custom paths with `cache-path` and restore-only operation with `cache-read-only: true`.
 - Set `problem-matcher: false` to disable Java compiler and uncaught-exception annotations.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ steps:
 
 - Migrated the action implementation to ESM to support the latest `@actions/*` packages.
 - Added the `oracle-openjdk` distribution and `java-version: latest` for resolving the newest stable GA release.
-- JDK downloads now automatically verify vendor-published checksums. Use `force-download: true` to bypass the tool cache and perform a reproducible fresh install.
+- JDK downloads now automatically verify vendor-published checksums.
+- Added `force-download: true` to bypass the tool cache and perform a reproducible fresh install.
 - Dependency caching now supports custom paths with `cache-path` and restore-only operation with `cache-read-only: true`.
 - Set `problem-matcher: false` to disable Java compiler and uncaught-exception annotations.
 - GraalVM distributions now set `GRAALVM_HOME` in addition to `JAVA_HOME`.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ steps:
 ### V6 (in development)
 
 - Migrated the action implementation to ESM to support the latest `@actions/*` packages.
+- Added the `oracle-openjdk` distribution and `java-version: latest` for resolving the newest stable GA release.
+- JDK downloads now automatically verify vendor-published checksums. Use `force-download: true` to bypass the tool cache and perform a reproducible fresh install.
+- Dependency caching now supports custom paths with `cache-path` and restore-only operation with `cache-read-only: true`.
+- Set `problem-matcher: false` to disable Java compiler and uncaught-exception annotations.
+- GraalVM distributions now set `GRAALVM_HOME` in addition to `JAVA_HOME`.
+- Invalid boolean values, unsupported distribution/package/platform combinations, and mismatched Maven toolchain ID counts now fail with targeted errors.
 - Renamed environment-variable-name inputs so they are not mistaken for secret values:
   - `server-username` -> `server-username-env-var`
   - `server-password` -> `server-password-env-var`


### PR DESCRIPTION
**Description:**
Expand the README V6 highlights with the new distribution and version alias, download verification and reproducibility controls, caching and problem-matcher options, GraalVM environment setup, and stricter input compatibility validation. Preserve the existing ESM, Maven input alias, GPG, and legacy distribution migration guidance.

**Related issue:**
N/A

**Check list:**
- [ ] Ran `npm run check` locally (format, lint, build, test) and all checks pass. Not run (documentation-only change).
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes. Not applicable (documentation-only change).