### PR TITLE
Fix Oracle macOS E2E version check

### DIFF
--- a/.github/workflows/e2e-versions.yml
+++ b/.github/workflows/e2e-versions.yml
@@ -71,7 +71,7 @@ jobs:
             version: 25
           - distribution: oracle
             os: macos-15-intel
-            version: 17
+            version: 21
           - distribution: oracle
             os: windows-latest
             version: 21


### PR DESCRIPTION
**Description:**
Oracle no longer publishes the macOS x64 JDK 17 `/latest/` artifact, so setup-java falls back to the immutable GA archive whose concrete version is `17`. Update the macOS Intel Oracle matrix case to JDK 21, where `/latest/` remains available and the concrete-version assertion continues to test the intended floating-download behavior.

**Related issue:**
https://github.com/actions/setup-java/actions/runs/32085636736/job/95557484658#step:4:16

**Check list:**
- [ ] Ran `npm run check` locally (format, lint, build, test) and all checks pass.
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.