### PR TITLE
Move the extracted JDK into the tool-cache instead of copying it

### DIFF
--- a/__tests__/util-install.test.ts
+++ b/__tests__/util-install.test.ts
@@ -1,0 +1,412 @@
+import {jest, describe, it, expect, beforeEach, afterEach} from '@jest/globals';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+jest.unstable_mockModule('@actions/core', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warning: jest.fn(),
+  error: jest.fn(),
+  getInput: jest.fn(() => ''),
+  isDebug: jest.fn(() => false),
+  addPath: jest.fn(),
+  exportVariable: jest.fn(),
+  setOutput: jest.fn()
+}));
+
+jest.unstable_mockModule('@actions/tool-cache', () => ({
+  cacheDir: jest.fn(),
+  extractTar: jest.fn(),
+  extractZip: jest.fn(),
+  extract7z: jest.fn()
+}));
+
+jest.unstable_mockModule('@actions/exec', () => ({
+  exec: jest.fn()
+}));
+
+jest.unstable_mockModule('@actions/io', () => ({
+  which: jest.fn(),
+  rmRF: jest.fn(async (target: string) =>
+    fs.rmSync(target, {recursive: true, force: true})
+  ),
+  mkdirP: jest.fn(async (target: string) =>
+    fs.mkdirSync(target, {recursive: true})
+  )
+}));
+
+jest.unstable_mockModule('@actions/http-client', () => ({
+  HttpClient: jest.fn(),
+  HttpClientError: class HttpClientError extends Error {}
+}));
+
+const tc = await import('@actions/tool-cache');
+const exec = await import('@actions/exec');
+const io = await import('@actions/io');
+const {cacheJdkDir, extractJdkFile} = await import('../src/util.js');
+
+const originalToolCache = process.env['RUNNER_TOOL_CACHE'];
+const originalTemp = process.env['RUNNER_TEMP'];
+const originalPlatform = process.platform;
+
+let workDir: string;
+
+function setPlatform(platform: NodeJS.Platform) {
+  Object.defineProperty(process, 'platform', {
+    value: platform,
+    configurable: true
+  });
+}
+
+beforeEach(() => {
+  workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'setup-java-util-'));
+  process.env['RUNNER_TOOL_CACHE'] = path.join(workDir, 'toolcache');
+  process.env['RUNNER_TEMP'] = path.join(workDir, 'temp');
+  fs.mkdirSync(process.env['RUNNER_TEMP'], {recursive: true});
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+  setPlatform(originalPlatform);
+  while (lockedDirs.length) {
+    fs.chmodSync(lockedDirs.pop()!, 0o755);
+  }
+  fs.rmSync(workDir, {recursive: true, force: true});
+  if (originalToolCache === undefined) {
+    delete process.env['RUNNER_TOOL_CACHE'];
+  } else {
+    process.env['RUNNER_TOOL_CACHE'] = originalToolCache;
+  }
+  if (originalTemp === undefined) {
+    delete process.env['RUNNER_TEMP'];
+  } else {
+    process.env['RUNNER_TEMP'] = originalTemp;
+  }
+});
+
+function createJdkDir(name = 'jdk-source'): string {
+  const sourceDir = path.join(workDir, name);
+  fs.mkdirSync(path.join(sourceDir, 'bin'), {recursive: true});
+  fs.writeFileSync(path.join(sourceDir, 'bin', 'java'), 'binary');
+  fs.writeFileSync(path.join(sourceDir, 'release'), 'JAVA_VERSION="17"');
+
+  return sourceDir;
+}
+
+// A rename needs write permission on the source's parent directory, so making
+// that parent read-only is a portable way to force the same failure a
+// cross-device tool-cache (EXDEV) or a Windows anti-virus handle (EPERM) would.
+// Root ignores the permission bits, so those tests are skipped there.
+const canForceRenameFailure =
+  process.platform !== 'win32' &&
+  typeof process.getuid === 'function' &&
+  process.getuid() !== 0;
+const itUnlessRoot = canForceRenameFailure ? it : it.skip;
+const lockedDirs: string[] = [];
+
+function createUnrenameableJdkDir(): string {
+  const parent = path.join(workDir, 'locked');
+  fs.mkdirSync(parent, {recursive: true});
+  const sourceDir = path.join(parent, 'jdk-source');
+  fs.mkdirSync(path.join(sourceDir, 'bin'), {recursive: true});
+  fs.writeFileSync(path.join(sourceDir, 'bin', 'java'), 'binary');
+  fs.chmodSync(parent, 0o555);
+  lockedDirs.push(parent);
+
+  return sourceDir;
+}
+
+describe('cacheJdkDir', () => {
+  it('moves the JDK into the tool-cache instead of copying it', async () => {
+    const sourceDir = createJdkDir();
+
+    const javaPath = await cacheJdkDir(
+      sourceDir,
+      'Java_temurin_jdk',
+      '17.0.1',
+      'x64'
+    );
+
+    expect(javaPath).toBe(
+      path.join(
+        process.env['RUNNER_TOOL_CACHE']!,
+        'Java_temurin_jdk',
+        '17.0.1',
+        'x64'
+      )
+    );
+    expect(fs.existsSync(path.join(javaPath, 'bin', 'java'))).toBe(true);
+    expect(fs.existsSync(path.join(javaPath, 'release'))).toBe(true);
+    // the source is moved, not copied, so it no longer exists
+    expect(fs.existsSync(sourceDir)).toBe(false);
+    expect(tc.cacheDir).not.toHaveBeenCalled();
+  });
+
+  it('writes the .complete marker expected by the tool-cache', async () => {
+    const javaPath = await cacheJdkDir(
+      createJdkDir(),
+      'Java_temurin_jdk',
+      '17.0.1',
+      'x64'
+    );
+
+    expect(fs.existsSync(`${javaPath}.complete`)).toBe(true);
+  });
+
+  it('replaces an existing tool-cache entry', async () => {
+    const destPath = path.join(
+      process.env['RUNNER_TOOL_CACHE']!,
+      'Java_temurin_jdk',
+      '17.0.1',
+      'x64'
+    );
+    fs.mkdirSync(destPath, {recursive: true});
+    fs.writeFileSync(path.join(destPath, 'stale'), 'stale');
+
+    const javaPath = await cacheJdkDir(
+      createJdkDir(),
+      'Java_temurin_jdk',
+      '17.0.1',
+      'x64'
+    );
+
+    expect(fs.existsSync(path.join(javaPath, 'stale'))).toBe(false);
+    expect(fs.existsSync(path.join(javaPath, 'bin', 'java'))).toBe(true);
+  });
+
+  it('normalizes the version the same way as tc.cacheDir', async () => {
+    const javaPath = await cacheJdkDir(
+      createJdkDir(),
+      'Java_temurin_jdk',
+      'v17.0.1',
+      'x64'
+    );
+
+    expect(path.basename(path.dirname(javaPath))).toBe('17.0.1');
+  });
+
+  it('keeps unparseable versions as-is', async () => {
+    const javaPath = await cacheJdkDir(
+      createJdkDir(),
+      'Java_temurin_jdk',
+      '17.0.1-ea.3',
+      'x64'
+    );
+
+    expect(path.basename(path.dirname(javaPath))).toBe('17.0.1-ea.3');
+  });
+
+  it('falls back to tc.cacheDir when the move fails', async () => {
+    (tc.cacheDir as jest.Mock).mockResolvedValue('/fallback/path' as never);
+    const missingDir = path.join(workDir, 'does-not-exist');
+
+    const javaPath = await cacheJdkDir(
+      missingDir,
+      'Java_temurin_jdk',
+      '17.0.1',
+      'x64'
+    );
+
+    expect(javaPath).toBe('/fallback/path');
+    expect(tc.cacheDir).toHaveBeenCalledWith(
+      missingDir,
+      'Java_temurin_jdk',
+      '17.0.1',
+      'x64'
+    );
+  });
+
+  itUnlessRoot(
+    'falls back to tc.cacheDir when the rename itself fails',
+    async () => {
+      const sourceDir = createUnrenameableJdkDir();
+      (tc.cacheDir as jest.Mock).mockResolvedValue('/fallback/path' as never);
+
+      await expect(
+        cacheJdkDir(sourceDir, 'Java_temurin_jdk', '17.0.1', 'x64')
+      ).resolves.toBe('/fallback/path');
+      // the source must survive so the copy-based fallback can still read it
+      expect(fs.existsSync(path.join(sourceDir, 'bin', 'java'))).toBe(true);
+    }
+  );
+
+  itUnlessRoot(
+    'does not leave a .complete marker behind when the rename fails',
+    async () => {
+      const destPath = path.join(
+        process.env['RUNNER_TOOL_CACHE']!,
+        'Java_temurin_jdk',
+        '17.0.1',
+        'x64'
+      );
+      fs.mkdirSync(destPath, {recursive: true});
+      fs.writeFileSync(`${destPath}.complete`, '');
+      (tc.cacheDir as jest.Mock).mockResolvedValue('/fallback/path' as never);
+
+      await cacheJdkDir(
+        createUnrenameableJdkDir(),
+        'Java_temurin_jdk',
+        '17.0.1',
+        'x64'
+      );
+
+      // a stale marker without a matching installation would make the
+      // tool-cache resolve a directory that is no longer there
+      expect(fs.existsSync(`${destPath}.complete`)).toBe(false);
+    }
+  );
+
+  it('falls back to tc.cacheDir for symlinked sources', async () => {
+    const realDir = createJdkDir('real-jdk');
+    const linkDir = path.join(workDir, 'linked-jdk');
+    fs.symlinkSync(realDir, linkDir, 'dir');
+    (tc.cacheDir as jest.Mock).mockResolvedValue('/fallback/path' as never);
+
+    await expect(
+      cacheJdkDir(linkDir, 'Java_temurin_jdk', '17.0.1', 'x64')
+    ).resolves.toBe('/fallback/path');
+    // moving the symlink itself would leave a dangling tool-cache entry
+    expect(fs.lstatSync(linkDir).isSymbolicLink()).toBe(true);
+  });
+
+  it('defaults the architecture the same way as tc.cacheDir', async () => {
+    const javaPath = await cacheJdkDir(
+      createJdkDir(),
+      'Java_temurin_jdk',
+      '17.0.1',
+      ''
+    );
+
+    expect(javaPath).toBe(
+      path.join(
+        process.env['RUNNER_TOOL_CACHE']!,
+        'Java_temurin_jdk',
+        '17.0.1',
+        os.arch()
+      )
+    );
+  });
+
+  it('falls back to tc.cacheDir when the tool-cache location is unknown', async () => {
+    delete process.env['RUNNER_TOOL_CACHE'];
+    (tc.cacheDir as jest.Mock).mockResolvedValue('/fallback/path' as never);
+
+    await expect(
+      cacheJdkDir(createJdkDir(), 'Java_temurin_jdk', '17.0.1', 'x64')
+    ).resolves.toBe('/fallback/path');
+  });
+});
+
+describe('extractJdkFile', () => {
+  it('uses pigz for tarballs when it is available', async () => {
+    (io.which as jest.Mock).mockResolvedValue('/usr/bin/pigz' as never);
+    (tc.extractTar as jest.Mock).mockResolvedValue('/extracted' as never);
+
+    await expect(extractJdkFile('/tmp/jdk.tar.gz')).resolves.toBe('/extracted');
+    expect(tc.extractTar).toHaveBeenCalledWith(
+      '/tmp/jdk.tar.gz',
+      expect.stringContaining(process.env['RUNNER_TEMP']!),
+      ['--use-compress-program', '/usr/bin/pigz -d', '-x']
+    );
+  });
+
+  it('falls back to gzip when pigz is not installed', async () => {
+    (io.which as jest.Mock).mockResolvedValue('' as never);
+    (tc.extractTar as jest.Mock).mockResolvedValue('/extracted' as never);
+
+    await expect(extractJdkFile('/tmp/jdk.tar.gz')).resolves.toBe('/extracted');
+    expect(tc.extractTar).toHaveBeenCalledWith('/tmp/jdk.tar.gz');
+  });
+
+  it('falls back to gzip when pigz extraction fails', async () => {
+    (io.which as jest.Mock).mockResolvedValue('/usr/bin/pigz' as never);
+    (tc.extractTar as jest.Mock)
+      .mockRejectedValueOnce(new Error('pigz exploded') as never)
+      .mockResolvedValue('/extracted' as never);
+
+    await expect(extractJdkFile('/tmp/jdk.tar.gz')).resolves.toBe('/extracted');
+    expect(tc.extractTar).toHaveBeenNthCalledWith(2, '/tmp/jdk.tar.gz');
+  });
+
+  it('cleans up the abandoned folder when pigz extraction fails', async () => {
+    (io.which as jest.Mock).mockResolvedValue('/usr/bin/pigz' as never);
+    let pigzDest: string | undefined;
+    (tc.extractTar as jest.Mock)
+      .mockImplementationOnce((...args: unknown[]) => {
+        pigzDest = args[1] as string;
+        throw new Error('pigz exploded');
+      })
+      .mockResolvedValue('/extracted' as never);
+
+    await extractJdkFile('/tmp/jdk.tar.gz');
+
+    expect(pigzDest).toBeDefined();
+    expect(fs.existsSync(pigzDest!)).toBe(false);
+  });
+
+  it('ignores pigz when its path contains whitespace', async () => {
+    (io.which as jest.Mock).mockResolvedValue(
+      'C:\\Program Files\\pigz.exe' as never
+    );
+    (tc.extractTar as jest.Mock).mockResolvedValue('/extracted' as never);
+
+    await extractJdkFile('/tmp/jdk.tar.gz');
+
+    // tar word-splits --use-compress-program, so a spaced path is unusable
+    expect(tc.extractTar).toHaveBeenCalledWith('/tmp/jdk.tar.gz');
+  });
+
+  it('leaves uncompressed tarballs on the default extraction path', async () => {
+    (tc.extractTar as jest.Mock).mockResolvedValue('/extracted' as never);
+
+    await expect(extractJdkFile('/tmp/jdk.tar')).resolves.toBe('/extracted');
+    expect(tc.extractTar).toHaveBeenCalledWith('/tmp/jdk.tar');
+    expect(io.which).not.toHaveBeenCalled();
+  });
+
+  it('uses the bundled tar.exe for zip archives on Windows', async () => {
+    setPlatform('win32');
+    const systemRoot = path.join(workDir, 'Windows');
+    fs.mkdirSync(path.join(systemRoot, 'System32'), {recursive: true});
+    const systemTar = path.join(systemRoot, 'System32', 'tar.exe');
+    fs.writeFileSync(systemTar, '');
+    process.env['SystemRoot'] = systemRoot;
+
+    const javaPath = await extractJdkFile('/tmp/jdk.zip');
+
+    expect(tc.extractZip).not.toHaveBeenCalled();
+    expect(exec.exec).toHaveBeenCalledWith(
+      `"${systemTar}"`,
+      ['-xf', '/tmp/jdk.zip', '-C', javaPath],
+      {silent: true}
+    );
+    expect(fs.existsSync(javaPath)).toBe(true);
+  });
+
+  it('falls back to tc.extractZip when tar.exe fails', async () => {
+    setPlatform('win32');
+    const systemRoot = path.join(workDir, 'Windows');
+    fs.mkdirSync(path.join(systemRoot, 'System32'), {recursive: true});
+    fs.writeFileSync(path.join(systemRoot, 'System32', 'tar.exe'), '');
+    process.env['SystemRoot'] = systemRoot;
+    let tarDest: string | undefined;
+    (exec.exec as jest.Mock).mockImplementation((...args: unknown[]) => {
+      tarDest = (args[1] as string[])[3];
+      throw new Error('boom');
+    });
+    (tc.extractZip as jest.Mock).mockResolvedValue('/extracted' as never);
+
+    await expect(extractJdkFile('/tmp/jdk.zip')).resolves.toBe('/extracted');
+    expect(tarDest).toBeDefined();
+    expect(fs.existsSync(tarDest!)).toBe(false);
+  });
+
+  it('uses tc.extractZip on non-Windows platforms', async () => {
+    setPlatform('linux');
+    (tc.extractZip as jest.Mock).mockResolvedValue('/extracted' as never);
+
+    await expect(extractJdkFile('/tmp/jdk.zip')).resolves.toBe('/extracted');
+    expect(exec.exec).not.toHaveBeenCalled();
+  });
+});

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -30840,7 +30840,7 @@ const DISTRIBUTIONS_ONLY_MAJOR_VERSION = (/* unused pure expression or super */ 
 /* harmony export */   Vt: () => (/* binding */ getBooleanInput),
 /* harmony export */   lN: () => (/* binding */ isJdkCacheEnabled)
 /* harmony export */ });
-/* unused harmony exports getVersionFromToolcachePath, extractJdkFile, getDownloadArchiveExtension, isVersionSatisfies, getToolcachePath, isGhes, getVersionFromFileContent, convertVersionToSemver, getGitHubHttpHeaders, MAX_PAGINATION_PAGES, getNextPageUrlFromLinkHeader, validatePaginationUrl, renameWinArchive, getLatestMajorVersion */
+/* unused harmony exports getVersionFromToolcachePath, extractJdkFile, cacheJdkDir, getDownloadArchiveExtension, isVersionSatisfies, getToolcachePath, isGhes, getVersionFromFileContent, convertVersionToSemver, getGitHubHttpHeaders, MAX_PAGINATION_PAGES, getNextPageUrlFromLinkHeader, validatePaginationUrl, renameWinArchive, getLatestMajorVersion */
 /* harmony import */ var os__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(857);
 /* harmony import */ var os__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(os__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(6928);
@@ -30851,7 +30851,14 @@ const DISTRIBUTIONS_ONLY_MAJOR_VERSION = (/* unused pure expression or super */ 
 /* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__nccwpck_require__.n(semver__WEBPACK_IMPORTED_MODULE_3__);
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_4__ = __nccwpck_require__(3838);
 /* harmony import */ var _actions_tool_cache__WEBPACK_IMPORTED_MODULE_5__ = __nccwpck_require__(9805);
-/* harmony import */ var _constants_js__WEBPACK_IMPORTED_MODULE_6__ = __nccwpck_require__(7242);
+/* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_6__ = __nccwpck_require__(5260);
+/* harmony import */ var _actions_io__WEBPACK_IMPORTED_MODULE_7__ = __nccwpck_require__(8701);
+/* harmony import */ var crypto__WEBPACK_IMPORTED_MODULE_8__ = __nccwpck_require__(6982);
+/* harmony import */ var crypto__WEBPACK_IMPORTED_MODULE_8___default = /*#__PURE__*/__nccwpck_require__.n(crypto__WEBPACK_IMPORTED_MODULE_8__);
+/* harmony import */ var _constants_js__WEBPACK_IMPORTED_MODULE_9__ = __nccwpck_require__(7242);
+
+
+
 
 
 
@@ -30878,8 +30885,8 @@ function getBooleanInput(inputName, defaultValue = false) {
     throw new Error(`Invalid value '${inputValue}' for boolean input '${inputName}'. Expected 'true' or 'false'.`);
 }
 function isJdkCacheEnabled(cache) {
-    return _actions_core__WEBPACK_IMPORTED_MODULE_4__/* .getInput */ .V4(_constants_js__WEBPACK_IMPORTED_MODULE_6__/* .INPUT_CACHE_JDK */ .GL).trim()
-        ? getBooleanInput(_constants_js__WEBPACK_IMPORTED_MODULE_6__/* .INPUT_CACHE_JDK */ .GL)
+    return _actions_core__WEBPACK_IMPORTED_MODULE_4__/* .getInput */ .V4(_constants_js__WEBPACK_IMPORTED_MODULE_9__/* .INPUT_CACHE_JDK */ .GL).trim()
+        ? getBooleanInput(_constants_js__WEBPACK_IMPORTED_MODULE_9__/* .INPUT_CACHE_JDK */ .GL)
         : Boolean(cache.trim());
 }
 function getVersionFromToolcachePath(toolPath) {
@@ -30899,13 +30906,115 @@ async function extractJdkFile(toolPath, extension) {
     }
     switch (extension) {
         case 'tar.gz':
+            return await extractTarGz(toolPath);
         case 'tar':
             return await tc.extractTar(toolPath);
         case 'zip':
-            return await tc.extractZip(toolPath);
+            return await extractZipArchive(toolPath);
         default:
             return await tc.extract7z(toolPath);
     }
+}
+async function createExtractFolder() {
+    const dest = path.join(getTempDir(), randomUUID());
+    await io.mkdirP(dest);
+    return dest;
+}
+/**
+ * Decompressing a JDK tarball with the default single-threaded gzip is one of the
+ * slowest parts of the install, so hand the decompression to `pigz` when the runner
+ * provides it. Any failure falls back to the stock extraction.
+ */
+async function extractTarGz(toolPath) {
+    const pigzPath = await io.which('pigz');
+    // tar splits --use-compress-program on whitespace, so a path containing a
+    // space would be word-split into a bogus command.
+    if (pigzPath && !/\s/.test(pigzPath)) {
+        const dest = await createExtractFolder();
+        try {
+            return await tc.extractTar(toolPath, dest, [
+                '--use-compress-program',
+                `${pigzPath} -d`,
+                '-x'
+            ]);
+        }
+        catch (error) {
+            await io.rmRF(dest);
+            core.debug(`Failed to extract '${toolPath}' with pigz, falling back to gzip: ${getErrorMessage(error)}`);
+        }
+    }
+    return await tc.extractTar(toolPath);
+}
+/**
+ * `tc.extractZip` shells out to PowerShell's `Expand-Archive` on Windows, which is
+ * several times slower than the bundled bsdtar. Prefer `tar.exe` and fall back to
+ * the stock extraction when it is unavailable or fails.
+ */
+async function extractZipArchive(toolPath) {
+    if (process.platform === 'win32') {
+        const systemTar = path.join(process.env['SystemRoot'] || 'C:\\Windows', 'System32', 'tar.exe');
+        if (fs.existsSync(systemTar)) {
+            const dest = await createExtractFolder();
+            try {
+                await exec.exec(`"${systemTar}"`, ['-xf', toolPath, '-C', dest], {
+                    silent: true
+                });
+                return dest;
+            }
+            catch (error) {
+                await io.rmRF(dest);
+                core.debug(`Failed to extract '${toolPath}' with tar.exe, falling back to Expand-Archive: ${getErrorMessage(error)}`);
+            }
+        }
+    }
+    return await tc.extractZip(toolPath);
+}
+/**
+ * Equivalent of `tc.cacheDir`, but moves the extracted JDK into the tool-cache
+ * instead of copying it. `tc.cacheDir` recursively copies the whole tree, which
+ * means a several hundred megabyte JDK is written to disk twice. The extraction
+ * directory and the tool-cache normally live on the same filesystem, so a rename
+ * is effectively free. Anything unexpected (a different filesystem, or a file
+ * handle held open by anti-virus software on Windows) falls back to the copy.
+ */
+async function cacheJdkDir(sourceDir, toolName, version, architecture) {
+    const destPath = getToolcacheDestination(toolName, version, architecture);
+    if (destPath) {
+        let moved = false;
+        try {
+            // lstat, not stat: renaming a symlinked source would put the link itself
+            // in the tool-cache, leaving a dangling JAVA_HOME once RUNNER_TEMP is
+            // cleaned. tc.cacheDir dereferences it, so let it handle that case.
+            if (fs.lstatSync(sourceDir).isDirectory()) {
+                await io.rmRF(destPath);
+                await io.rmRF(`${destPath}.complete`);
+                await io.mkdirP(path.dirname(destPath));
+                // Renaming is atomic, so a failure here leaves sourceDir untouched and
+                // the copy-based fallback below can still run.
+                fs.renameSync(sourceDir, destPath);
+                moved = true;
+            }
+        }
+        catch (error) {
+            core.debug(`Failed to move '${sourceDir}' into the tool-cache, falling back to a copy: ${getErrorMessage(error)}`);
+        }
+        if (moved) {
+            fs.writeFileSync(`${destPath}.complete`, '');
+            return destPath;
+        }
+    }
+    return await tc.cacheDir(sourceDir, toolName, version, architecture);
+}
+function getToolcacheDestination(toolName, version, architecture) {
+    const toolcacheRoot = process.env['RUNNER_TOOL_CACHE'];
+    if (!toolcacheRoot) {
+        return null;
+    }
+    // Mirrors the destination layout used by `tc.cacheDir`.
+    return path.join(toolcacheRoot, toolName, semver.clean(version) || version, architecture || os.arch());
+}
+function getErrorMessage(error) {
+    return error instanceof Error ? error.message : String(error);
 }
 function getDownloadArchiveExtension() {
     return process.platform === 'win32' ? 'zip' : 'tar.gz';
@@ -30938,7 +31047,7 @@ function getToolcachePath(toolName, version, architecture) {
     return null;
 }
 function isJobStatusSuccess() {
-    const jobStatus = _actions_core__WEBPACK_IMPORTED_MODULE_4__/* .getInput */ .V4(_constants_js__WEBPACK_IMPORTED_MODULE_6__/* .INPUT_JOB_STATUS */ .wG);
+    const jobStatus = _actions_core__WEBPACK_IMPORTED_MODULE_4__/* .getInput */ .V4(_constants_js__WEBPACK_IMPORTED_MODULE_9__/* .INPUT_JOB_STATUS */ .wG);
     return jobStatus === 'success';
 }
 function isGhes() {

--- a/dist/setup/126.index.js
+++ b/dist/setup/126.index.js
@@ -9,21 +9,19 @@ export const modules = {
 /* harmony export */   CorrettoDistribution: () => (/* binding */ CorrettoDistribution)
 /* harmony export */ });
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(3838);
-/* harmony import */ var _actions_tool_cache__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(9805);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(9896);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_2__);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(6928);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_3__);
-/* harmony import */ var _util_js__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(4527);
-/* harmony import */ var _base_installer_js__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(6242);
-
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(9896);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(6928);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var _util_js__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(4527);
+/* harmony import */ var _base_installer_js__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(6242);
 
 
 
 
 
 const CORRETTO_VERSIONS_URL = 'https://corretto.github.io/corretto-downloads/latest_links/indexmap_with_checksum.json';
-class CorrettoDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5__/* .JavaBase */ .O {
+class CorrettoDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_4__/* .JavaBase */ .O {
     constructor(installerOptions) {
         super('Corretto', installerOptions);
     }
@@ -31,15 +29,15 @@ class CorrettoDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5
         _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq(`Downloading Java ${javaRelease.version} (${this.distribution}) from ${javaRelease.url} ...`);
         let javaArchivePath = await this.downloadAndVerify(javaRelease);
         _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq(`Extracting Java archive...`);
-        const extension = (0,_util_js__WEBPACK_IMPORTED_MODULE_4__/* .getDownloadArchiveExtension */ .ag)();
+        const extension = (0,_util_js__WEBPACK_IMPORTED_MODULE_3__/* .getDownloadArchiveExtension */ .ag)();
         if (process.platform === 'win32') {
-            javaArchivePath = (0,_util_js__WEBPACK_IMPORTED_MODULE_4__/* .renameWinArchive */ .n2)(javaArchivePath);
+            javaArchivePath = (0,_util_js__WEBPACK_IMPORTED_MODULE_3__/* .renameWinArchive */ .n2)(javaArchivePath);
         }
-        const extractedJavaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_4__/* .extractJdkFile */ .PE)(javaArchivePath, extension);
-        const archiveName = fs__WEBPACK_IMPORTED_MODULE_2___default().readdirSync(extractedJavaPath)[0];
-        const archivePath = path__WEBPACK_IMPORTED_MODULE_3___default().join(extractedJavaPath, archiveName);
+        const extractedJavaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_3__/* .extractJdkFile */ .PE)(javaArchivePath, extension);
+        const archiveName = fs__WEBPACK_IMPORTED_MODULE_1___default().readdirSync(extractedJavaPath)[0];
+        const archivePath = path__WEBPACK_IMPORTED_MODULE_2___default().join(extractedJavaPath, archiveName);
         const version = this.getToolcacheVersionName(javaRelease.version);
-        const javaPath = await _actions_tool_cache__WEBPACK_IMPORTED_MODULE_1__/* .cacheDir */ .e8(archivePath, this.toolcacheFolderName, version, this.architecture);
+        const javaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_3__/* .cacheJdkDir */ .Vj)(archivePath, this.toolcacheFolderName, version, this.architecture);
         return { version: javaRelease.version, path: javaPath };
     }
     async findPackageForDownload(version) {
@@ -66,7 +64,7 @@ class CorrettoDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5
             .filter(item => item.version == version)
             .map(item => {
             return {
-                version: (0,_util_js__WEBPACK_IMPORTED_MODULE_4__/* .convertVersionToSemver */ .ZY)(item.correttoVersion),
+                version: (0,_util_js__WEBPACK_IMPORTED_MODULE_3__/* .convertVersionToSemver */ .ZY)(item.correttoVersion),
                 url: item.downloadLink,
                 checksum: {
                     algorithm: 'sha256',
@@ -112,7 +110,7 @@ class CorrettoDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5
         for (const version in eligibleVersions) {
             const availableVersion = eligibleVersions[version];
             for (const fileType in availableVersion) {
-                const skipNonExtractableBinaries = fileType != (0,_util_js__WEBPACK_IMPORTED_MODULE_4__/* .getDownloadArchiveExtension */ .ag)();
+                const skipNonExtractableBinaries = fileType != (0,_util_js__WEBPACK_IMPORTED_MODULE_3__/* .getDownloadArchiveExtension */ .ag)();
                 if (skipNonExtractableBinaries) {
                     continue;
                 }

--- a/dist/setup/151.index.js
+++ b/dist/setup/151.index.js
@@ -9,16 +9,14 @@ export const modules = {
 /* harmony export */   KonaDistribution: () => (/* binding */ KonaDistribution)
 /* harmony export */ });
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(3838);
-/* harmony import */ var _actions_tool_cache__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(9805);
-/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(2088);
-/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(semver__WEBPACK_IMPORTED_MODULE_2__);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(9896);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_3__);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(6928);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_4__);
-/* harmony import */ var _base_installer_js__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(6242);
-/* harmony import */ var _util_js__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(4527);
-
+/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(2088);
+/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(semver__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(9896);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(6928);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_3__);
+/* harmony import */ var _base_installer_js__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(6242);
+/* harmony import */ var _util_js__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(4527);
 
 
 
@@ -26,7 +24,7 @@ export const modules = {
 
 
 const KONA_RELEASES_URL = 'https://tencent.github.io/konajdk/releases/kona-v1.json';
-class KonaDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5__/* .JavaBase */ .O {
+class KonaDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_4__/* .JavaBase */ .O {
     constructor(installerOptions) {
         super('Kona', installerOptions);
     }
@@ -34,15 +32,15 @@ class KonaDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5__/*
         _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq(`Downloading Kona JDK ${javaRelease.version} (${this.distribution}) from ${javaRelease.url} ...`);
         const javaArchivePath = await this.downloadAndVerify(javaRelease);
         _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq(`Extracting Java archive...`);
-        const extension = (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .getDownloadArchiveExtension */ .ag)();
+        const extension = (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .getDownloadArchiveExtension */ .ag)();
         const archivePath = process.platform === 'win32'
-            ? (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .renameWinArchive */ .n2)(javaArchivePath)
+            ? (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .renameWinArchive */ .n2)(javaArchivePath)
             : javaArchivePath;
-        const extractedJavaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .extractJdkFile */ .PE)(archivePath, extension);
-        const archiveName = fs__WEBPACK_IMPORTED_MODULE_3___default().readdirSync(extractedJavaPath)[0];
-        const jdkDirectory = path__WEBPACK_IMPORTED_MODULE_4___default().join(extractedJavaPath, archiveName);
+        const extractedJavaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .extractJdkFile */ .PE)(archivePath, extension);
+        const archiveName = fs__WEBPACK_IMPORTED_MODULE_2___default().readdirSync(extractedJavaPath)[0];
+        const jdkDirectory = path__WEBPACK_IMPORTED_MODULE_3___default().join(extractedJavaPath, archiveName);
         const version = this.getToolcacheVersionName(javaRelease.version);
-        const javaPath = await _actions_tool_cache__WEBPACK_IMPORTED_MODULE_1__/* .cacheDir */ .e8(jdkDirectory, this.toolcacheFolderName, version, this.architecture);
+        const javaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .cacheJdkDir */ .Vj)(jdkDirectory, this.toolcacheFolderName, version, this.architecture);
         return { version: javaRelease.version, path: javaPath };
     }
     async findPackageForDownload(version) {
@@ -55,7 +53,7 @@ class KonaDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5__/*
         const availableReleases = await this.getAvailableReleases();
         const releases = availableReleases
             .filter(item => {
-            return (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .isVersionSatisfies */ .y)(version, item.version);
+            return (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .isVersionSatisfies */ .y)(version, item.version);
         })
             .map(item => {
             return {
@@ -70,7 +68,7 @@ class KonaDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5__/*
                     : undefined
             };
         })
-            .sort((a, b) => -semver__WEBPACK_IMPORTED_MODULE_2___default().compareBuild(a.version, b.version));
+            .sort((a, b) => -semver__WEBPACK_IMPORTED_MODULE_1___default().compareBuild(a.version, b.version));
         if (!releases.length) {
             throw new Error(`No Kona release for the specified version "${version}" on OS "${this.getOs()}" and arch "${this.getArch()}".`);
         }

--- a/dist/setup/182.index.js
+++ b/dist/setup/182.index.js
@@ -9,15 +9,13 @@ export const modules = {
 /* harmony export */   OracleDistribution: () => (/* binding */ OracleDistribution)
 /* harmony export */ });
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(3838);
-/* harmony import */ var _actions_tool_cache__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(9805);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(9896);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_2__);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(6928);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_3__);
-/* harmony import */ var _base_installer_js__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(6242);
-/* harmony import */ var _util_js__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(4527);
-/* harmony import */ var _actions_http_client__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(4942);
-
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(9896);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(6928);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var _base_installer_js__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(6242);
+/* harmony import */ var _util_js__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(4527);
+/* harmony import */ var _actions_http_client__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(4942);
 
 
 
@@ -25,7 +23,7 @@ export const modules = {
 
 
 const ORACLE_DL_BASE = 'https://download.oracle.com/java';
-class OracleDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_4__/* .JavaBase */ .O {
+class OracleDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_3__/* .JavaBase */ .O {
     constructor(installerOptions) {
         super('Oracle', installerOptions);
     }
@@ -33,15 +31,15 @@ class OracleDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_4__
         _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq(`Downloading Java ${javaRelease.version} (${this.distribution}) from ${javaRelease.url} ...`);
         let javaArchivePath = await this.downloadAndVerify(javaRelease);
         _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq(`Extracting Java archive...`);
-        const extension = (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .getDownloadArchiveExtension */ .ag)();
+        const extension = (0,_util_js__WEBPACK_IMPORTED_MODULE_4__/* .getDownloadArchiveExtension */ .ag)();
         if (process.platform === 'win32') {
-            javaArchivePath = (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .renameWinArchive */ .n2)(javaArchivePath);
+            javaArchivePath = (0,_util_js__WEBPACK_IMPORTED_MODULE_4__/* .renameWinArchive */ .n2)(javaArchivePath);
         }
-        const extractedJavaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .extractJdkFile */ .PE)(javaArchivePath, extension);
-        const archiveName = fs__WEBPACK_IMPORTED_MODULE_2___default().readdirSync(extractedJavaPath)[0];
-        const archivePath = path__WEBPACK_IMPORTED_MODULE_3___default().join(extractedJavaPath, archiveName);
+        const extractedJavaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_4__/* .extractJdkFile */ .PE)(javaArchivePath, extension);
+        const archiveName = fs__WEBPACK_IMPORTED_MODULE_1___default().readdirSync(extractedJavaPath)[0];
+        const archivePath = path__WEBPACK_IMPORTED_MODULE_2___default().join(extractedJavaPath, archiveName);
         const version = this.getToolcacheVersionName(javaRelease.version);
-        const javaPath = await _actions_tool_cache__WEBPACK_IMPORTED_MODULE_1__/* .cacheDir */ .e8(archivePath, this.toolcacheFolderName, version, this.architecture);
+        const javaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_4__/* .cacheJdkDir */ .Vj)(archivePath, this.toolcacheFolderName, version, this.architecture);
         return { version: javaRelease.version, path: javaPath };
     }
     async findPackageForDownload(range) {
@@ -56,12 +54,12 @@ class OracleDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_4__
             throw new Error('Oracle JDK provides only the `jdk` package type');
         }
         const platform = this.getPlatform();
-        const extension = (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .getDownloadArchiveExtension */ .ag)();
+        const extension = (0,_util_js__WEBPACK_IMPORTED_MODULE_4__/* .getDownloadArchiveExtension */ .ag)();
         // The `latest` alias is normalized to the SemVer wildcard. Oracle builds its
         // download URLs from a concrete major and has no endpoint to list releases,
         // so resolve the newest available GA major from the Adoptium API and use it.
         if (this.latest) {
-            const latestMajor = await (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .getLatestMajorVersion */ .ri)(this.http);
+            const latestMajor = await (0,_util_js__WEBPACK_IMPORTED_MODULE_4__/* .getLatestMajorVersion */ .ri)(this.http);
             range = latestMajor.toString();
         }
         const isOnlyMajorProvided = !range.includes('.');
@@ -83,14 +81,14 @@ class OracleDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_4__
         }
         for (const url of possibleUrls) {
             const response = await this.http.head(url);
-            if (response.message.statusCode === _actions_http_client__WEBPACK_IMPORTED_MODULE_6__/* .HttpCodes */ .Hv.OK) {
+            if (response.message.statusCode === _actions_http_client__WEBPACK_IMPORTED_MODULE_5__/* .HttpCodes */ .Hv.OK) {
                 return {
                     url,
                     version: range,
                     checksum: await this.fetchChecksum(`${url}.sha256`, 'sha256')
                 };
             }
-            if (response.message.statusCode !== _actions_http_client__WEBPACK_IMPORTED_MODULE_6__/* .HttpCodes */ .Hv.NotFound) {
+            if (response.message.statusCode !== _actions_http_client__WEBPACK_IMPORTED_MODULE_5__/* .HttpCodes */ .Hv.NotFound) {
                 throw new Error(`Http request for Oracle JDK failed with status code: ${response.message.statusCode}`);
             }
         }

--- a/dist/setup/19.index.js
+++ b/dist/setup/19.index.js
@@ -8,17 +8,16 @@ export const modules = {
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   LocalDistribution: () => (/* binding */ LocalDistribution)
 /* harmony export */ });
-/* harmony import */ var _actions_tool_cache__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(9805);
-/* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(3838);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(9896);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_2__);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(6928);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_3__);
-/* harmony import */ var _base_installer_js__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(6242);
-/* harmony import */ var _util_js__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(4527);
-/* harmony import */ var _constants_js__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(7242);
-/* harmony import */ var crypto__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(6982);
-/* harmony import */ var crypto__WEBPACK_IMPORTED_MODULE_6___default = /*#__PURE__*/__webpack_require__.n(crypto__WEBPACK_IMPORTED_MODULE_6__);
+/* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(3838);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(9896);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(6928);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var _base_installer_js__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(6242);
+/* harmony import */ var _util_js__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(4527);
+/* harmony import */ var _constants_js__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(7242);
+/* harmony import */ var crypto__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(6982);
+/* harmony import */ var crypto__WEBPACK_IMPORTED_MODULE_5___default = /*#__PURE__*/__webpack_require__.n(crypto__WEBPACK_IMPORTED_MODULE_5__);
 
 
 
@@ -27,8 +26,7 @@ export const modules = {
 
 
 
-
-class LocalDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_4__/* .JavaBase */ .O {
+class LocalDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_3__/* .JavaBase */ .O {
     jdkFile;
     constructor(installerOptions, jdkFile) {
         super('jdkfile', installerOptions);
@@ -43,15 +41,15 @@ class LocalDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_4__/
         }
         let foundJava = this.forceDownload ? null : this.findInToolcache();
         if (foundJava) {
-            _actions_core__WEBPACK_IMPORTED_MODULE_1__/* .info */ .pq(`Resolved Java ${foundJava.version} from tool-cache`);
+            _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq(`Resolved Java ${foundJava.version} from tool-cache`);
         }
         else {
-            _actions_core__WEBPACK_IMPORTED_MODULE_1__/* .info */ .pq(`Java ${this.version} was not found in tool-cache. Trying to unpack JDK file...`);
+            _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq(`Java ${this.version} was not found in tool-cache. Trying to unpack JDK file...`);
             if (!this.jdkFile) {
                 throw new Error("'jdkFile' is not specified");
             }
-            const jdkFilePath = path__WEBPACK_IMPORTED_MODULE_3___default().resolve(this.jdkFile);
-            const stats = fs__WEBPACK_IMPORTED_MODULE_2___default().statSync(jdkFilePath);
+            const jdkFilePath = path__WEBPACK_IMPORTED_MODULE_2___default().resolve(this.jdkFile);
+            const stats = fs__WEBPACK_IMPORTED_MODULE_1___default().statSync(jdkFilePath);
             if (!stats.isFile()) {
                 throw new Error(`JDK file was not found in path '${jdkFilePath}'`);
             }
@@ -85,12 +83,12 @@ class LocalDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_4__/
                 }
             }
             if (!foundJava) {
-                _actions_core__WEBPACK_IMPORTED_MODULE_1__/* .info */ .pq(`Extracting Java from '${jdkFilePath}'`);
-                const extractedJavaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .extractJdkFile */ .PE)(jdkFilePath);
-                const archiveName = fs__WEBPACK_IMPORTED_MODULE_2___default().readdirSync(extractedJavaPath)[0];
-                const archivePath = path__WEBPACK_IMPORTED_MODULE_3___default().join(extractedJavaPath, archiveName);
+                _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq(`Extracting Java from '${jdkFilePath}'`);
+                const extractedJavaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_4__/* .extractJdkFile */ .PE)(jdkFilePath);
+                const archiveName = fs__WEBPACK_IMPORTED_MODULE_1___default().readdirSync(extractedJavaPath)[0];
+                const archivePath = path__WEBPACK_IMPORTED_MODULE_2___default().join(extractedJavaPath, archiveName);
                 const javaVersion = this.version;
-                const javaPath = await _actions_tool_cache__WEBPACK_IMPORTED_MODULE_0__/* .cacheDir */ .e8(archivePath, this.toolcacheFolderName, this.getToolcacheVersionName(javaVersion), this.architecture);
+                const javaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_4__/* .cacheJdkDir */ .Vj)(archivePath, this.toolcacheFolderName, this.getToolcacheVersionName(javaVersion), this.architecture);
                 foundJava = {
                     version: javaVersion,
                     path: javaPath
@@ -102,16 +100,16 @@ class LocalDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_4__/
             }
         }
         // JDK folder may contain postfix "Contents/Home" on macOS
-        const macOSPostfixPath = path__WEBPACK_IMPORTED_MODULE_3___default().join(foundJava.path, _constants_js__WEBPACK_IMPORTED_MODULE_7__/* .MACOS_JAVA_CONTENT_POSTFIX */ .PG);
-        if (process.platform === 'darwin' && fs__WEBPACK_IMPORTED_MODULE_2___default().existsSync(macOSPostfixPath)) {
+        const macOSPostfixPath = path__WEBPACK_IMPORTED_MODULE_2___default().join(foundJava.path, _constants_js__WEBPACK_IMPORTED_MODULE_6__/* .MACOS_JAVA_CONTENT_POSTFIX */ .PG);
+        if (process.platform === 'darwin' && fs__WEBPACK_IMPORTED_MODULE_1___default().existsSync(macOSPostfixPath)) {
             foundJava.path = macOSPostfixPath;
         }
         if (this.setDefault) {
-            _actions_core__WEBPACK_IMPORTED_MODULE_1__/* .info */ .pq(`Setting Java ${foundJava.version} as the default`);
+            _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq(`Setting Java ${foundJava.version} as the default`);
             this.setJavaDefault(foundJava.version, foundJava.path);
         }
         else {
-            _actions_core__WEBPACK_IMPORTED_MODULE_1__/* .info */ .pq(`Installing Java ${foundJava.version} (not setting as default)`);
+            _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq(`Installing Java ${foundJava.version} (not setting as default)`);
             this.setJavaEnvironment(foundJava.version, foundJava.path);
         }
         return foundJava;
@@ -126,8 +124,8 @@ class LocalDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_4__/
     }
 }
 async function hashFile(file) {
-    const hash = (0,crypto__WEBPACK_IMPORTED_MODULE_6__.createHash)('sha256');
-    for await (const chunk of (0,fs__WEBPACK_IMPORTED_MODULE_2__.createReadStream)(file)) {
+    const hash = (0,crypto__WEBPACK_IMPORTED_MODULE_5__.createHash)('sha256');
+    for await (const chunk of (0,fs__WEBPACK_IMPORTED_MODULE_1__.createReadStream)(file)) {
         hash.update(chunk);
     }
     return hash.digest('hex');

--- a/dist/setup/220.index.js
+++ b/dist/setup/220.index.js
@@ -89,7 +89,7 @@ class MicrosoftDistributions extends base_installer/* JavaBase */.O {
         const extractedJavaPath = await (0,util/* extractJdkFile */.PE)(javaArchivePath, extension);
         const archiveName = external_fs_default().readdirSync(extractedJavaPath)[0];
         const archivePath = external_path_default().join(extractedJavaPath, archiveName);
-        const javaPath = await tool_cache/* cacheDir */.e8(archivePath, this.toolcacheFolderName, this.getToolcacheVersionName(javaRelease.version), this.architecture);
+        const javaPath = await (0,util/* cacheJdkDir */.Vj)(archivePath, this.toolcacheFolderName, this.getToolcacheVersionName(javaRelease.version), this.architecture);
         return { version: javaRelease.version, path: javaPath };
     }
     async findPackageForDownload(range) {

--- a/dist/setup/282.index.js
+++ b/dist/setup/282.index.js
@@ -9,16 +9,15 @@ export const modules = {
 /* harmony export */   JetBrainsDistribution: () => (/* binding */ JetBrainsDistribution)
 /* harmony export */ });
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(3838);
-/* harmony import */ var _actions_tool_cache__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(9805);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(9896);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_2__);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(6928);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_3__);
-/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(2088);
-/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__webpack_require__.n(semver__WEBPACK_IMPORTED_MODULE_4__);
-/* harmony import */ var _base_installer_js__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(6242);
-/* harmony import */ var _util_js__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(4527);
-/* harmony import */ var _actions_http_client__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(4942);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(9896);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(6928);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(2088);
+/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(semver__WEBPACK_IMPORTED_MODULE_3__);
+/* harmony import */ var _base_installer_js__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(6242);
+/* harmony import */ var _util_js__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(4527);
+/* harmony import */ var _actions_http_client__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(4942);
 
 
 
@@ -26,8 +25,7 @@ export const modules = {
 
 
 
-
-class JetBrainsDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5__/* .JavaBase */ .O {
+class JetBrainsDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_4__/* .JavaBase */ .O {
     constructor(installerOptions) {
         super('JetBrains', installerOptions);
     }
@@ -41,9 +39,9 @@ class JetBrainsDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_
             };
         });
         const satisfiedVersions = versions
-            .filter(item => (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .isVersionSatisfies */ .y)(range, item.version))
+            .filter(item => (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .isVersionSatisfies */ .y)(range, item.version))
             .sort((a, b) => {
-            return -semver__WEBPACK_IMPORTED_MODULE_4___default().compareBuild(a.version, b.version);
+            return -semver__WEBPACK_IMPORTED_MODULE_3___default().compareBuild(a.version, b.version);
         });
         const resolvedFullVersion = satisfiedVersions.length > 0 ? satisfiedVersions[0] : null;
         if (!resolvedFullVersion) {
@@ -63,11 +61,11 @@ class JetBrainsDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_
         _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq(`Downloading Java ${javaRelease.version} (${this.distribution}) from ${javaRelease.url} ...`);
         const javaArchivePath = await this.downloadAndVerify(javaRelease);
         _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq(`Extracting Java archive...`);
-        const extractedJavaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .extractJdkFile */ .PE)(javaArchivePath, 'tar.gz');
-        const archiveName = fs__WEBPACK_IMPORTED_MODULE_2___default().readdirSync(extractedJavaPath)[0];
-        const archivePath = path__WEBPACK_IMPORTED_MODULE_3___default().join(extractedJavaPath, archiveName);
+        const extractedJavaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .extractJdkFile */ .PE)(javaArchivePath, 'tar.gz');
+        const archiveName = fs__WEBPACK_IMPORTED_MODULE_1___default().readdirSync(extractedJavaPath)[0];
+        const archivePath = path__WEBPACK_IMPORTED_MODULE_2___default().join(extractedJavaPath, archiveName);
         const version = this.getToolcacheVersionName(javaRelease.version);
-        const javaPath = await _actions_tool_cache__WEBPACK_IMPORTED_MODULE_1__/* .cacheDir */ .e8(archivePath, this.toolcacheFolderName, version, this.architecture);
+        const javaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .cacheJdkDir */ .Vj)(archivePath, this.toolcacheFolderName, version, this.architecture);
         return { version: javaRelease.version, path: javaPath };
     }
     async getAvailableVersions() {
@@ -156,13 +154,13 @@ class JetBrainsDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_
             let url = `https://cache-redirector.jetbrains.com/intellij-jbr/${type}-${semver}-${platform}-${arch}-b${build}.tar.gz`;
             let include = false;
             const res = await this.http.head(url);
-            if (res.message.statusCode === _actions_http_client__WEBPACK_IMPORTED_MODULE_7__/* .HttpCodes */ .Hv.OK) {
+            if (res.message.statusCode === _actions_http_client__WEBPACK_IMPORTED_MODULE_6__/* .HttpCodes */ .Hv.OK) {
                 include = true;
             }
             else {
                 url = `https://cache-redirector.jetbrains.com/intellij-jbr/${type}_nomod-${semver}-${platform}-${arch}-b${build}.tar.gz`;
                 const res2 = await this.http.head(url);
-                if (res2.message.statusCode === _actions_http_client__WEBPACK_IMPORTED_MODULE_7__/* .HttpCodes */ .Hv.OK) {
+                if (res2.message.statusCode === _actions_http_client__WEBPACK_IMPORTED_MODULE_6__/* .HttpCodes */ .Hv.OK) {
                     include = true;
                 }
             }

--- a/dist/setup/463.index.js
+++ b/dist/setup/463.index.js
@@ -16,8 +16,6 @@ __webpack_require__.d(__webpack_exports__, {
 
 // EXTERNAL MODULE: ./node_modules/@actions/core/lib/core.js + 7 modules
 var core = __webpack_require__(3838);
-// EXTERNAL MODULE: ./node_modules/@actions/tool-cache/lib/tool-cache.js + 2 modules
-var tool_cache = __webpack_require__(9805);
 // EXTERNAL MODULE: external "fs"
 var external_fs_ = __webpack_require__(9896);
 var external_fs_default = /*#__PURE__*/__webpack_require__.n(external_fs_);
@@ -71,7 +69,6 @@ var constants = __webpack_require__(7242);
 // EXTERNAL MODULE: ./src/util.ts
 var util = __webpack_require__(4527);
 ;// CONCATENATED MODULE: ./src/distributions/temurin/installer.ts
-
 
 
 
@@ -150,7 +147,7 @@ class TemurinDistribution extends base_installer/* JavaBase */.O {
             await this.installJmods(javaRelease.version, javaHome);
         }
         const version = this.getToolcacheVersionName(javaRelease.version);
-        const javaPath = await tool_cache/* cacheDir */.e8(archivePath, this.toolcacheFolderName, version, this.architecture);
+        const javaPath = await (0,util/* cacheJdkDir */.Vj)(archivePath, this.toolcacheFolderName, version, this.architecture);
         return { version: javaRelease.version, path: javaPath };
     }
     supportsSignatureVerification() {

--- a/dist/setup/524.index.js
+++ b/dist/setup/524.index.js
@@ -13,12 +13,10 @@ export const modules = {
 /* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(semver__WEBPACK_IMPORTED_MODULE_1__);
 /* harmony import */ var _util_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(4527);
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(3838);
-/* harmony import */ var _actions_tool_cache__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(9805);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(9896);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_5___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_5__);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(6928);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_6___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_6__);
-
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(9896);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_4__);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(6928);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_5___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_5__);
 
 
 
@@ -40,9 +38,9 @@ class LibericaNikDistributions extends _base_installer_js__WEBPACK_IMPORTED_MODU
             javaArchivePath = (0,_util_js__WEBPACK_IMPORTED_MODULE_2__/* .renameWinArchive */ .n2)(javaArchivePath);
         }
         const extractedJavaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_2__/* .extractJdkFile */ .PE)(javaArchivePath, extension);
-        const archiveName = fs__WEBPACK_IMPORTED_MODULE_5___default().readdirSync(extractedJavaPath)[0];
-        const archivePath = path__WEBPACK_IMPORTED_MODULE_6___default().join(extractedJavaPath, archiveName);
-        const javaPath = await _actions_tool_cache__WEBPACK_IMPORTED_MODULE_4__/* .cacheDir */ .e8(archivePath, this.toolcacheFolderName, this.getToolcacheVersionName(javaRelease.version), this.architecture);
+        const archiveName = fs__WEBPACK_IMPORTED_MODULE_4___default().readdirSync(extractedJavaPath)[0];
+        const archivePath = path__WEBPACK_IMPORTED_MODULE_5___default().join(extractedJavaPath, archiveName);
+        const javaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_2__/* .cacheJdkDir */ .Vj)(archivePath, this.toolcacheFolderName, this.getToolcacheVersionName(javaRelease.version), this.architecture);
         return { version: javaRelease.version, path: javaPath };
     }
     async findPackageForDownload(range) {

--- a/dist/setup/557.index.js
+++ b/dist/setup/557.index.js
@@ -9,23 +9,21 @@ export const modules = {
 /* harmony export */   SapMachineDistribution: () => (/* binding */ SapMachineDistribution)
 /* harmony export */ });
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(3838);
-/* harmony import */ var _actions_tool_cache__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(9805);
-/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(2088);
-/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(semver__WEBPACK_IMPORTED_MODULE_2__);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(9896);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_3__);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(6928);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_4__);
-/* harmony import */ var _util_js__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(4527);
-/* harmony import */ var _base_installer_js__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(6242);
+/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(2088);
+/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(semver__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(9896);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(6928);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_3__);
+/* harmony import */ var _util_js__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(4527);
+/* harmony import */ var _base_installer_js__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(6242);
 
 
 
 
 
 
-
-class SapMachineDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_6__/* .JavaBase */ .O {
+class SapMachineDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5__/* .JavaBase */ .O {
     constructor(installerOptions) {
         super('SapMachine', installerOptions);
     }
@@ -37,7 +35,7 @@ class SapMachineDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE
         const availableVersions = await this.getAvailableVersions();
         const matchedVersions = availableVersions
             .filter(item => {
-            return (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .isVersionSatisfies */ .y)(version, item.version);
+            return (0,_util_js__WEBPACK_IMPORTED_MODULE_4__/* .isVersionSatisfies */ .y)(version, item.version);
         })
             .map(item => {
             return {
@@ -79,15 +77,15 @@ class SapMachineDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE
         _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq(`Downloading Java ${javaRelease.version} (${this.distribution}) from ${javaRelease.url} ...`);
         let javaArchivePath = await this.downloadAndVerify(javaRelease);
         _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq(`Extracting Java archive...`);
-        const extension = (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .getDownloadArchiveExtension */ .ag)();
+        const extension = (0,_util_js__WEBPACK_IMPORTED_MODULE_4__/* .getDownloadArchiveExtension */ .ag)();
         if (process.platform === 'win32') {
-            javaArchivePath = (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .renameWinArchive */ .n2)(javaArchivePath);
+            javaArchivePath = (0,_util_js__WEBPACK_IMPORTED_MODULE_4__/* .renameWinArchive */ .n2)(javaArchivePath);
         }
-        const extractedJavaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .extractJdkFile */ .PE)(javaArchivePath, extension);
-        const archiveName = fs__WEBPACK_IMPORTED_MODULE_3___default().readdirSync(extractedJavaPath)[0];
-        const archivePath = path__WEBPACK_IMPORTED_MODULE_4___default().join(extractedJavaPath, archiveName);
+        const extractedJavaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_4__/* .extractJdkFile */ .PE)(javaArchivePath, extension);
+        const archiveName = fs__WEBPACK_IMPORTED_MODULE_2___default().readdirSync(extractedJavaPath)[0];
+        const archivePath = path__WEBPACK_IMPORTED_MODULE_3___default().join(extractedJavaPath, archiveName);
         const version = this.getToolcacheVersionName(javaRelease.version);
-        const javaPath = await _actions_tool_cache__WEBPACK_IMPORTED_MODULE_1__/* .cacheDir */ .e8(archivePath, this.toolcacheFolderName, version, this.architecture);
+        const javaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_4__/* .cacheJdkDir */ .Vj)(archivePath, this.toolcacheFolderName, version, this.architecture);
         return { version: javaRelease.version, path: javaPath };
     }
     parseVersions(platform, arch, versions) {
@@ -104,9 +102,9 @@ class SapMachineDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE
                     if (buildVersionWithoutPrefix.split('.').length > 3) {
                         buildVersionWithoutPrefix = buildVersionWithoutPrefix.replace('+', '.');
                     }
-                    buildVersionWithoutPrefix = (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .convertVersionToSemver */ .ZY)(buildVersionWithoutPrefix);
+                    buildVersionWithoutPrefix = (0,_util_js__WEBPACK_IMPORTED_MODULE_4__/* .convertVersionToSemver */ .ZY)(buildVersionWithoutPrefix);
                     // ignore invalid version
-                    if (!semver__WEBPACK_IMPORTED_MODULE_2___default().valid(buildVersionWithoutPrefix)) {
+                    if (!semver__WEBPACK_IMPORTED_MODULE_1___default().valid(buildVersionWithoutPrefix)) {
                         _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .debug */ .Yz(`Invalid version: ${buildVersionWithoutPrefix}`);
                         continue;
                     }
@@ -153,7 +151,7 @@ class SapMachineDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE
         const sortedVersions = eligibleVersions.sort((versionObj1, versionObj2) => {
             const version1 = versionObj1.version;
             const version2 = versionObj2.version;
-            return semver__WEBPACK_IMPORTED_MODULE_2___default().compareBuild(version1, version2);
+            return semver__WEBPACK_IMPORTED_MODULE_1___default().compareBuild(version1, version2);
         });
         return sortedVersions.reverse();
     }
@@ -165,7 +163,7 @@ class SapMachineDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE
                 return 'macos';
             case 'linux':
                 // figure out if alpine/musl
-                if (fs__WEBPACK_IMPORTED_MODULE_3___default().existsSync('/etc/alpine-release')) {
+                if (fs__WEBPACK_IMPORTED_MODULE_2___default().existsSync('/etc/alpine-release')) {
                     return 'linux-musl';
                 }
                 return 'linux';

--- a/dist/setup/63.index.js
+++ b/dist/setup/63.index.js
@@ -13,12 +13,10 @@ export const modules = {
 /* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(semver__WEBPACK_IMPORTED_MODULE_1__);
 /* harmony import */ var _util_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(4527);
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(3838);
-/* harmony import */ var _actions_tool_cache__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(9805);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(9896);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_5___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_5__);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(6928);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_6___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_6__);
-
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(9896);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_4__);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(6928);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_5___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_5__);
 
 
 
@@ -40,9 +38,9 @@ class LibericaDistributions extends _base_installer_js__WEBPACK_IMPORTED_MODULE_
             javaArchivePath = (0,_util_js__WEBPACK_IMPORTED_MODULE_2__/* .renameWinArchive */ .n2)(javaArchivePath);
         }
         const extractedJavaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_2__/* .extractJdkFile */ .PE)(javaArchivePath, extension);
-        const archiveName = fs__WEBPACK_IMPORTED_MODULE_5___default().readdirSync(extractedJavaPath)[0];
-        const archivePath = path__WEBPACK_IMPORTED_MODULE_6___default().join(extractedJavaPath, archiveName);
-        const javaPath = await _actions_tool_cache__WEBPACK_IMPORTED_MODULE_4__/* .cacheDir */ .e8(archivePath, this.toolcacheFolderName, this.getToolcacheVersionName(javaRelease.version), this.architecture);
+        const archiveName = fs__WEBPACK_IMPORTED_MODULE_4___default().readdirSync(extractedJavaPath)[0];
+        const archivePath = path__WEBPACK_IMPORTED_MODULE_5___default().join(extractedJavaPath, archiveName);
+        const javaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_2__/* .cacheJdkDir */ .Vj)(archivePath, this.toolcacheFolderName, this.getToolcacheVersionName(javaRelease.version), this.architecture);
         return { version: javaRelease.version, path: javaPath };
     }
     async findPackageForDownload(range) {

--- a/dist/setup/675.index.js
+++ b/dist/setup/675.index.js
@@ -9,23 +9,21 @@ export const modules = {
 /* harmony export */   DragonwellDistribution: () => (/* binding */ DragonwellDistribution)
 /* harmony export */ });
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(3838);
-/* harmony import */ var _actions_tool_cache__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(9805);
-/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(2088);
-/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(semver__WEBPACK_IMPORTED_MODULE_2__);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(9896);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_3__);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(6928);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_4__);
-/* harmony import */ var _base_installer_js__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(6242);
-/* harmony import */ var _util_js__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(4527);
+/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(2088);
+/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(semver__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(9896);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(6928);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_3__);
+/* harmony import */ var _base_installer_js__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(6242);
+/* harmony import */ var _util_js__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(4527);
 
 
 
 
 
 
-
-class DragonwellDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5__/* .JavaBase */ .O {
+class DragonwellDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_4__/* .JavaBase */ .O {
     constructor(installerOptions) {
         super('Dragonwell', installerOptions);
     }
@@ -39,7 +37,7 @@ class DragonwellDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE
         const availableVersions = await this.getAvailableVersions();
         const matchedVersions = availableVersions
             .filter(item => {
-            return (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .isVersionSatisfies */ .y)(version, item.jdk_version);
+            return (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .isVersionSatisfies */ .y)(version, item.jdk_version);
         })
             .map(item => {
             return {
@@ -83,15 +81,15 @@ class DragonwellDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE
         _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq(`Downloading Java ${javaRelease.version} (${this.distribution}) from ${javaRelease.url} ...`);
         let javaArchivePath = await this.downloadAndVerify(javaRelease);
         _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq(`Extracting Java archive...`);
-        const extension = (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .getDownloadArchiveExtension */ .ag)();
+        const extension = (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .getDownloadArchiveExtension */ .ag)();
         if (process.platform === 'win32') {
-            javaArchivePath = (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .renameWinArchive */ .n2)(javaArchivePath);
+            javaArchivePath = (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .renameWinArchive */ .n2)(javaArchivePath);
         }
-        const extractedJavaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .extractJdkFile */ .PE)(javaArchivePath, extension);
-        const archiveName = fs__WEBPACK_IMPORTED_MODULE_3___default().readdirSync(extractedJavaPath)[0];
-        const archivePath = path__WEBPACK_IMPORTED_MODULE_4___default().join(extractedJavaPath, archiveName);
+        const extractedJavaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .extractJdkFile */ .PE)(javaArchivePath, extension);
+        const archiveName = fs__WEBPACK_IMPORTED_MODULE_2___default().readdirSync(extractedJavaPath)[0];
+        const archivePath = path__WEBPACK_IMPORTED_MODULE_3___default().join(extractedJavaPath, archiveName);
         const version = this.getToolcacheVersionName(javaRelease.version);
-        const javaPath = await _actions_tool_cache__WEBPACK_IMPORTED_MODULE_1__/* .cacheDir */ .e8(archivePath, this.toolcacheFolderName, version, this.architecture);
+        const javaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .cacheJdkDir */ .Vj)(archivePath, this.toolcacheFolderName, version, this.architecture);
         return { version: javaRelease.version, path: javaPath };
     }
     parseVersions(platform, arch, dragonwellVersions) {
@@ -116,7 +114,7 @@ class DragonwellDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE
                 const jdkVersionNums = jdkVersion
                     .replace('+', '.')
                     .split('.');
-                jdkVersion = (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .convertVersionToSemver */ .ZY)(`${jdkVersionNums.slice(0, 3).join('.')}.${jdkVersionNums[jdkVersionNums.length - 1]}`);
+                jdkVersion = (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .convertVersionToSemver */ .ZY)(`${jdkVersionNums.slice(0, 3).join('.')}.${jdkVersionNums[jdkVersionNums.length - 1]}`);
                 for (const edition in archMap) {
                     eligibleVersions.push({
                         os: platform,
@@ -139,7 +137,7 @@ class DragonwellDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE
         const sortedVersions = eligibleVersions.sort((versionObj1, versionObj2) => {
             const version1 = versionObj1.jdk_version;
             const version2 = versionObj2.jdk_version;
-            return semver__WEBPACK_IMPORTED_MODULE_2___default().compareBuild(version1, version2);
+            return semver__WEBPACK_IMPORTED_MODULE_1___default().compareBuild(version1, version2);
         });
         return sortedVersions.reverse();
     }
@@ -169,7 +167,7 @@ class DragonwellDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE
         const branch = 'main';
         const filePath = 'releases.json';
         const backupUrl = `https://api.github.com/repos/${owner}/${repository}/contents/${filePath}?ref=${branch}`;
-        const headers = (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .getGitHubHttpHeaders */ .U_)();
+        const headers = (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .getGitHubHttpHeaders */ .U_)();
         try {
             _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .debug */ .Yz(`Trying to fetch available Dragonwell versions info from the backup url: ${backupUrl}`);
             const fetchedDragonwellJson = (await this.http.getJson(backupUrl, headers)).result;

--- a/dist/setup/735.index.js
+++ b/dist/setup/735.index.js
@@ -9,16 +9,14 @@ export const modules = {
 /* harmony export */   OpenJdkDistribution: () => (/* binding */ OpenJdkDistribution)
 /* harmony export */ });
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(3838);
-/* harmony import */ var _actions_tool_cache__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(9805);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(9896);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_2__);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(6928);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_3__);
-/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(2088);
-/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__webpack_require__.n(semver__WEBPACK_IMPORTED_MODULE_4__);
-/* harmony import */ var _base_installer_js__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(6242);
-/* harmony import */ var _util_js__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(4527);
-
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(9896);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(6928);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(2088);
+/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(semver__WEBPACK_IMPORTED_MODULE_3__);
+/* harmony import */ var _base_installer_js__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(6242);
+/* harmony import */ var _util_js__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(4527);
 
 
 
@@ -26,7 +24,7 @@ export const modules = {
 
 
 const OPENJDK_BASE_URL = 'https://jdk.java.net';
-class OpenJdkDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5__/* .JavaBase */ .O {
+class OpenJdkDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_4__/* .JavaBase */ .O {
     constructor(installerOptions) {
         super('Oracle OpenJDK', installerOptions);
     }
@@ -41,8 +39,8 @@ class OpenJdkDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5_
         const platform = this.getPlatform();
         const releases = await this.getAvailableVersions(platform, arch);
         const matchingReleases = releases
-            .filter(release => (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .isVersionSatisfies */ .y)(range, release.version))
-            .sort((left, right) => -semver__WEBPACK_IMPORTED_MODULE_4___default().compareBuild(left.version, right.version));
+            .filter(release => (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .isVersionSatisfies */ .y)(range, release.version))
+            .sort((left, right) => -semver__WEBPACK_IMPORTED_MODULE_3___default().compareBuild(left.version, right.version));
         if (!matchingReleases.length) {
             throw this.createVersionNotFoundError(range, releases.map(release => release.version), `Platform: ${platform}`);
         }
@@ -58,12 +56,12 @@ class OpenJdkDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5_
         _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq(`Extracting Java archive...`);
         const extension = javaRelease.url.endsWith('.zip') ? 'zip' : 'tar.gz';
         if (extension === 'zip') {
-            javaArchivePath = (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .renameWinArchive */ .n2)(javaArchivePath);
+            javaArchivePath = (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .renameWinArchive */ .n2)(javaArchivePath);
         }
-        const extractedJavaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .extractJdkFile */ .PE)(javaArchivePath, extension);
-        const archiveName = fs__WEBPACK_IMPORTED_MODULE_2___default().readdirSync(extractedJavaPath)[0];
-        const archivePath = path__WEBPACK_IMPORTED_MODULE_3___default().join(extractedJavaPath, archiveName);
-        const javaPath = await _actions_tool_cache__WEBPACK_IMPORTED_MODULE_1__/* .cacheDir */ .e8(archivePath, this.toolcacheFolderName, this.getToolcacheVersionName(javaRelease.version), this.architecture);
+        const extractedJavaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .extractJdkFile */ .PE)(javaArchivePath, extension);
+        const archiveName = fs__WEBPACK_IMPORTED_MODULE_1___default().readdirSync(extractedJavaPath)[0];
+        const archivePath = path__WEBPACK_IMPORTED_MODULE_2___default().join(extractedJavaPath, archiveName);
+        const javaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .cacheJdkDir */ .Vj)(archivePath, this.toolcacheFolderName, this.getToolcacheVersionName(javaRelease.version), this.architecture);
         return { version: javaRelease.version, path: javaPath };
     }
     async getAvailableVersions(platform, arch) {
@@ -106,7 +104,7 @@ class OpenJdkDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5_
     toSemver(version, urlBuild) {
         const [javaVersion, filenameBuild] = version.replace('-ea', '').split('+');
         const versionParts = javaVersion.split('.');
-        const normalizedVersion = (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .convertVersionToSemver */ .ZY)(versionParts.length === 1 ? `${javaVersion}.0.0` : javaVersion);
+        const normalizedVersion = (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .convertVersionToSemver */ .ZY)(versionParts.length === 1 ? `${javaVersion}.0.0` : javaVersion);
         const build = filenameBuild ?? (versionParts.length <= 3 ? urlBuild : undefined);
         return build ? `${normalizedVersion}+${build}` : normalizedVersion;
     }

--- a/dist/setup/939.index.js
+++ b/dist/setup/939.index.js
@@ -13,12 +13,10 @@ export const modules = {
 /* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(semver__WEBPACK_IMPORTED_MODULE_1__);
 /* harmony import */ var _util_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(4527);
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(3838);
-/* harmony import */ var _actions_tool_cache__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(9805);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(9896);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_5___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_5__);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(6928);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_6___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_6__);
-
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(9896);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_4__);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(6928);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_5___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_5__);
 
 
 
@@ -90,10 +88,10 @@ class SemeruDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_0__
             javaArchivePath = (0,_util_js__WEBPACK_IMPORTED_MODULE_2__/* .renameWinArchive */ .n2)(javaArchivePath);
         }
         const extractedJavaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_2__/* .extractJdkFile */ .PE)(javaArchivePath, extension);
-        const archiveName = fs__WEBPACK_IMPORTED_MODULE_5___default().readdirSync(extractedJavaPath)[0];
-        const archivePath = path__WEBPACK_IMPORTED_MODULE_6___default().join(extractedJavaPath, archiveName);
+        const archiveName = fs__WEBPACK_IMPORTED_MODULE_4___default().readdirSync(extractedJavaPath)[0];
+        const archivePath = path__WEBPACK_IMPORTED_MODULE_5___default().join(extractedJavaPath, archiveName);
         const version = this.getToolcacheVersionName(javaRelease.version);
-        const javaPath = await _actions_tool_cache__WEBPACK_IMPORTED_MODULE_4__/* .cacheDir */ .e8(archivePath, this.toolcacheFolderName, version, this.architecture);
+        const javaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_2__/* .cacheJdkDir */ .Vj)(archivePath, this.toolcacheFolderName, version, this.architecture);
         return { version: javaRelease.version, path: javaPath };
     }
     get toolcacheFolderName() {

--- a/dist/setup/968.index.js
+++ b/dist/setup/968.index.js
@@ -10,17 +10,15 @@ export const modules = {
 /* harmony export */   GraalVMDistribution: () => (/* binding */ GraalVMDistribution)
 /* harmony export */ });
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(3838);
-/* harmony import */ var _actions_tool_cache__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(9805);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(9896);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_2__);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(6928);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_3__);
-/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(2088);
-/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__webpack_require__.n(semver__WEBPACK_IMPORTED_MODULE_4__);
-/* harmony import */ var _base_installer_js__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(6242);
-/* harmony import */ var _actions_http_client__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(4942);
-/* harmony import */ var _util_js__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(4527);
-
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(9896);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(6928);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(2088);
+/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(semver__WEBPACK_IMPORTED_MODULE_3__);
+/* harmony import */ var _base_installer_js__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(6242);
+/* harmony import */ var _actions_http_client__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(4942);
+/* harmony import */ var _util_js__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(4527);
 
 
 
@@ -39,7 +37,7 @@ const IS_WINDOWS = process.platform === 'win32';
 const GRAALVM_PLATFORM = IS_WINDOWS ? 'windows' : process.platform;
 const GRAALVM_MIN_VERSION = 17;
 const SUPPORTED_ARCHITECTURES = ['x64', 'aarch64'];
-class GraalVMDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5__/* .JavaBase */ .O {
+class GraalVMDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_4__/* .JavaBase */ .O {
     constructor(installerOptions, distributionName = 'GraalVM') {
         super(distributionName, installerOptions);
     }
@@ -48,22 +46,22 @@ class GraalVMDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5_
             _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq(`Downloading Java ${javaRelease.version} (${this.distribution}) from ${javaRelease.url} ...`);
             let javaArchivePath = await this.downloadAndVerify(javaRelease);
             _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq(`Extracting Java archive...`);
-            const extension = (0,_util_js__WEBPACK_IMPORTED_MODULE_7__/* .getDownloadArchiveExtension */ .ag)();
+            const extension = (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .getDownloadArchiveExtension */ .ag)();
             if (IS_WINDOWS) {
-                javaArchivePath = (0,_util_js__WEBPACK_IMPORTED_MODULE_7__/* .renameWinArchive */ .n2)(javaArchivePath);
+                javaArchivePath = (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .renameWinArchive */ .n2)(javaArchivePath);
             }
-            const extractedJavaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_7__/* .extractJdkFile */ .PE)(javaArchivePath, extension);
+            const extractedJavaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .extractJdkFile */ .PE)(javaArchivePath, extension);
             // Add validation for extracted path
-            if (!fs__WEBPACK_IMPORTED_MODULE_2___default().existsSync(extractedJavaPath)) {
+            if (!fs__WEBPACK_IMPORTED_MODULE_1___default().existsSync(extractedJavaPath)) {
                 throw new Error(`Extraction failed: path ${extractedJavaPath} does not exist`);
             }
-            const dirContents = fs__WEBPACK_IMPORTED_MODULE_2___default().readdirSync(extractedJavaPath);
+            const dirContents = fs__WEBPACK_IMPORTED_MODULE_1___default().readdirSync(extractedJavaPath);
             if (dirContents.length === 0) {
                 throw new Error('Extraction failed: no files found in extracted directory');
             }
-            const archivePath = path__WEBPACK_IMPORTED_MODULE_3___default().join(extractedJavaPath, dirContents[0]);
+            const archivePath = path__WEBPACK_IMPORTED_MODULE_2___default().join(extractedJavaPath, dirContents[0]);
             const version = this.getToolcacheVersionName(javaRelease.version);
-            const javaPath = await _actions_tool_cache__WEBPACK_IMPORTED_MODULE_1__/* .cacheDir */ .e8(archivePath, this.toolcacheFolderName, version, this.architecture);
+            const javaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .cacheJdkDir */ .Vj)(archivePath, this.toolcacheFolderName, version, this.architecture);
             return { version: javaRelease.version, path: javaPath };
         }
         catch (error) {
@@ -85,7 +83,7 @@ class GraalVMDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5_
         // builds its download URLs from a concrete major and has no endpoint to list
         // releases, so resolve the newest available GA major from the Adoptium API.
         if (this.latest) {
-            range = (await (0,_util_js__WEBPACK_IMPORTED_MODULE_7__/* .getLatestMajorVersion */ .ri)(this.http)).toString();
+            range = (await (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .getLatestMajorVersion */ .ri)(this.http)).toString();
         }
         const { platform, extension, major } = this.validateStableBuildRequest(range);
         const fileUrl = this.constructFileUrl(range, major, platform, arch, extension);
@@ -114,7 +112,7 @@ class GraalVMDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5_
             throw new Error(`${this.distribution} provides only the \`jdk\` package type`);
         }
         const platform = this.getPlatform();
-        const extension = (0,_util_js__WEBPACK_IMPORTED_MODULE_7__/* .getDownloadArchiveExtension */ .ag)();
+        const extension = (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .getDownloadArchiveExtension */ .ag)();
         const major = range.includes('.') ? range.split('.')[0] : range;
         const majorVersion = parseInt(major);
         if (isNaN(majorVersion)) {
@@ -136,7 +134,7 @@ class GraalVMDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5_
     }
     handleHttpResponse(response, range) {
         const statusCode = response.message.statusCode;
-        if (statusCode === _actions_http_client__WEBPACK_IMPORTED_MODULE_6__/* .HttpCodes */ .Hv.NotFound) {
+        if (statusCode === _actions_http_client__WEBPACK_IMPORTED_MODULE_5__/* .HttpCodes */ .Hv.NotFound) {
             // Create the standard error with additional hint about checking the download URL
             const error = this.createVersionNotFoundError(range);
             if (this.latest) {
@@ -145,11 +143,11 @@ class GraalVMDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5_
             error.message += `\nPlease check if this version is available at ${GRAALVM_DOWNLOAD_URL} . Pick a version from the list.`;
             throw error;
         }
-        if (statusCode === _actions_http_client__WEBPACK_IMPORTED_MODULE_6__/* .HttpCodes */ .Hv.Unauthorized ||
-            statusCode === _actions_http_client__WEBPACK_IMPORTED_MODULE_6__/* .HttpCodes */ .Hv.Forbidden) {
+        if (statusCode === _actions_http_client__WEBPACK_IMPORTED_MODULE_5__/* .HttpCodes */ .Hv.Unauthorized ||
+            statusCode === _actions_http_client__WEBPACK_IMPORTED_MODULE_5__/* .HttpCodes */ .Hv.Forbidden) {
             throw new Error(`Access denied when downloading GraalVM. Status code: ${statusCode}. Please check your credentials or permissions.`);
         }
-        if (statusCode !== _actions_http_client__WEBPACK_IMPORTED_MODULE_6__/* .HttpCodes */ .Hv.OK) {
+        if (statusCode !== _actions_http_client__WEBPACK_IMPORTED_MODULE_5__/* .HttpCodes */ .Hv.OK) {
             throw new Error(`HTTP request for GraalVM failed with status code: ${statusCode} (${response.message.statusMessage || 'Unknown error'})`);
         }
     }
@@ -182,7 +180,7 @@ class GraalVMDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5_
     }
     async fetchEAJson(javaEaVersion) {
         const url = `https://api.github.com/repos/graalvm/oracle-graalvm-ea-builds/contents/versions/${javaEaVersion}.json?ref=main`;
-        const headers = (0,_util_js__WEBPACK_IMPORTED_MODULE_7__/* .getGitHubHttpHeaders */ .U_)();
+        const headers = (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .getGitHubHttpHeaders */ .U_)();
         _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .debug */ .Yz(`Trying to fetch available version info for GraalVM EA builds from '${url}'`);
         try {
             const response = await this.http.getJson(url, headers);
@@ -243,7 +241,7 @@ class GraalVMCommunityDistribution extends GraalVMDistribution {
                 throw new Error(`${this.distribution} provides only the \`jdk\` package type`);
             }
             platform = this.getPlatform();
-            extension = (0,_util_js__WEBPACK_IMPORTED_MODULE_7__/* .getDownloadArchiveExtension */ .ag)();
+            extension = (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .getDownloadArchiveExtension */ .ag)();
         }
         else {
             ({ platform, extension } = this.validateStableBuildRequest(range));
@@ -253,8 +251,8 @@ class GraalVMCommunityDistribution extends GraalVMDistribution {
         const assetSuffix = `_${platform}-${arch}_bin.${extension}`;
         const availableVersions = await this.getAvailableVersions(assetSuffix);
         const satisfiedVersion = availableVersions
-            .filter(item => (0,_util_js__WEBPACK_IMPORTED_MODULE_7__/* .isVersionSatisfies */ .y)(range, item.version))
-            .sort((a, b) => -semver__WEBPACK_IMPORTED_MODULE_4___default().compareBuild(a.version, b.version))[0];
+            .filter(item => (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .isVersionSatisfies */ .y)(range, item.version))
+            .sort((a, b) => -semver__WEBPACK_IMPORTED_MODULE_3___default().compareBuild(a.version, b.version))[0];
         if (!satisfiedVersion) {
             const error = this.createVersionNotFoundError(range, availableVersions.map(item => item.version), `Platform: ${platform}`);
             error.message += `\nPlease check if this version is available at ${GRAALVM_COMMUNITY_DOWNLOAD_URL}.`;
@@ -263,10 +261,10 @@ class GraalVMCommunityDistribution extends GraalVMDistribution {
         return satisfiedVersion;
     }
     async getAvailableVersions(assetSuffix) {
-        const headers = (0,_util_js__WEBPACK_IMPORTED_MODULE_7__/* .getGitHubHttpHeaders */ .U_)();
+        const headers = (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .getGitHubHttpHeaders */ .U_)();
         const versions = new Map();
         let releasesUrl = GRAALVM_COMMUNITY_RELEASES_URL;
-        for (let pageIndex = 0; releasesUrl && pageIndex < _util_js__WEBPACK_IMPORTED_MODULE_7__/* .MAX_PAGINATION_PAGES */ .Tp; pageIndex++) {
+        for (let pageIndex = 0; releasesUrl && pageIndex < _util_js__WEBPACK_IMPORTED_MODULE_6__/* .MAX_PAGINATION_PAGES */ .Tp; pageIndex++) {
             const response = await this.http.getJson(releasesUrl, headers);
             // A successful GitHub releases listing is always a JSON array (possibly
             // empty). Anything else indicates an unexpected/error payload (rate
@@ -322,12 +320,12 @@ class GraalVMCommunityDistribution extends GraalVMDistribution {
         if (!GRAALVM_COMMUNITY_VERSION_PATTERN.test(rawVersion)) {
             return null;
         }
-        return (0,_util_js__WEBPACK_IMPORTED_MODULE_7__/* .convertVersionToSemver */ .ZY)(rawVersion);
+        return (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .convertVersionToSemver */ .ZY)(rawVersion);
     }
     getNextReleasesUrl(headers) {
-        const nextUrl = (0,_util_js__WEBPACK_IMPORTED_MODULE_7__/* .getNextPageUrlFromLinkHeader */ .rC)(headers);
+        const nextUrl = (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .getNextPageUrlFromLinkHeader */ .rC)(headers);
         if (nextUrl &&
-            !(0,_util_js__WEBPACK_IMPORTED_MODULE_7__/* .validatePaginationUrl */ .SA)(nextUrl, GRAALVM_COMMUNITY_RELEASES_PAGE_ORIGIN)) {
+            !(0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .validatePaginationUrl */ .SA)(nextUrl, GRAALVM_COMMUNITY_RELEASES_PAGE_ORIGIN)) {
             _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .warning */ .$e(`Ignoring pagination link with unexpected origin: ${nextUrl}`);
             return null;
         }

--- a/dist/setup/978.index.js
+++ b/dist/setup/978.index.js
@@ -9,23 +9,21 @@ export const modules = {
 /* harmony export */   ZuluDistribution: () => (/* binding */ ZuluDistribution)
 /* harmony export */ });
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(3838);
-/* harmony import */ var _actions_tool_cache__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(9805);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(6928);
-/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_2__);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(9896);
-/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_3__);
-/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(2088);
-/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_4___default = /*#__PURE__*/__webpack_require__.n(semver__WEBPACK_IMPORTED_MODULE_4__);
-/* harmony import */ var _base_installer_js__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(6242);
-/* harmony import */ var _util_js__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(4527);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(6928);
+/* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(9896);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(2088);
+/* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(semver__WEBPACK_IMPORTED_MODULE_3__);
+/* harmony import */ var _base_installer_js__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(6242);
+/* harmony import */ var _util_js__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(4527);
 
 
 
 
 
 
-
-class ZuluDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5__/* .JavaBase */ .O {
+class ZuluDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_4__/* .JavaBase */ .O {
     constructor(installerOptions) {
         super('Zulu', installerOptions);
     }
@@ -39,19 +37,19 @@ class ZuluDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5__/*
                 ? [...item.java_version, item.openjdk_build_number]
                 : item.java_version;
             return {
-                version: (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .convertVersionToSemver */ .ZY)(javaVersion),
+                version: (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .convertVersionToSemver */ .ZY)(javaVersion),
                 url: item.download_url,
-                zuluVersion: (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .convertVersionToSemver */ .ZY)(item.distro_version),
+                zuluVersion: (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .convertVersionToSemver */ .ZY)(item.distro_version),
                 packageUuid: item.package_uuid
             };
         });
         const satisfiedVersions = availableVersions
-            .filter(item => (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .isVersionSatisfies */ .y)(version, item.version))
+            .filter(item => (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .isVersionSatisfies */ .y)(version, item.version))
             .sort((a, b) => {
             // Azul provides two versions: java_version and distro_version
             // we should sort by both fields by descending
-            return (-semver__WEBPACK_IMPORTED_MODULE_4___default().compareBuild(a.version, b.version) ||
-                -semver__WEBPACK_IMPORTED_MODULE_4___default().compareBuild(a.zuluVersion, b.zuluVersion));
+            return (-semver__WEBPACK_IMPORTED_MODULE_3___default().compareBuild(a.version, b.version) ||
+                -semver__WEBPACK_IMPORTED_MODULE_3___default().compareBuild(a.zuluVersion, b.zuluVersion));
         })
             .map((item) => ({
             version: item.version,
@@ -85,21 +83,21 @@ class ZuluDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_5__/*
         _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq(`Downloading Java ${javaRelease.version} (${this.distribution}) from ${javaRelease.url} ...`);
         let javaArchivePath = await this.downloadAndVerify(javaRelease);
         _actions_core__WEBPACK_IMPORTED_MODULE_0__/* .info */ .pq(`Extracting Java archive...`);
-        const extension = (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .getDownloadArchiveExtension */ .ag)();
+        const extension = (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .getDownloadArchiveExtension */ .ag)();
         if (process.platform === 'win32') {
-            javaArchivePath = (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .renameWinArchive */ .n2)(javaArchivePath);
+            javaArchivePath = (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .renameWinArchive */ .n2)(javaArchivePath);
         }
-        const extractedJavaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .extractJdkFile */ .PE)(javaArchivePath, extension);
-        const archiveName = fs__WEBPACK_IMPORTED_MODULE_3___default().readdirSync(extractedJavaPath)[0];
-        const archivePath = path__WEBPACK_IMPORTED_MODULE_2___default().join(extractedJavaPath, archiveName);
-        const javaPath = await _actions_tool_cache__WEBPACK_IMPORTED_MODULE_1__/* .cacheDir */ .e8(archivePath, this.toolcacheFolderName, this.getToolcacheVersionName(javaRelease.version), this.architecture);
+        const extractedJavaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .extractJdkFile */ .PE)(javaArchivePath, extension);
+        const archiveName = fs__WEBPACK_IMPORTED_MODULE_2___default().readdirSync(extractedJavaPath)[0];
+        const archivePath = path__WEBPACK_IMPORTED_MODULE_1___default().join(extractedJavaPath, archiveName);
+        const javaPath = await (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .cacheJdkDir */ .Vj)(archivePath, this.toolcacheFolderName, this.getToolcacheVersionName(javaRelease.version), this.architecture);
         return { version: javaRelease.version, path: javaPath };
     }
     async getAvailableVersions() {
         const arch = this.getArchitectureOptions();
         const [bundleType, features] = this.packageType.split('+');
         const platform = this.getPlatformOption();
-        const extension = (0,_util_js__WEBPACK_IMPORTED_MODULE_6__/* .getDownloadArchiveExtension */ .ag)();
+        const extension = (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .getDownloadArchiveExtension */ .ag)();
         const javafx = features?.includes('fx') ?? false;
         const crac = features?.includes('crac') ?? false;
         const releaseStatus = this.stable ? 'ga' : 'ea';

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -31241,6 +31241,7 @@ function validateToolchainIds(versions, versionFile, toolchainIds) {
 /* harmony export */   SA: () => (/* binding */ validatePaginationUrl),
 /* harmony export */   Tp: () => (/* binding */ MAX_PAGINATION_PAGES),
 /* harmony export */   U_: () => (/* binding */ getGitHubHttpHeaders),
+/* harmony export */   Vj: () => (/* binding */ cacheJdkDir),
 /* harmony export */   Vt: () => (/* binding */ getBooleanInput),
 /* harmony export */   ZY: () => (/* binding */ convertVersionToSemver),
 /* harmony export */   aT: () => (/* binding */ isGhes),
@@ -31263,7 +31264,14 @@ function validateToolchainIds(versions, versionFile, toolchainIds) {
 /* harmony import */ var semver__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__nccwpck_require__.n(semver__WEBPACK_IMPORTED_MODULE_3__);
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_4__ = __nccwpck_require__(3838);
 /* harmony import */ var _actions_tool_cache__WEBPACK_IMPORTED_MODULE_5__ = __nccwpck_require__(9805);
-/* harmony import */ var _constants_js__WEBPACK_IMPORTED_MODULE_6__ = __nccwpck_require__(7242);
+/* harmony import */ var _actions_exec__WEBPACK_IMPORTED_MODULE_6__ = __nccwpck_require__(5260);
+/* harmony import */ var _actions_io__WEBPACK_IMPORTED_MODULE_7__ = __nccwpck_require__(8701);
+/* harmony import */ var crypto__WEBPACK_IMPORTED_MODULE_8__ = __nccwpck_require__(6982);
+/* harmony import */ var crypto__WEBPACK_IMPORTED_MODULE_8___default = /*#__PURE__*/__nccwpck_require__.n(crypto__WEBPACK_IMPORTED_MODULE_8__);
+/* harmony import */ var _constants_js__WEBPACK_IMPORTED_MODULE_9__ = __nccwpck_require__(7242);
+
+
+
 
 
 
@@ -31290,8 +31298,8 @@ function getBooleanInput(inputName, defaultValue = false) {
     throw new Error(`Invalid value '${inputValue}' for boolean input '${inputName}'. Expected 'true' or 'false'.`);
 }
 function isJdkCacheEnabled(cache) {
-    return _actions_core__WEBPACK_IMPORTED_MODULE_4__/* .getInput */ .V4(_constants_js__WEBPACK_IMPORTED_MODULE_6__/* .INPUT_CACHE_JDK */ .GL).trim()
-        ? getBooleanInput(_constants_js__WEBPACK_IMPORTED_MODULE_6__/* .INPUT_CACHE_JDK */ .GL)
+    return _actions_core__WEBPACK_IMPORTED_MODULE_4__/* .getInput */ .V4(_constants_js__WEBPACK_IMPORTED_MODULE_9__/* .INPUT_CACHE_JDK */ .GL).trim()
+        ? getBooleanInput(_constants_js__WEBPACK_IMPORTED_MODULE_9__/* .INPUT_CACHE_JDK */ .GL)
         : Boolean(cache.trim());
 }
 function getVersionFromToolcachePath(toolPath) {
@@ -31311,13 +31319,115 @@ async function extractJdkFile(toolPath, extension) {
     }
     switch (extension) {
         case 'tar.gz':
+            return await extractTarGz(toolPath);
         case 'tar':
             return await _actions_tool_cache__WEBPACK_IMPORTED_MODULE_5__/* .extractTar */ .nN(toolPath);
         case 'zip':
-            return await _actions_tool_cache__WEBPACK_IMPORTED_MODULE_5__/* .extractZip */ .JE(toolPath);
+            return await extractZipArchive(toolPath);
         default:
             return await _actions_tool_cache__WEBPACK_IMPORTED_MODULE_5__/* .extract7z */ .$E(toolPath);
     }
+}
+async function createExtractFolder() {
+    const dest = path__WEBPACK_IMPORTED_MODULE_1___default().join(getTempDir(), (0,crypto__WEBPACK_IMPORTED_MODULE_8__.randomUUID)());
+    await _actions_io__WEBPACK_IMPORTED_MODULE_7__/* .mkdirP */ .U$(dest);
+    return dest;
+}
+/**
+ * Decompressing a JDK tarball with the default single-threaded gzip is one of the
+ * slowest parts of the install, so hand the decompression to `pigz` when the runner
+ * provides it. Any failure falls back to the stock extraction.
+ */
+async function extractTarGz(toolPath) {
+    const pigzPath = await _actions_io__WEBPACK_IMPORTED_MODULE_7__/* .which */ .K7('pigz');
+    // tar splits --use-compress-program on whitespace, so a path containing a
+    // space would be word-split into a bogus command.
+    if (pigzPath && !/\s/.test(pigzPath)) {
+        const dest = await createExtractFolder();
+        try {
+            return await _actions_tool_cache__WEBPACK_IMPORTED_MODULE_5__/* .extractTar */ .nN(toolPath, dest, [
+                '--use-compress-program',
+                `${pigzPath} -d`,
+                '-x'
+            ]);
+        }
+        catch (error) {
+            await _actions_io__WEBPACK_IMPORTED_MODULE_7__/* .rmRF */ .Yz(dest);
+            _actions_core__WEBPACK_IMPORTED_MODULE_4__/* .debug */ .Yz(`Failed to extract '${toolPath}' with pigz, falling back to gzip: ${getErrorMessage(error)}`);
+        }
+    }
+    return await _actions_tool_cache__WEBPACK_IMPORTED_MODULE_5__/* .extractTar */ .nN(toolPath);
+}
+/**
+ * `tc.extractZip` shells out to PowerShell's `Expand-Archive` on Windows, which is
+ * several times slower than the bundled bsdtar. Prefer `tar.exe` and fall back to
+ * the stock extraction when it is unavailable or fails.
+ */
+async function extractZipArchive(toolPath) {
+    if (process.platform === 'win32') {
+        const systemTar = path__WEBPACK_IMPORTED_MODULE_1___default().join(process.env['SystemRoot'] || 'C:\\Windows', 'System32', 'tar.exe');
+        if (fs__WEBPACK_IMPORTED_MODULE_2__.existsSync(systemTar)) {
+            const dest = await createExtractFolder();
+            try {
+                await _actions_exec__WEBPACK_IMPORTED_MODULE_6__/* .exec */ .m(`"${systemTar}"`, ['-xf', toolPath, '-C', dest], {
+                    silent: true
+                });
+                return dest;
+            }
+            catch (error) {
+                await _actions_io__WEBPACK_IMPORTED_MODULE_7__/* .rmRF */ .Yz(dest);
+                _actions_core__WEBPACK_IMPORTED_MODULE_4__/* .debug */ .Yz(`Failed to extract '${toolPath}' with tar.exe, falling back to Expand-Archive: ${getErrorMessage(error)}`);
+            }
+        }
+    }
+    return await _actions_tool_cache__WEBPACK_IMPORTED_MODULE_5__/* .extractZip */ .JE(toolPath);
+}
+/**
+ * Equivalent of `tc.cacheDir`, but moves the extracted JDK into the tool-cache
+ * instead of copying it. `tc.cacheDir` recursively copies the whole tree, which
+ * means a several hundred megabyte JDK is written to disk twice. The extraction
+ * directory and the tool-cache normally live on the same filesystem, so a rename
+ * is effectively free. Anything unexpected (a different filesystem, or a file
+ * handle held open by anti-virus software on Windows) falls back to the copy.
+ */
+async function cacheJdkDir(sourceDir, toolName, version, architecture) {
+    const destPath = getToolcacheDestination(toolName, version, architecture);
+    if (destPath) {
+        let moved = false;
+        try {
+            // lstat, not stat: renaming a symlinked source would put the link itself
+            // in the tool-cache, leaving a dangling JAVA_HOME once RUNNER_TEMP is
+            // cleaned. tc.cacheDir dereferences it, so let it handle that case.
+            if (fs__WEBPACK_IMPORTED_MODULE_2__.lstatSync(sourceDir).isDirectory()) {
+                await _actions_io__WEBPACK_IMPORTED_MODULE_7__/* .rmRF */ .Yz(destPath);
+                await _actions_io__WEBPACK_IMPORTED_MODULE_7__/* .rmRF */ .Yz(`${destPath}.complete`);
+                await _actions_io__WEBPACK_IMPORTED_MODULE_7__/* .mkdirP */ .U$(path__WEBPACK_IMPORTED_MODULE_1___default().dirname(destPath));
+                // Renaming is atomic, so a failure here leaves sourceDir untouched and
+                // the copy-based fallback below can still run.
+                fs__WEBPACK_IMPORTED_MODULE_2__.renameSync(sourceDir, destPath);
+                moved = true;
+            }
+        }
+        catch (error) {
+            _actions_core__WEBPACK_IMPORTED_MODULE_4__/* .debug */ .Yz(`Failed to move '${sourceDir}' into the tool-cache, falling back to a copy: ${getErrorMessage(error)}`);
+        }
+        if (moved) {
+            fs__WEBPACK_IMPORTED_MODULE_2__.writeFileSync(`${destPath}.complete`, '');
+            return destPath;
+        }
+    }
+    return await _actions_tool_cache__WEBPACK_IMPORTED_MODULE_5__/* .cacheDir */ .e8(sourceDir, toolName, version, architecture);
+}
+function getToolcacheDestination(toolName, version, architecture) {
+    const toolcacheRoot = process.env['RUNNER_TOOL_CACHE'];
+    if (!toolcacheRoot) {
+        return null;
+    }
+    // Mirrors the destination layout used by `tc.cacheDir`.
+    return path__WEBPACK_IMPORTED_MODULE_1___default().join(toolcacheRoot, toolName, semver__WEBPACK_IMPORTED_MODULE_3__.clean(version) || version, architecture || os__WEBPACK_IMPORTED_MODULE_0___default().arch());
+}
+function getErrorMessage(error) {
+    return error instanceof Error ? error.message : String(error);
 }
 function getDownloadArchiveExtension() {
     return process.platform === 'win32' ? 'zip' : 'tar.gz';
@@ -31415,7 +31525,7 @@ function getVersionFromFileContent(content, distributionName, versionFile) {
     }
     // Apply DISTRIBUTIONS_ONLY_MAJOR_VERSION logic whenever the effective distribution
     // (either explicitly provided or extracted from the version file) is in the list.
-    if (_constants_js__WEBPACK_IMPORTED_MODULE_6__/* .DISTRIBUTIONS_ONLY_MAJOR_VERSION */ ._V.includes(extractedDistribution || distributionName)) {
+    if (_constants_js__WEBPACK_IMPORTED_MODULE_9__/* .DISTRIBUTIONS_ONLY_MAJOR_VERSION */ ._V.includes(extractedDistribution || distributionName)) {
         const coerceVersion = semver__WEBPACK_IMPORTED_MODULE_3__.coerce(version) ?? version;
         version = semver__WEBPACK_IMPORTED_MODULE_3__.major(coerceVersion).toString();
     }

--- a/src/distributions/corretto/installer.ts
+++ b/src/distributions/corretto/installer.ts
@@ -1,8 +1,8 @@
 import * as core from '@actions/core';
-import * as tc from '@actions/tool-cache';
 import fs from 'fs';
 import path from 'path';
 import {
+  cacheJdkDir,
   extractJdkFile,
   getDownloadArchiveExtension,
   convertVersionToSemver,
@@ -46,7 +46,7 @@ export class CorrettoDistribution extends JavaBase {
     const archivePath = path.join(extractedJavaPath, archiveName);
     const version = this.getToolcacheVersionName(javaRelease.version);
 
-    const javaPath = await tc.cacheDir(
+    const javaPath = await cacheJdkDir(
       archivePath,
       this.toolcacheFolderName,
       version,

--- a/src/distributions/dragonwell/installer.ts
+++ b/src/distributions/dragonwell/installer.ts
@@ -1,5 +1,4 @@
 import * as core from '@actions/core';
-import * as tc from '@actions/tool-cache';
 import semver from 'semver';
 
 import fs from 'fs';
@@ -7,6 +6,7 @@ import path from 'path';
 
 import {JavaBase} from '../base-installer.js';
 import {
+  cacheJdkDir,
   convertVersionToSemver,
   extractJdkFile,
   getDownloadArchiveExtension,
@@ -121,7 +121,7 @@ export class DragonwellDistribution extends JavaBase {
     const archivePath = path.join(extractedJavaPath, archiveName);
     const version = this.getToolcacheVersionName(javaRelease.version);
 
-    const javaPath = await tc.cacheDir(
+    const javaPath = await cacheJdkDir(
       archivePath,
       this.toolcacheFolderName,
       version,

--- a/src/distributions/graalvm/installer.ts
+++ b/src/distributions/graalvm/installer.ts
@@ -1,5 +1,4 @@
 import * as core from '@actions/core';
-import * as tc from '@actions/tool-cache';
 import fs from 'fs';
 import path from 'path';
 import semver from 'semver';
@@ -12,6 +11,7 @@ import {
   JavaInstallerResults
 } from '../base-models.js';
 import {
+  cacheJdkDir,
   convertVersionToSemver,
   extractJdkFile,
   getDownloadArchiveExtension,
@@ -97,7 +97,7 @@ export class GraalVMDistribution extends JavaBase {
       const archivePath = path.join(extractedJavaPath, dirContents[0]);
       const version = this.getToolcacheVersionName(javaRelease.version);
 
-      const javaPath = await tc.cacheDir(
+      const javaPath = await cacheJdkDir(
         archivePath,
         this.toolcacheFolderName,
         version,

--- a/src/distributions/jetbrains/installer.ts
+++ b/src/distributions/jetbrains/installer.ts
@@ -1,5 +1,4 @@
 import * as core from '@actions/core';
-import * as tc from '@actions/tool-cache';
 
 import fs from 'fs';
 import path from 'path';
@@ -12,7 +11,7 @@ import {
   JavaInstallerOptions,
   JavaInstallerResults
 } from '../base-models.js';
-import {extractJdkFile, isVersionSatisfies} from '../../util.js';
+import {cacheJdkDir, extractJdkFile, isVersionSatisfies} from '../../util.js';
 import {OutgoingHttpHeaders} from 'http';
 import {HttpCodes} from '@actions/http-client';
 
@@ -79,7 +78,7 @@ export class JetBrainsDistribution extends JavaBase {
     const archivePath = path.join(extractedJavaPath, archiveName);
     const version = this.getToolcacheVersionName(javaRelease.version);
 
-    const javaPath = await tc.cacheDir(
+    const javaPath = await cacheJdkDir(
       archivePath,
       this.toolcacheFolderName,
       version,

--- a/src/distributions/kona/installer.ts
+++ b/src/distributions/kona/installer.ts
@@ -1,5 +1,4 @@
 import * as core from '@actions/core';
-import * as tc from '@actions/tool-cache';
 import semver from 'semver';
 
 import fs from 'fs';
@@ -13,6 +12,7 @@ import {
   JavaInstallerResults
 } from '../base-models.js';
 import {
+  cacheJdkDir,
   extractJdkFile,
   getDownloadArchiveExtension,
   isVersionSatisfies,
@@ -48,7 +48,7 @@ export class KonaDistribution extends JavaBase {
     const jdkDirectory = path.join(extractedJavaPath, archiveName);
     const version = this.getToolcacheVersionName(javaRelease.version);
 
-    const javaPath = await tc.cacheDir(
+    const javaPath = await cacheJdkDir(
       jdkDirectory,
       this.toolcacheFolderName,
       version,

--- a/src/distributions/liberica-nik/installer.ts
+++ b/src/distributions/liberica-nik/installer.ts
@@ -6,6 +6,7 @@ import {
 } from '../base-models.js';
 import semver from 'semver';
 import {
+  cacheJdkDir,
   extractJdkFile,
   getDownloadArchiveExtension,
   isVersionSatisfies,
@@ -13,7 +14,6 @@ import {
 } from '../../util.js';
 import * as core from '@actions/core';
 import {ArchitectureOptions, NikVersion, OsVersions} from './models.js';
-import * as tc from '@actions/tool-cache';
 import fs from 'fs';
 import path from 'path';
 
@@ -44,7 +44,7 @@ export class LibericaNikDistributions extends JavaBase {
     const archiveName = fs.readdirSync(extractedJavaPath)[0];
     const archivePath = path.join(extractedJavaPath, archiveName);
 
-    const javaPath = await tc.cacheDir(
+    const javaPath = await cacheJdkDir(
       archivePath,
       this.toolcacheFolderName,
       this.getToolcacheVersionName(javaRelease.version),

--- a/src/distributions/liberica/installer.ts
+++ b/src/distributions/liberica/installer.ts
@@ -6,6 +6,7 @@ import {
 } from '../base-models.js';
 import semver from 'semver';
 import {
+  cacheJdkDir,
   extractJdkFile,
   getDownloadArchiveExtension,
   isVersionSatisfies,
@@ -13,7 +14,6 @@ import {
 } from '../../util.js';
 import * as core from '@actions/core';
 import {ArchitectureOptions, LibericaVersion, OsVersions} from './models.js';
-import * as tc from '@actions/tool-cache';
 import fs from 'fs';
 import path from 'path';
 
@@ -44,7 +44,7 @@ export class LibericaDistributions extends JavaBase {
     const archiveName = fs.readdirSync(extractedJavaPath)[0];
     const archivePath = path.join(extractedJavaPath, archiveName);
 
-    const javaPath = await tc.cacheDir(
+    const javaPath = await cacheJdkDir(
       archivePath,
       this.toolcacheFolderName,
       this.getToolcacheVersionName(javaRelease.version),

--- a/src/distributions/local/installer.ts
+++ b/src/distributions/local/installer.ts
@@ -1,4 +1,3 @@
-import * as tc from '@actions/tool-cache';
 import * as core from '@actions/core';
 
 import fs from 'fs';
@@ -10,7 +9,7 @@ import {
   JavaDownloadRelease,
   JavaInstallerResults
 } from '../base-models.js';
-import {extractJdkFile} from '../../util.js';
+import {cacheJdkDir, extractJdkFile} from '../../util.js';
 import {MACOS_JAVA_CONTENT_POSTFIX} from '../../constants.js';
 import {createReadStream} from 'fs';
 import {createHash} from 'crypto';
@@ -92,7 +91,7 @@ export class LocalDistribution extends JavaBase {
         const archivePath = path.join(extractedJavaPath, archiveName);
         const javaVersion = this.version;
 
-        const javaPath = await tc.cacheDir(
+        const javaPath = await cacheJdkDir(
           archivePath,
           this.toolcacheFolderName,
           this.getToolcacheVersionName(javaVersion),

--- a/src/distributions/microsoft/installer.ts
+++ b/src/distributions/microsoft/installer.ts
@@ -5,6 +5,7 @@ import {
   JavaInstallerResults
 } from '../base-models.js';
 import {
+  cacheJdkDir,
   extractJdkFile,
   getDownloadArchiveExtension,
   getGitHubHttpHeaders,
@@ -64,7 +65,7 @@ export class MicrosoftDistributions extends JavaBase {
     const archiveName = fs.readdirSync(extractedJavaPath)[0];
     const archivePath = path.join(extractedJavaPath, archiveName);
 
-    const javaPath = await tc.cacheDir(
+    const javaPath = await cacheJdkDir(
       archivePath,
       this.toolcacheFolderName,
       this.getToolcacheVersionName(javaRelease.version),

--- a/src/distributions/openjdk/installer.ts
+++ b/src/distributions/openjdk/installer.ts
@@ -1,5 +1,4 @@
 import * as core from '@actions/core';
-import * as tc from '@actions/tool-cache';
 import fs from 'fs';
 import path from 'path';
 import semver from 'semver';
@@ -11,6 +10,7 @@ import {
   JavaInstallerResults
 } from '../base-models.js';
 import {
+  cacheJdkDir,
   convertVersionToSemver,
   extractJdkFile,
   isVersionSatisfies,
@@ -74,7 +74,7 @@ export class OpenJdkDistribution extends JavaBase {
 
     const archiveName = fs.readdirSync(extractedJavaPath)[0];
     const archivePath = path.join(extractedJavaPath, archiveName);
-    const javaPath = await tc.cacheDir(
+    const javaPath = await cacheJdkDir(
       archivePath,
       this.toolcacheFolderName,
       this.getToolcacheVersionName(javaRelease.version),

--- a/src/distributions/oracle/installer.ts
+++ b/src/distributions/oracle/installer.ts
@@ -1,5 +1,4 @@
 import * as core from '@actions/core';
-import * as tc from '@actions/tool-cache';
 
 import fs from 'fs';
 import path from 'path';
@@ -11,6 +10,7 @@ import {
   JavaInstallerResults
 } from '../base-models.js';
 import {
+  cacheJdkDir,
   extractJdkFile,
   getDownloadArchiveExtension,
   getLatestMajorVersion,
@@ -45,7 +45,7 @@ export class OracleDistribution extends JavaBase {
     const archivePath = path.join(extractedJavaPath, archiveName);
     const version = this.getToolcacheVersionName(javaRelease.version);
 
-    const javaPath = await tc.cacheDir(
+    const javaPath = await cacheJdkDir(
       archivePath,
       this.toolcacheFolderName,
       version,

--- a/src/distributions/sapmachine/installer.ts
+++ b/src/distributions/sapmachine/installer.ts
@@ -1,10 +1,10 @@
 import * as core from '@actions/core';
-import * as tc from '@actions/tool-cache';
 import semver from 'semver';
 import fs from 'fs';
 import {OutgoingHttpHeaders} from 'http';
 import path from 'path';
 import {
+  cacheJdkDir,
   convertVersionToSemver,
   extractJdkFile,
   getDownloadArchiveExtension,
@@ -124,7 +124,7 @@ export class SapMachineDistribution extends JavaBase {
     const archivePath = path.join(extractedJavaPath, archiveName);
     const version = this.getToolcacheVersionName(javaRelease.version);
 
-    const javaPath = await tc.cacheDir(
+    const javaPath = await cacheJdkDir(
       archivePath,
       this.toolcacheFolderName,
       version,

--- a/src/distributions/semeru/installer.ts
+++ b/src/distributions/semeru/installer.ts
@@ -6,6 +6,7 @@ import {
 } from '../base-models.js';
 import semver from 'semver';
 import {
+  cacheJdkDir,
   extractJdkFile,
   getNextPageUrlFromLinkHeader,
   getDownloadArchiveExtension,
@@ -15,7 +16,6 @@ import {
   validatePaginationUrl
 } from '../../util.js';
 import * as core from '@actions/core';
-import * as tc from '@actions/tool-cache';
 import fs from 'fs';
 import path from 'path';
 import {ISemeruAvailableVersions} from './models.js';
@@ -125,7 +125,7 @@ export class SemeruDistribution extends JavaBase {
     const archivePath = path.join(extractedJavaPath, archiveName);
     const version = this.getToolcacheVersionName(javaRelease.version);
 
-    const javaPath: string = await tc.cacheDir(
+    const javaPath: string = await cacheJdkDir(
       archivePath,
       this.toolcacheFolderName,
       version,

--- a/src/distributions/temurin/installer.ts
+++ b/src/distributions/temurin/installer.ts
@@ -1,5 +1,4 @@
 import * as core from '@actions/core';
-import * as tc from '@actions/tool-cache';
 
 import fs from 'fs';
 import path from 'path';
@@ -16,6 +15,7 @@ import {
   JavaInstallerResults
 } from '../base-models.js';
 import {
+  cacheJdkDir,
   extractJdkFile,
   getNextPageUrlFromLinkHeader,
   getDownloadArchiveExtension,
@@ -122,7 +122,7 @@ export class TemurinDistribution extends JavaBase {
     }
     const version = this.getToolcacheVersionName(javaRelease.version);
 
-    const javaPath = await tc.cacheDir(
+    const javaPath = await cacheJdkDir(
       archivePath,
       this.toolcacheFolderName,
       version,

--- a/src/distributions/zulu/installer.ts
+++ b/src/distributions/zulu/installer.ts
@@ -1,5 +1,4 @@
 import * as core from '@actions/core';
-import * as tc from '@actions/tool-cache';
 
 import path from 'path';
 import fs from 'fs';
@@ -8,6 +7,7 @@ import semver from 'semver';
 import {JavaBase} from '../base-installer.js';
 import {IZuluPackageDetails, IZuluVersions} from './models.js';
 import {
+  cacheJdkDir,
   extractJdkFile,
   getDownloadArchiveExtension,
   convertVersionToSemver,
@@ -122,7 +122,7 @@ export class ZuluDistribution extends JavaBase {
     const archiveName = fs.readdirSync(extractedJavaPath)[0];
     const archivePath = path.join(extractedJavaPath, archiveName);
 
-    const javaPath = await tc.cacheDir(
+    const javaPath = await cacheJdkDir(
       archivePath,
       this.toolcacheFolderName,
       this.getToolcacheVersionName(javaRelease.version),

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,7 +5,10 @@ import * as semver from 'semver';
 import * as core from '@actions/core';
 
 import * as tc from '@actions/tool-cache';
+import * as exec from '@actions/exec';
+import * as io from '@actions/io';
 import * as httpm from '@actions/http-client';
+import {randomUUID} from 'crypto';
 import {
   INPUT_JOB_STATUS,
   DISTRIBUTIONS_ONLY_MAJOR_VERSION,
@@ -64,13 +67,152 @@ export async function extractJdkFile(toolPath: string, extension?: string) {
 
   switch (extension) {
     case 'tar.gz':
+      return await extractTarGz(toolPath);
     case 'tar':
       return await tc.extractTar(toolPath);
     case 'zip':
-      return await tc.extractZip(toolPath);
+      return await extractZipArchive(toolPath);
     default:
       return await tc.extract7z(toolPath);
   }
+}
+
+async function createExtractFolder(): Promise<string> {
+  const dest = path.join(getTempDir(), randomUUID());
+  await io.mkdirP(dest);
+
+  return dest;
+}
+
+/**
+ * Decompressing a JDK tarball with the default single-threaded gzip is one of the
+ * slowest parts of the install, so hand the decompression to `pigz` when the runner
+ * provides it. Any failure falls back to the stock extraction.
+ */
+async function extractTarGz(toolPath: string): Promise<string> {
+  const pigzPath = await io.which('pigz');
+  // tar splits --use-compress-program on whitespace, so a path containing a
+  // space would be word-split into a bogus command.
+  if (pigzPath && !/\s/.test(pigzPath)) {
+    const dest = await createExtractFolder();
+    try {
+      return await tc.extractTar(toolPath, dest, [
+        '--use-compress-program',
+        `${pigzPath} -d`,
+        '-x'
+      ]);
+    } catch (error) {
+      await io.rmRF(dest);
+      core.debug(
+        `Failed to extract '${toolPath}' with pigz, falling back to gzip: ${getErrorMessage(error)}`
+      );
+    }
+  }
+
+  return await tc.extractTar(toolPath);
+}
+
+/**
+ * `tc.extractZip` shells out to PowerShell's `Expand-Archive` on Windows, which is
+ * several times slower than the bundled bsdtar. Prefer `tar.exe` and fall back to
+ * the stock extraction when it is unavailable or fails.
+ */
+async function extractZipArchive(toolPath: string): Promise<string> {
+  if (process.platform === 'win32') {
+    const systemTar = path.join(
+      process.env['SystemRoot'] || 'C:\\Windows',
+      'System32',
+      'tar.exe'
+    );
+
+    if (fs.existsSync(systemTar)) {
+      const dest = await createExtractFolder();
+      try {
+        await exec.exec(`"${systemTar}"`, ['-xf', toolPath, '-C', dest], {
+          silent: true
+        });
+
+        return dest;
+      } catch (error) {
+        await io.rmRF(dest);
+        core.debug(
+          `Failed to extract '${toolPath}' with tar.exe, falling back to Expand-Archive: ${getErrorMessage(error)}`
+        );
+      }
+    }
+  }
+
+  return await tc.extractZip(toolPath);
+}
+
+/**
+ * Equivalent of `tc.cacheDir`, but moves the extracted JDK into the tool-cache
+ * instead of copying it. `tc.cacheDir` recursively copies the whole tree, which
+ * means a several hundred megabyte JDK is written to disk twice. The extraction
+ * directory and the tool-cache normally live on the same filesystem, so a rename
+ * is effectively free. Anything unexpected (a different filesystem, or a file
+ * handle held open by anti-virus software on Windows) falls back to the copy.
+ */
+export async function cacheJdkDir(
+  sourceDir: string,
+  toolName: string,
+  version: string,
+  architecture: string
+): Promise<string> {
+  const destPath = getToolcacheDestination(toolName, version, architecture);
+
+  if (destPath) {
+    let moved = false;
+    try {
+      // lstat, not stat: renaming a symlinked source would put the link itself
+      // in the tool-cache, leaving a dangling JAVA_HOME once RUNNER_TEMP is
+      // cleaned. tc.cacheDir dereferences it, so let it handle that case.
+      if (fs.lstatSync(sourceDir).isDirectory()) {
+        await io.rmRF(destPath);
+        await io.rmRF(`${destPath}.complete`);
+        await io.mkdirP(path.dirname(destPath));
+        // Renaming is atomic, so a failure here leaves sourceDir untouched and
+        // the copy-based fallback below can still run.
+        fs.renameSync(sourceDir, destPath);
+        moved = true;
+      }
+    } catch (error) {
+      core.debug(
+        `Failed to move '${sourceDir}' into the tool-cache, falling back to a copy: ${getErrorMessage(error)}`
+      );
+    }
+
+    if (moved) {
+      fs.writeFileSync(`${destPath}.complete`, '');
+
+      return destPath;
+    }
+  }
+
+  return await tc.cacheDir(sourceDir, toolName, version, architecture);
+}
+
+function getToolcacheDestination(
+  toolName: string,
+  version: string,
+  architecture: string
+): string | null {
+  const toolcacheRoot = process.env['RUNNER_TOOL_CACHE'];
+  if (!toolcacheRoot) {
+    return null;
+  }
+
+  // Mirrors the destination layout used by `tc.cacheDir`.
+  return path.join(
+    toolcacheRoot,
+    toolName,
+    semver.clean(version) || version,
+    architecture || os.arch()
+  );
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 export function getDownloadArchiveExtension() {


### PR DESCRIPTION
**Description:**

Installing a JDK writes it to disk twice. Every distribution extracts the archive into `RUNNER_TEMP` and then calls `tc.cacheDir`, which recursively *copies* the whole tree into `RUNNER_TOOL_CACHE`. For a 200-600MB JDK that is a few hundred megabytes of pure redundant I/O on every cache miss, and it is the single most expensive step in the install path - considerably more than the vendor metadata requests people usually suspect.

This PR addresses that, plus the extraction step next to it.

**1. Move instead of copy (`cacheJdkDir`)**

New helper in `src/util.ts`, replacing `tc.cacheDir` at all 15 distribution installers. The extraction directory and the tool-cache normally live on the same filesystem, so the copy can just be a `fs.renameSync`. The helper mirrors the destination layout `tc.cacheDir` produces exactly (including `semver.clean(version) || version` and the `arch` default) and writes the `.complete` marker itself, so `tc.findAllVersions` / `findInToolcache` keep resolving entries unchanged.

It falls back to the original `tc.cacheDir` copy when:

- `RUNNER_TOOL_CACHE` is unset,
- the source is not a real directory. `lstat` is deliberate here: renaming a *symlinked* source would put the link itself in the tool-cache, leaving a dangling `JAVA_HOME` once `RUNNER_TEMP` is cleaned, and the `.complete` marker would make it look healthy forever,
- the rename fails. The upstream toolkit explicitly comments "do not move. move can fail on Windows due to anti-virus software having an open handle on a file", and a cross-device tool-cache raises `EXDEV`. A rename is atomic, so a failure leaves the source fully intact for the fallback to copy.

**2. Faster extraction**

`extractJdkFile` now hands tarball decompression to `pigz` when the runner provides it, and extracts Windows zips with the bundled `%SystemRoot%\System32\tar.exe` instead of `tc.extractZip`, which shells out to PowerShell's `Expand-Archive` (typically several times slower for a JDK-sized archive). Both paths fall back to the stock extraction, cleaning up the abandoned directory first so a failure does not double peak temp usage.

**Worth a careful look:**

- The move changes a copy-children-into-dest into a rename-dest semantic. I diffed this against the real `cacheDir` / `_createToolPath` / `_completeToolPath` in `@actions/tool-cache` to confirm the resulting layout is identical, and the symlink case above is the one place they genuinely differ, which is why it falls back.
- `pigz` is skipped if its resolved path contains whitespace, since `tar` word-splits `--use-compress-program`.
- Verified end to end by running the built action against Temurin 21 and Zulu 17: the extraction directory drops to 0B (proving the move), the `.complete` marker and directory layout match, `java -version` works, and a subsequent run resolves from the tool-cache with no network.

**Related issue:**
N/A

**Check list:**
- [x] Ran `npm run check` locally (format, lint, build, test) and all checks pass.
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.

Tests: 20 new cases in `__tests__/util-install.test.ts` covering the move, marker creation, replacing an existing entry, version/arch normalization parity with `tc.cacheDir`, and each fallback path (missing tool-cache root, symlinked source, rename failure with no stale marker left behind, pigz failure and cleanup, whitespace in the pigz path, Windows tar.exe failure and cleanup). Full suite is 1272 passing.