### PR TITLE
Test JDK 26 installation from SDKMAN

### DIFF
--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -636,6 +636,26 @@ jobs:
         run: bash __tests__/verify-java.sh "17.0.10" "$JAVA_PATH"
         shell: bash
 
+  setup-java-version-from-sdkman-major:
+    name: temurin 26 from .sdkmanrc - ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+      - *checkout_step
+      - name: Create SDKMAN and Gradle files
+        run: |
+          echo "java=26-tem" > .sdkmanrc
+          touch build.gradle
+      - name: setup-java
+        uses: ./
+        id: setup-java
+        with:
+          java-version-file: .sdkmanrc
+          cache: gradle
+      - name: Verify Java
+        env:
+          JAVA_PATH: ${{ steps.setup-java.outputs.path }}
+        run: bash __tests__/verify-java.sh "26" "$JAVA_PATH"
+
   setup-java-set-default:
     name: set-default option - ${{ matrix.os }}
     needs: setup-java-major-versions

--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -263,6 +263,7 @@ describe('validatePaginationUrl', () => {
 describe('getVersionFromFileContent', () => {
   describe('.sdkmanrc', () => {
     it.each([
+      ['java=26-tem', '26', 'temurin'],
       ['java=11.0.20.1-tem', '11.0.20', 'temurin'],
       ['java = 11.0.20.1-tem', '11.0.20', 'temurin'],
       ['java=11.0.20.1-tem # a comment in sdkmanrc', '11.0.20', 'temurin'],


### PR DESCRIPTION
**Description:**
Adds regression coverage for installing Temurin JDK 26 when `.sdkmanrc` contains `java=26-tem`. The unit test covers version and distribution inference, while a focused Ubuntu E2E job exercises the reported Gradle cache configuration and verifies the installed JDK. Temurin resolution remains metadata-driven rather than hard-coding version 26.

**Related issue:**
https://github.com/actions/setup-java/issues/1234

Fixes: #1234

**Check list:**
- [ ] Ran `npm run check` locally (format, lint, build, test) and all checks pass.
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.