### PR TITLE
docs: correct the mvn-toolchain-id default in README and action.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ steps:
 | `overwrite-settings` | Overwrite an existing `settings.xml`. | `true` |
 | `gpg-private-key` | GPG private key to import. | |
 | `gpg-passphrase-env-var` | Environment variable name for the GPG private key passphrase. | `GPG_PASSPHRASE` when a key is set |
-| `mvn-toolchain-id` | Maven Toolchain ID. When multiple Java versions are installed, the number of IDs must match the number of versions. | `${vendor}_${java-version}` |
+| `mvn-toolchain-id` | Maven Toolchain ID. When multiple Java versions are installed, the number of IDs must match the number of versions. | `${mvn-toolchain-vendor}_${java-version}` |
 | `mvn-toolchain-vendor` | Maven Toolchain vendor value. | `${distribution}` |
 | `show-download-progress` | Keep Maven artifact download and transfer progress in logs. When `false`, the action adds `-ntp` to `MAVEN_ARGS`. | `false` |
 

--- a/action.yml
+++ b/action.yml
@@ -106,7 +106,7 @@ inputs:
     required: false
     default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
   mvn-toolchain-id:
-    description: 'Name of Maven Toolchain ID if the default name of "${distribution}_${java-version}" is not wanted. When supplied, the number of IDs must match the number of Java versions. See examples of supported syntax in Advanced Usage file'
+    description: 'Name of Maven Toolchain ID if the default name of "${mvn-toolchain-vendor}_${java-version}" is not wanted. The toolchain vendor defaults to the "distribution" input. When supplied, the number of IDs must match the number of Java versions. See examples of supported syntax in Advanced Usage file'
     required: false
   mvn-toolchain-vendor:
     description: 'Name of Maven Toolchain Vendor if the default name of "${distribution}" is not wanted. See examples of supported syntax in Advanced Usage file'


### PR DESCRIPTION
**Description:**

The generated Maven toolchain ID is `${vendor}_${version}`, where `vendor` is the `mvn-toolchain-vendor` input falling back to `distribution` (`src/toolchains.ts`). Two places described this incorrectly, and they disagreed with each other:

- `action.yml` claimed the default was `"${distribution}_${java-version}"`. That is wrong whenever `mvn-toolchain-vendor` is set, because overriding the vendor also changes the generated ID. A user who sets a vendor and then writes a toolchain requirement against the distribution-based ID gets a toolchain that never matches.
- `README.md` said `${vendor}_${java-version}`. That is accurate, but `vendor` is not the name of any action input, so it left readers to guess where the value came from.

Both now name `mvn-toolchain-vendor` and state that it falls back to `distribution`. `docs/advanced-usage.md` already explained this correctly and is unchanged.

Found via a Copilot review comment on #1205, which flagged the README wording; checking it against the source showed `action.yml` was the more misleading of the two.

**Related issue:**
N/A. Follow-up to #1204.

**Check list:**
- [ ] Ran `npm run check` locally (format, lint, build, test) and all checks pass. Not run. The change is two description strings; `action.yml` is metadata that is not compiled into `dist/`, and I verified it still parses as YAML.
- [x] Mark if documentation changes are required. This change is documentation only.
- [ ] Mark if tests were added or updated to cover the changes. No behavior change.
