### PR TITLE
Handle early dependency cache failures during Java setup

### DIFF
--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -67,7 +67,7 @@ jest.unstable_mockModule('@actions/glob', () => ({
 const core = await import('@actions/core');
 const cache = await import('@actions/cache');
 const glob = await import('@actions/glob');
-const {restore, save} = await import('../src/cache.js');
+const {restore, save, validatePackageManager} = await import('../src/cache.js');
 
 describe('dependency cache', () => {
   const ORIGINAL_RUNNER_OS = process.env['RUNNER_OS'];
@@ -128,6 +128,20 @@ describe('dependency cache', () => {
     jest.resetAllMocks();
     jest.clearAllMocks();
     jest.restoreAllMocks();
+  });
+
+  describe('validatePackageManager', () => {
+    it('accepts supported package managers', () => {
+      expect(() => validatePackageManager('maven')).not.toThrow();
+      expect(() => validatePackageManager('gradle')).not.toThrow();
+      expect(() => validatePackageManager('sbt')).not.toThrow();
+    });
+
+    it('throws the targeted error for unsupported package managers', () => {
+      expect(() => validatePackageManager('ant')).toThrow(
+        'unknown package manager specified: ant'
+      );
+    });
   });
 
   describe('restore', () => {

--- a/__tests__/setup-java.test.ts
+++ b/__tests__/setup-java.test.ts
@@ -510,6 +510,21 @@ describe('setup action orchestration', () => {
     expect(cache.restore).not.toHaveBeenCalled();
   });
 
+  it('reports missing java-version before validating the cache input', async () => {
+    inputs.set('distribution', 'temurin');
+    inputs.set('cache', 'ant');
+    (cache.validatePackageManager as jest.Mock).mockImplementation(() => {
+      throw new Error('unknown package manager specified: ant');
+    });
+
+    await run();
+
+    expect(core.setFailed).toHaveBeenCalledWith(
+      'java-version or java-version-file input expected'
+    );
+    expect(cache.validatePackageManager).not.toHaveBeenCalled();
+  });
+
   it.each([
     ['', '', false],
     ['', 'true', true],

--- a/__tests__/setup-java.test.ts
+++ b/__tests__/setup-java.test.ts
@@ -47,7 +47,8 @@ jest.unstable_mockModule('../src/toolchain-ids.js', () => ({
 }));
 
 jest.unstable_mockModule('../src/cache.js', () => ({
-  restore: jest.fn()
+  restore: jest.fn(),
+  validatePackageManager: jest.fn()
 }));
 
 jest.unstable_mockModule('../src/cache-feature.js', () => ({
@@ -129,6 +130,9 @@ describe('setup action orchestration', () => {
     (toolchains.configureToolchains as jest.Mock).mockResolvedValue(undefined);
     (auth.configureAuthentication as jest.Mock).mockResolvedValue(undefined);
     (cache.restore as jest.Mock).mockResolvedValue(undefined);
+    (cache.validatePackageManager as jest.Mock).mockImplementation(
+      () => undefined
+    );
   });
 
   it('does not execute the action when imported', () => {
@@ -486,6 +490,26 @@ describe('setup action orchestration', () => {
     );
   });
 
+  it('fails invalid cache input before resolving a Java distribution', async () => {
+    inputs.set('distribution', 'temurin');
+    inputs.set('cache', 'ant');
+    multilineInputs.set('java-version', ['21']);
+    const setupJava = jest.fn();
+    (factory.getJavaDistribution as jest.Mock).mockReturnValue({setupJava});
+    (cache.validatePackageManager as jest.Mock).mockImplementation(() => {
+      throw new Error('unknown package manager specified: ant');
+    });
+
+    await run();
+
+    expect(core.setFailed).toHaveBeenCalledWith(
+      'unknown package manager specified: ant'
+    );
+    expect(factory.getJavaDistribution).not.toHaveBeenCalled();
+    expect(setupJava).not.toHaveBeenCalled();
+    expect(cache.restore).not.toHaveBeenCalled();
+  });
+
   it.each([
     ['', '', false],
     ['', 'true', true],
@@ -591,6 +615,42 @@ describe('setup action orchestration', () => {
     await run();
 
     expect(core.setFailed).toHaveBeenCalledWith('download failed');
+  });
+
+  it('observes cache failures while Java setup is still pending', async () => {
+    inputs.set('distribution', 'temurin');
+    inputs.set('cache', 'maven');
+    multilineInputs.set('java-version', ['21']);
+    const javaSetup = deferred<{version: string; path: string}>();
+    const setupJava = jest.fn(() => javaSetup.promise);
+    (factory.getJavaDistribution as jest.Mock).mockReturnValue({setupJava});
+    (cache.restore as jest.Mock).mockRejectedValue(
+      new Error('cache restore failed')
+    );
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    const runPromise = run();
+    try {
+      await tick();
+
+      expect(setupJava).toHaveBeenCalled();
+      expect(core.setFailed).not.toHaveBeenCalled();
+      expect(unhandledRejections).toEqual([]);
+
+      javaSetup.resolve({version: '21.0.4+7', path: '/opt/java/21'});
+      await runPromise;
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+      javaSetup.resolve({version: '21.0.4+7', path: '/opt/java/21'});
+      await runPromise;
+    }
+
+    expect(unhandledRejections).toEqual([]);
+    expect(core.setFailed).toHaveBeenCalledWith('cache restore failed');
   });
 });
 

--- a/__tests__/setup-java.test.ts
+++ b/__tests__/setup-java.test.ts
@@ -624,9 +624,12 @@ describe('setup action orchestration', () => {
     const javaSetup = deferred<{version: string; path: string}>();
     const setupJava = jest.fn(() => javaSetup.promise);
     (factory.getJavaDistribution as jest.Mock).mockReturnValue({setupJava});
-    (cache.restore as jest.Mock).mockRejectedValue(
-      new Error('cache restore failed')
-    );
+    const cacheRestore = deferred<void>();
+    const cacheRestoreCalled = deferred<void>();
+    (cache.restore as jest.Mock).mockImplementation(() => {
+      cacheRestoreCalled.resolve();
+      return cacheRestore.promise;
+    });
     const unhandledRejections: unknown[] = [];
     const onUnhandledRejection = (reason: unknown) => {
       unhandledRejections.push(reason);
@@ -635,18 +638,20 @@ describe('setup action orchestration', () => {
 
     const runPromise = run();
     try {
+      // Only reject once the restore has actually started and while the Java
+      // installation is still pending, so the unfixed code would leave the
+      // rejection unhandled.
+      await cacheRestoreCalled.promise;
+      cacheRestore.reject(new Error('cache restore failed'));
       await tick();
 
       expect(setupJava).toHaveBeenCalled();
-      expect(core.setFailed).not.toHaveBeenCalled();
       expect(unhandledRejections).toEqual([]);
-
-      javaSetup.resolve({version: '21.0.4+7', path: '/opt/java/21'});
-      await runPromise;
+      expect(core.setFailed).not.toHaveBeenCalled();
     } finally {
-      process.off('unhandledRejection', onUnhandledRejection);
       javaSetup.resolve({version: '21.0.4+7', path: '/opt/java/21'});
       await runPromise;
+      process.off('unhandledRejection', onUnhandledRejection);
     }
 
     expect(unhandledRejections).toEqual([]);

--- a/dist/cleanup/377.index.js
+++ b/dist/cleanup/377.index.js
@@ -8,7 +8,7 @@ export const modules = {
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   save: () => (/* binding */ save)
 /* harmony export */ });
-/* unused harmony export restore */
+/* unused harmony exports validatePackageManager, restore */
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(6928);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var os__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(857);
@@ -106,6 +106,9 @@ function findPackageManager(id) {
         throw new Error(`unknown package manager specified: ${id}`);
     }
     return packageManager;
+}
+function validatePackageManager(id) {
+    findPackageManager(id);
 }
 function resolveCachePaths(packageManager, cachePaths) {
     return cachePaths.length > 0 ? cachePaths : packageManager.path;

--- a/dist/setup/377.index.js
+++ b/dist/setup/377.index.js
@@ -6,7 +6,8 @@ export const modules = {
 /***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
 
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   restore: () => (/* binding */ restore)
+/* harmony export */   restore: () => (/* binding */ restore),
+/* harmony export */   validatePackageManager: () => (/* binding */ validatePackageManager)
 /* harmony export */ });
 /* unused harmony export save */
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(6928);
@@ -106,6 +107,9 @@ function findPackageManager(id) {
         throw new Error(`unknown package manager specified: ${id}`);
     }
     return packageManager;
+}
+function validatePackageManager(id) {
+    findPackageManager(id);
 }
 function resolveCachePaths(packageManager, cachePaths) {
     return cachePaths.length > 0 ? cachePaths : packageManager.path;

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -36342,6 +36342,10 @@ async function run() {
     let cacheRestore;
     const toolchainConfigurations = [];
     try {
+        if (cache) {
+            const { validatePackageManager } = await Promise.all(/* import() */[__nccwpck_require__.e(824), __nccwpck_require__.e(971), __nccwpck_require__.e(377)]).then(__nccwpck_require__.bind(__nccwpck_require__, 7377));
+            validatePackageManager(cache);
+        }
         setup_java_core/* startGroup */.Oh('Installed distributions');
         if (!versions.length && !versionFile) {
             throw new Error('java-version or java-version-file input expected');
@@ -36377,7 +36381,7 @@ async function run() {
                 toolchainIds
             };
             cacheRestore = cache
-                ? startCacheRestore(cache, cacheDependencyPath, cachePath)
+                ? settle(startCacheRestore(cache, cacheDependencyPath, cachePath))
                 : undefined;
             toolchainConfigurations.push(await installVersion(versionInfo.version, installerInputsOptions));
         }
@@ -36400,7 +36404,7 @@ async function run() {
                 toolchainIds
             };
             cacheRestore = cache
-                ? startCacheRestore(cache, cacheDependencyPath, cachePath)
+                ? settle(startCacheRestore(cache, cacheDependencyPath, cachePath))
                 : undefined;
             for (const [index, version] of versions.entries()) {
                 toolchainConfigurations.push(await installVersion(version, installerInputsOptions, index));
@@ -36415,18 +36419,17 @@ async function run() {
         actionError = error;
     }
     if (cacheRestore) {
-        try {
-            await cacheRestore;
-        }
-        catch (error) {
-            if (!actionError) {
-                actionError = error;
-            }
+        const cacheResult = await cacheRestore;
+        if (cacheResult.status === 'rejected' && !actionError) {
+            actionError = cacheResult.reason;
         }
     }
     if (actionError) {
         setup_java_core/* setFailed */.C1(actionError.message);
     }
+}
+function settle(promise) {
+    return promise.then(value => ({ status: 'fulfilled', value }), reason => ({ status: 'rejected', reason }));
 }
 if (process.argv[1] === (0,external_url_.fileURLToPath)(import.meta.url)) {
     run();

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -36346,10 +36346,6 @@ async function run() {
     let cacheRestore;
     const toolchainConfigurations = [];
     try {
-        if (cache) {
-            const { validatePackageManager } = await Promise.all(/* import() */[__nccwpck_require__.e(824), __nccwpck_require__.e(971), __nccwpck_require__.e(377)]).then(__nccwpck_require__.bind(__nccwpck_require__, 7377));
-            validatePackageManager(cache);
-        }
         setup_java_core/* startGroup */.Oh('Installed distributions');
         if (!versions.length && !versionFile) {
             throw new Error('java-version or java-version-file input expected');
@@ -36384,6 +36380,7 @@ async function run() {
                 jdkFile,
                 toolchainIds
             };
+            await validateCacheInput(cache);
             cacheRestore = cache
                 ? settle(startCacheRestore(cache, cacheDependencyPath, cachePath))
                 : undefined;
@@ -36407,6 +36404,7 @@ async function run() {
                 jdkFile,
                 toolchainIds
             };
+            await validateCacheInput(cache);
             cacheRestore = cache
                 ? settle(startCacheRestore(cache, cacheDependencyPath, cachePath))
                 : undefined;
@@ -36431,6 +36429,13 @@ async function run() {
     if (actionError) {
         setup_java_core/* setFailed */.C1(actionError.message);
     }
+}
+async function validateCacheInput(cache) {
+    if (!cache) {
+        return;
+    }
+    const { validatePackageManager } = await Promise.all(/* import() */[__nccwpck_require__.e(824), __nccwpck_require__.e(971), __nccwpck_require__.e(377)]).then(__nccwpck_require__.bind(__nccwpck_require__, 7377));
+    validatePackageManager(cache);
 }
 function settle(promise) {
     return promise.then(value => ({ status: 'fulfilled', value }), reason => ({ status: 'rejected', reason }));

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -137,6 +137,10 @@ function findPackageManager(id: string): PackageManager {
   return packageManager;
 }
 
+export function validatePackageManager(id: string): void {
+  findPackageManager(id);
+}
+
 function resolveCachePaths(
   packageManager: PackageManager,
   cachePaths: string[]

--- a/src/setup-java.ts
+++ b/src/setup-java.ts
@@ -41,11 +41,6 @@ export async function run() {
   const toolchainConfigurations: ToolchainConfiguration[] = [];
 
   try {
-    if (cache) {
-      const {validatePackageManager} = await import('./cache.js');
-      validatePackageManager(cache);
-    }
-
     core.startGroup('Installed distributions');
 
     if (!versions.length && !versionFile) {
@@ -99,6 +94,7 @@ export async function run() {
         toolchainIds
       };
 
+      await validateCacheInput(cache);
       cacheRestore = cache
         ? settle(startCacheRestore(cache, cacheDependencyPath, cachePath))
         : undefined;
@@ -125,6 +121,7 @@ export async function run() {
         toolchainIds
       };
 
+      await validateCacheInput(cache);
       cacheRestore = cache
         ? settle(startCacheRestore(cache, cacheDependencyPath, cachePath))
         : undefined;
@@ -158,6 +155,14 @@ export async function run() {
   if (actionError) {
     core.setFailed(actionError.message);
   }
+}
+
+async function validateCacheInput(cache: string): Promise<void> {
+  if (!cache) {
+    return;
+  }
+  const {validatePackageManager} = await import('./cache.js');
+  validatePackageManager(cache);
 }
 
 function settle<T>(promise: Promise<T>): Promise<PromiseSettledResult<T>> {

--- a/src/setup-java.ts
+++ b/src/setup-java.ts
@@ -37,10 +37,15 @@ export async function run() {
     core.getInput(constants.INPUT_VERIFY_SIGNATURE_PUBLIC_KEY) || undefined;
   const toolchainIds = core.getMultilineInput(constants.INPUT_MVN_TOOLCHAIN_ID);
   let actionError: Error | undefined;
-  let cacheRestore: Promise<void> | undefined;
+  let cacheRestore: Promise<PromiseSettledResult<void>> | undefined;
   const toolchainConfigurations: ToolchainConfiguration[] = [];
 
   try {
+    if (cache) {
+      const {validatePackageManager} = await import('./cache.js');
+      validatePackageManager(cache);
+    }
+
     core.startGroup('Installed distributions');
 
     if (!versions.length && !versionFile) {
@@ -95,7 +100,7 @@ export async function run() {
       };
 
       cacheRestore = cache
-        ? startCacheRestore(cache, cacheDependencyPath, cachePath)
+        ? settle(startCacheRestore(cache, cacheDependencyPath, cachePath))
         : undefined;
       toolchainConfigurations.push(
         await installVersion(versionInfo.version, installerInputsOptions)
@@ -121,7 +126,7 @@ export async function run() {
       };
 
       cacheRestore = cache
-        ? startCacheRestore(cache, cacheDependencyPath, cachePath)
+        ? settle(startCacheRestore(cache, cacheDependencyPath, cachePath))
         : undefined;
       for (const [index, version] of versions.entries()) {
         toolchainConfigurations.push(
@@ -144,18 +149,22 @@ export async function run() {
   }
 
   if (cacheRestore) {
-    try {
-      await cacheRestore;
-    } catch (error) {
-      if (!actionError) {
-        actionError = error as Error;
-      }
+    const cacheResult = await cacheRestore;
+    if (cacheResult.status === 'rejected' && !actionError) {
+      actionError = cacheResult.reason as Error;
     }
   }
 
   if (actionError) {
     core.setFailed(actionError.message);
   }
+}
+
+function settle<T>(promise: Promise<T>): Promise<PromiseSettledResult<T>> {
+  return promise.then<PromiseFulfilledResult<T>, PromiseRejectedResult>(
+    value => ({status: 'fulfilled', value}),
+    reason => ({status: 'rejected', reason})
+  );
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {


### PR DESCRIPTION
**Description:**
Validate dependency cache providers before Java distribution installation, and attach rejection handling to cache restoration immediately while it continues to overlap JDK setup. Reconcile the settled cache result after setup so Java/configuration errors retain precedence and cache failures are reported through `core.setFailed` when setup succeeds.

Regenerate the setup and cleanup bundles for the shared cache validation path.

**Related issue:**
Fixes #1223

**Check list:**
- [x] Ran `npm run check` locally (format, lint, build, test) and all checks pass.
- [x] Documentation changes are not required.
- [x] Tests were added or updated to cover the changes.