### PR TITLE
Expose contributing guide to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ The scripts and documentation in this project are released under the [MIT Licens
 
 ## Contributions
 
-Contributions are welcome. See our [Contributor's Guide](docs/contributors.md).
+Contributions are welcome. See our [Contributor's Guide](docs/CONTRIBUTING.md).
 
 ## Code of Conduct
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributors
+# Contributing
 
 Thank you for contributing!
 


### PR DESCRIPTION
**Description:**
GitHub does not recognize the existing contributor guide because its filename is non-standard. Rename it to `docs/CONTRIBUTING.md`, update its heading, and adjust the README link so the guide appears in the repository community profile and contribution surfaces.

**Related issue:**
N/A

**Check list:**
- [ ] Ran `npm run check` locally (format, lint, build, test) and all checks pass.
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.