### PR TITLE
Include gradle.properties in Gradle cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ The primary dependency cache key is `setup-java-<runner-os>-<node-arch>-<package
 
 | Package manager | Files used for the primary dependency-cache key |
 | --- | --- |
-| Gradle | `**/*.gradle*`, `**/gradle-wrapper.properties`, `buildSrc/**/Versions.kt`, `buildSrc/**/Dependencies.kt`, `gradle/*.versions.toml`, `**/versions.properties` |
+| Gradle | `**/*.gradle*`, `**/gradle.properties`, `**/gradle-wrapper.properties`, `buildSrc/**/Versions.kt`, `buildSrc/**/Dependencies.kt`, `gradle/*.versions.toml`, `**/versions.properties` |
 | Maven | `**/pom.xml`, `**/.mvn/wrapper/maven-wrapper.properties`, `**/.mvn/extensions.xml` |
 | sbt | `**/*.sbt`, `**/project/build.properties`, `**/project/**.scala`, `**/project/**.sbt` |
 

--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -11,6 +11,7 @@ import {
 import {mkdtempSync} from 'fs';
 import {tmpdir} from 'os';
 import {join} from 'path';
+import {createHash} from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 
@@ -342,7 +343,7 @@ describe('dependency cache', () => {
         await expect(restore('gradle', '')).rejects.toThrow(
           `No file in ${projectRoot(
             workspace
-          )} matched to [**/*.gradle*,**/gradle-wrapper.properties,buildSrc/**/Versions.kt,buildSrc/**/Dependencies.kt,gradle/*.versions.toml,**/versions.properties], make sure you have checked out the target repository`
+          )} matched to [**/*.gradle*,**/gradle.properties,**/gradle-wrapper.properties,buildSrc/**/Versions.kt,buildSrc/**/Dependencies.kt,gradle/*.versions.toml,**/versions.properties], make sure you have checked out the target repository`
         );
       });
       it('downloads cache based on build.gradle', async () => {
@@ -351,7 +352,7 @@ describe('dependency cache', () => {
         await restore('gradle', '');
         expect(spyCacheRestore).toHaveBeenCalled();
         expect(spyGlobHashFiles).toHaveBeenCalledWith(
-          '**/*.gradle*\n**/gradle-wrapper.properties\nbuildSrc/**/Versions.kt\nbuildSrc/**/Dependencies.kt\ngradle/*.versions.toml\n**/versions.properties'
+          '**/*.gradle*\n**/gradle.properties\n**/gradle-wrapper.properties\nbuildSrc/**/Versions.kt\nbuildSrc/**/Dependencies.kt\ngradle/*.versions.toml\n**/versions.properties'
         );
         expect(spyWarning).not.toHaveBeenCalled();
         expect(spyInfo).toHaveBeenCalledWith('gradle cache is not found');
@@ -362,7 +363,7 @@ describe('dependency cache', () => {
         await restore('gradle', '');
         expect(spyCacheRestore).toHaveBeenCalled();
         expect(spyGlobHashFiles).toHaveBeenCalledWith(
-          '**/*.gradle*\n**/gradle-wrapper.properties\nbuildSrc/**/Versions.kt\nbuildSrc/**/Dependencies.kt\ngradle/*.versions.toml\n**/versions.properties'
+          '**/*.gradle*\n**/gradle.properties\n**/gradle-wrapper.properties\nbuildSrc/**/Versions.kt\nbuildSrc/**/Dependencies.kt\ngradle/*.versions.toml\n**/versions.properties'
         );
         expect(spyWarning).not.toHaveBeenCalled();
         expect(spyInfo).toHaveBeenCalledWith('gradle cache is not found');
@@ -374,7 +375,7 @@ describe('dependency cache', () => {
         await restore('gradle', '');
         expect(spyCacheRestore).toHaveBeenCalled();
         expect(spyGlobHashFiles).toHaveBeenCalledWith(
-          '**/*.gradle*\n**/gradle-wrapper.properties\nbuildSrc/**/Versions.kt\nbuildSrc/**/Dependencies.kt\ngradle/*.versions.toml\n**/versions.properties'
+          '**/*.gradle*\n**/gradle.properties\n**/gradle-wrapper.properties\nbuildSrc/**/Versions.kt\nbuildSrc/**/Dependencies.kt\ngradle/*.versions.toml\n**/versions.properties'
         );
         expect(spyWarning).not.toHaveBeenCalled();
         expect(spyInfo).toHaveBeenCalledWith('gradle cache is not found');
@@ -386,10 +387,38 @@ describe('dependency cache', () => {
         await restore('gradle', '');
         expect(spyCacheRestore).toHaveBeenCalled();
         expect(spyGlobHashFiles).toHaveBeenCalledWith(
-          '**/*.gradle*\n**/gradle-wrapper.properties\nbuildSrc/**/Versions.kt\nbuildSrc/**/Dependencies.kt\ngradle/*.versions.toml\n**/versions.properties'
+          '**/*.gradle*\n**/gradle.properties\n**/gradle-wrapper.properties\nbuildSrc/**/Versions.kt\nbuildSrc/**/Dependencies.kt\ngradle/*.versions.toml\n**/versions.properties'
         );
         expect(spyWarning).not.toHaveBeenCalled();
         expect(spyInfo).toHaveBeenCalledWith('gradle cache is not found');
+      });
+      it('changes the cache key when gradle.properties changes', async () => {
+        const buildFile = join(workspace, 'build.gradle');
+        const propertiesFile = join(workspace, 'gradle.properties');
+        createFile(buildFile);
+        createFile(propertiesFile, 'dependencyVersion=1.0.0');
+        spyGlobHashFiles.mockImplementation(async (pattern: string) => {
+          if (pattern === '**/gradle-wrapper.properties') {
+            return '';
+          }
+
+          const files = [buildFile];
+          if (pattern.split('\n').includes('**/gradle.properties')) {
+            files.push(propertiesFile);
+          }
+          const hash = createHash('sha256');
+          files.forEach(file => hash.update(fs.readFileSync(file)));
+          return hash.digest('hex');
+        });
+
+        await restore('gradle', '');
+        const firstKey = spyCacheRestore.mock.calls[0][1];
+
+        fs.writeFileSync(propertiesFile, 'dependencyVersion=2.0.0');
+        await restore('gradle', '');
+        const secondKey = spyCacheRestore.mock.calls[1][1];
+
+        expect(secondKey).not.toBe(firstKey);
       });
       it('restores the gradle wrapper distribution cache independently of the main cache', async () => {
         createFile(join(workspace, 'build.gradle'));
@@ -529,7 +558,7 @@ describe('dependency cache', () => {
       await restore('gradle', '');
       expect(spyCacheRestore).toHaveBeenCalled();
       expect(spyGlobHashFiles).toHaveBeenCalledWith(
-        '**/*.gradle*\n**/gradle-wrapper.properties\nbuildSrc/**/Versions.kt\nbuildSrc/**/Dependencies.kt\ngradle/*.versions.toml\n**/versions.properties'
+        '**/*.gradle*\n**/gradle.properties\n**/gradle-wrapper.properties\nbuildSrc/**/Versions.kt\nbuildSrc/**/Dependencies.kt\ngradle/*.versions.toml\n**/versions.properties'
       );
       expect(spyWarning).not.toHaveBeenCalled();
       expect(spyInfo).toHaveBeenCalledWith('gradle cache is not found');
@@ -1027,9 +1056,9 @@ function createStateForSuccessfulRestore() {
   });
 }
 
-function createFile(path: string) {
+function createFile(path: string, contents = '') {
   core.info(`created a file at ${path}`);
-  fs.writeFileSync(path, '');
+  fs.writeFileSync(path, contents);
 }
 
 function deferred<T>() {

--- a/dist/cleanup/377.index.js
+++ b/dist/cleanup/377.index.js
@@ -56,6 +56,7 @@ const supportedPackageManager = [
         // https://github.com/actions/cache/blob/0638051e9af2c23d10bb70fa9beffcad6cff9ce3/examples.md#java---gradle
         pattern: [
             '**/*.gradle*',
+            '**/gradle.properties',
             '**/gradle-wrapper.properties',
             'buildSrc/**/Versions.kt',
             'buildSrc/**/Dependencies.kt',

--- a/dist/setup/377.index.js
+++ b/dist/setup/377.index.js
@@ -56,6 +56,7 @@ const supportedPackageManager = [
         // https://github.com/actions/cache/blob/0638051e9af2c23d10bb70fa9beffcad6cff9ce3/examples.md#java---gradle
         pattern: [
             '**/*.gradle*',
+            '**/gradle.properties',
             '**/gradle-wrapper.properties',
             'buildSrc/**/Versions.kt',
             'buildSrc/**/Dependencies.kt',

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -82,6 +82,7 @@ const supportedPackageManager: PackageManager[] = [
     // https://github.com/actions/cache/blob/0638051e9af2c23d10bb70fa9beffcad6cff9ce3/examples.md#java---gradle
     pattern: [
       '**/*.gradle*',
+      '**/gradle.properties',
       '**/gradle-wrapper.properties',
       'buildSrc/**/Versions.kt',
       'buildSrc/**/Dependencies.kt',


### PR DESCRIPTION
**Description:**
Include `**/gradle.properties` in the default Gradle dependency-cache hash inputs so changes to dependency, plugin, or repository properties produce a new primary cache key.

This keeps the change focused on `gradle.properties`, updates the documented defaults and generated `dist` bundles, and adds a behavior test showing that changing only `gradle.properties` changes the computed key.

Prior art: #460 was closed after becoming stale and conflicted; maintainers invited a fresh focused PR.

Tests:
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js --runInBand __tests__/cache.test.ts`
- `npm run check`

**Related issue:**
Fixes #1222

**Check list:**
- [x] Ran `npm run check` locally (format, lint, build, test) and all checks pass.
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.
