### PR TITLE
Fix js-yaml audit vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4605,9 +4605,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
**Description:**
Upgrade the transitive `js-yaml` dependency from 3.15.0 to 3.15.1, resolving high-severity advisory GHSA-5p4m-2wfm-xmqj. `npm audit` now reports zero vulnerabilities.

**Related issue:**
N/A

**Check list:**
- [x] Ran `npm run check` locally (format, lint, build, test) and all checks pass.
- [x] Documentation changes are not required.
- [x] Tests were not added or updated because this is a lockfile-only transitive dependency patch.