### PR TITLE
Fix JetBrains GitHub token resolution

### DIFF
--- a/__tests__/distributors/jetbrains-installer.test.ts
+++ b/__tests__/distributors/jetbrains-installer.test.ts
@@ -80,8 +80,11 @@ function response(
 describe('getAvailableVersions', () => {
   let spyHttpClient: any;
   let spyCoreError: any;
+  const originalGitHubToken = process.env.GITHUB_TOKEN;
 
   beforeEach(() => {
+    delete process.env.GITHUB_TOKEN;
+    (core.getInput as jest.Mock).mockReturnValue('');
     spyHttpClient = jest.spyOn(HttpClient.prototype, 'getJson');
     spyHttpClient.mockReturnValue({
       statusCode: 200,
@@ -95,6 +98,11 @@ describe('getAvailableVersions', () => {
   });
 
   afterEach(() => {
+    if (originalGitHubToken === undefined) {
+      delete process.env.GITHUB_TOKEN;
+    } else {
+      process.env.GITHUB_TOKEN = originalGitHubToken;
+    }
     jest.resetAllMocks();
     jest.clearAllMocks();
     jest.restoreAllMocks();
@@ -189,6 +197,92 @@ describe('getAvailableVersions', () => {
       'jbr-release-26.0.0b1.1'
     ]);
     expect(spyHttpClient).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses the token input for every paginated GitHub Releases request', async () => {
+    (core.getInput as jest.Mock).mockReturnValue('input-token');
+    spyHttpClient
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        headers: nextPageHeader(2),
+        result: [release('jbr-release-21.0.11b1163.116', false)]
+      })
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        headers: {},
+        result: [release('jbr-release-21.0.10b1087.6', false)]
+      });
+    const distribution = new JetBrainsDistribution({
+      version: '21',
+      architecture: 'x64',
+      packageType: 'jdk',
+      checkLatest: false
+    });
+
+    await distribution['getAvailableVersions']();
+
+    expect(spyHttpClient).toHaveBeenNthCalledWith(1, JETBRAINS_RELEASES_URL, {
+      Accept: 'application/vnd.github+json',
+      Authorization: 'Bearer input-token'
+    });
+    expect(spyHttpClient).toHaveBeenNthCalledWith(
+      2,
+      `${JETBRAINS_RELEASES_URL}&page=2`,
+      {
+        Accept: 'application/vnd.github+json',
+        Authorization: 'Bearer input-token'
+      }
+    );
+  });
+
+  it('prefers the token input over the environment fallback', async () => {
+    (core.getInput as jest.Mock).mockReturnValue('input-token');
+    process.env.GITHUB_TOKEN = 'environment-token';
+    const distribution = new JetBrainsDistribution({
+      version: '21',
+      architecture: 'x64',
+      packageType: 'jdk',
+      checkLatest: false
+    });
+
+    await distribution['getAvailableVersions']();
+
+    expect(spyHttpClient).toHaveBeenCalledWith(JETBRAINS_RELEASES_URL, {
+      Accept: 'application/vnd.github+json',
+      Authorization: 'Bearer input-token'
+    });
+  });
+
+  it('falls back to GITHUB_TOKEN when the token input is empty', async () => {
+    process.env.GITHUB_TOKEN = 'environment-token';
+    const distribution = new JetBrainsDistribution({
+      version: '21',
+      architecture: 'x64',
+      packageType: 'jdk',
+      checkLatest: false
+    });
+
+    await distribution['getAvailableVersions']();
+
+    expect(spyHttpClient).toHaveBeenCalledWith(JETBRAINS_RELEASES_URL, {
+      Accept: 'application/vnd.github+json',
+      Authorization: 'Bearer environment-token'
+    });
+  });
+
+  it('omits authorization when no GitHub token is available', async () => {
+    const distribution = new JetBrainsDistribution({
+      version: '21',
+      architecture: 'x64',
+      packageType: 'jdk',
+      checkLatest: false
+    });
+
+    await distribution['getAvailableVersions']();
+
+    expect(spyHttpClient).toHaveBeenCalledWith(JETBRAINS_RELEASES_URL, {
+      Accept: 'application/vnd.github+json'
+    });
   });
 
   it('stops pagination when a raw GitHub page is empty', async () => {

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -30839,7 +30839,7 @@ const DISTRIBUTIONS_ONLY_MAJOR_VERSION = (/* unused pure expression or super */ 
 /* harmony export */   Vt: () => (/* binding */ getBooleanInput),
 /* harmony export */   lN: () => (/* binding */ isJdkCacheEnabled)
 /* harmony export */ });
-/* unused harmony exports getVersionFromToolcachePath, extractJdkFile, cacheJdkDir, getJavaVersionFromReleaseFile, getDownloadArchiveExtension, isVersionSatisfies, getToolcachePath, isGhes, getVersionFromFileContent, convertVersionToSemver, getArtifactFingerprint, getGitHubHttpHeaders, MAX_PAGINATION_PAGES, getNextPageUrlFromLinkHeader, validatePaginationUrl, renameWinArchive, getLatestMajorVersion */
+/* unused harmony exports getVersionFromToolcachePath, extractJdkFile, cacheJdkDir, getJavaVersionFromReleaseFile, getDownloadArchiveExtension, isVersionSatisfies, getToolcachePath, isGhes, getVersionFromFileContent, convertVersionToSemver, getArtifactFingerprint, getGitHubToken, getGitHubHttpHeaders, MAX_PAGINATION_PAGES, getNextPageUrlFromLinkHeader, validatePaginationUrl, renameWinArchive, getLatestMajorVersion */
 /* harmony import */ var os__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(857);
 /* harmony import */ var os__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(os__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(6928);
@@ -31266,8 +31266,11 @@ function getArtifactFingerprint(headers) {
     }
     return undefined;
 }
+function getGitHubToken() {
+    return core.getInput('token') || process.env.GITHUB_TOKEN;
+}
 function getGitHubHttpHeaders() {
-    const resolvedToken = core.getInput('token') || process.env.GITHUB_TOKEN;
+    const resolvedToken = getGitHubToken();
     const auth = !resolvedToken ? undefined : `token ${resolvedToken}`;
     const headers = {
         accept: 'application/vnd.github.VERSION.raw'

--- a/dist/setup/282.index.js
+++ b/dist/setup/282.index.js
@@ -77,10 +77,12 @@ class JetBrainsDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_
             console.time('Retrieving available versions for JBR took'); // eslint-disable-line no-console
         }
         const rawVersions = [];
-        const bearerToken = process.env.GITHUB_TOKEN;
-        const requestHeaders = {};
+        const bearerToken = (0,_util_js__WEBPACK_IMPORTED_MODULE_5__/* .getGitHubToken */ .lK)();
+        const requestHeaders = {
+            Accept: 'application/vnd.github+json'
+        };
         if (bearerToken) {
-            requestHeaders['Authorization'] = `Bearer ${bearerToken}`;
+            requestHeaders.Authorization = `Bearer ${bearerToken}`;
         }
         let releasesUrl = JETBRAINS_RELEASES_URL;
         let pageCount = 0;

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -31265,6 +31265,7 @@ function validateToolchainIds(versions, versionFile, toolchainIds) {
 /* harmony export */   ZY: () => (/* binding */ convertVersionToSemver),
 /* harmony export */   aT: () => (/* binding */ isGhes),
 /* harmony export */   ag: () => (/* binding */ getDownloadArchiveExtension),
+/* harmony export */   lK: () => (/* binding */ getGitHubToken),
 /* harmony export */   lN: () => (/* binding */ isJdkCacheEnabled),
 /* harmony export */   n2: () => (/* binding */ renameWinArchive),
 /* harmony export */   rC: () => (/* binding */ getNextPageUrlFromLinkHeader),
@@ -31699,8 +31700,11 @@ function getArtifactFingerprint(headers) {
     }
     return undefined;
 }
+function getGitHubToken() {
+    return _actions_core__WEBPACK_IMPORTED_MODULE_4__/* .getInput */ .V4('token') || process.env.GITHUB_TOKEN;
+}
 function getGitHubHttpHeaders() {
-    const resolvedToken = _actions_core__WEBPACK_IMPORTED_MODULE_4__/* .getInput */ .V4('token') || process.env.GITHUB_TOKEN;
+    const resolvedToken = getGitHubToken();
     const auth = !resolvedToken ? undefined : `token ${resolvedToken}`;
     const headers = {
         accept: 'application/vnd.github.VERSION.raw'

--- a/src/distributions/jetbrains/installer.ts
+++ b/src/distributions/jetbrains/installer.ts
@@ -14,6 +14,7 @@ import {
 import {
   cacheJdkDir,
   extractJdkFile,
+  getGitHubToken,
   getNextPageUrlFromLinkHeader,
   isVersionSatisfies,
   MAX_PAGINATION_PAGES,
@@ -108,10 +109,12 @@ export class JetBrainsDistribution extends JavaBase {
     }
 
     const rawVersions: IJetBrainsRawVersion[] = [];
-    const bearerToken = process.env.GITHUB_TOKEN;
-    const requestHeaders: OutgoingHttpHeaders = {};
+    const bearerToken = getGitHubToken();
+    const requestHeaders: OutgoingHttpHeaders = {
+      Accept: 'application/vnd.github+json'
+    };
     if (bearerToken) {
-      requestHeaders['Authorization'] = `Bearer ${bearerToken}`;
+      requestHeaders.Authorization = `Bearer ${bearerToken}`;
     }
     let releasesUrl: string | null = JETBRAINS_RELEASES_URL;
     let pageCount = 0;

--- a/src/util.ts
+++ b/src/util.ts
@@ -544,8 +544,12 @@ export function getArtifactFingerprint(
   return undefined;
 }
 
+export function getGitHubToken(): string | undefined {
+  return core.getInput('token') || process.env.GITHUB_TOKEN;
+}
+
 export function getGitHubHttpHeaders(): OutgoingHttpHeaders {
-  const resolvedToken = core.getInput('token') || process.env.GITHUB_TOKEN;
+  const resolvedToken = getGitHubToken();
   const auth = !resolvedToken ? undefined : `token ${resolvedToken}`;
 
   const headers: OutgoingHttpHeaders = {


### PR DESCRIPTION
**Description:**
Resolve GitHub authentication for JetBrains Runtime release discovery from the action `token` input first, with `GITHUB_TOKEN` retained as a fallback. Releases API pagination now keeps the same authentication and requests GitHub JSON media; requests remain unauthenticated when neither token source is set.

The shared token resolver is also used by the existing GitHub-hosted manifest headers. Generated `dist` bundles are included.

**Related issue:**
Fixes #1221

**Check list:**
- [x] Ran `npm run check` locally (format, lint, build, test) and all checks pass.
- [x] Documentation changes are not required.
- [x] Tests were added or updated to cover the changes.