### PR TITLE
Set default signature verification for supported distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ steps:
 | `force-download` | Always download Java and replace any matching version in the tool cache. | `false` |
 | `set-default` | Add Java to `PATH` and set `JAVA_HOME`. When `false`, only version-specific `JAVA_HOME_<major>_<arch>` variables are set. | `true` |
 | `problem-matcher` | Register Java compiler and uncaught exception problem matchers. | `true` |
-| `verify-signature` | Verify downloaded Java package signatures when supported. Currently supported for `temurin` and `microsoft`. | `false` |
+| `verify-signature` | Verify downloaded Java package signatures when supported. Defaults to `true` for `temurin` and `microsoft`, and `false` for other distributions. | Automatically enabled for `temurin` and `microsoft` |
 | `verify-signature-public-key` | ASCII-armored GPG public key to use for signature verification. Overrides the bundled key. | |
 | `token` | Token for fetching GitHub.com-hosted version manifests, useful on GitHub Enterprise Server when unauthenticated requests are rate-limited. | `${{ github.token }}` on GitHub.com; empty string on GHES |
 | `cache` | Enable dependency caching for `maven`, `gradle`, or `sbt`. | |

--- a/__tests__/distributors/microsoft-installer.test.ts
+++ b/__tests__/distributors/microsoft-installer.test.ts
@@ -398,13 +398,12 @@ describe('downloadTool', () => {
     jest.restoreAllMocks();
   });
 
-  it('verifies signature when enabled', async () => {
+  it('verifies signatures by default', async () => {
     const signedDistribution = new MicrosoftDistributions({
       version: '17',
       architecture: 'x64',
       packageType: 'jdk',
-      checkLatest: false,
-      verifySignature: true
+      checkLatest: false
     });
 
     await signedDistribution['downloadTool']({

--- a/__tests__/distributors/temurin-installer.test.ts
+++ b/__tests__/distributors/temurin-installer.test.ts
@@ -457,14 +457,13 @@ describe('downloadTool', () => {
     jest.restoreAllMocks();
   });
 
-  it('verifies signature when enabled', async () => {
+  it('verifies signatures by default', async () => {
     const distribution = new TemurinDistribution(
       {
         version: '17',
         architecture: 'x64',
         packageType: 'jdk',
-        checkLatest: false,
-        verifySignature: true
+        checkLatest: false
       },
       TemurinImplementation.Hotspot
     );
@@ -480,6 +479,27 @@ describe('downloadTool', () => {
       'https://example.com/jdk.tar.gz.sig',
       ADOPTIUM_PUBLIC_KEY
     );
+  });
+
+  it('does not verify signatures when explicitly disabled', async () => {
+    const distribution = new TemurinDistribution(
+      {
+        version: '17',
+        architecture: 'x64',
+        packageType: 'jdk',
+        checkLatest: false,
+        verifySignature: false
+      },
+      TemurinImplementation.Hotspot
+    );
+
+    await distribution['downloadTool']({
+      version: '17.0.14+7',
+      url: 'https://example.com/jdk.tar.gz',
+      signatureUrl: 'https://example.com/jdk.tar.gz.sig'
+    });
+
+    expect(spyVerifySignature).not.toHaveBeenCalled();
   });
 
   it('downloads and adds matching JMODs to the JDK', async () => {
@@ -499,7 +519,8 @@ describe('downloadTool', () => {
         version: '25',
         architecture: 'x64',
         packageType: 'jdk+jmods',
-        checkLatest: false
+        checkLatest: false,
+        verifySignature: false
       },
       TemurinImplementation.Hotspot
     );

--- a/__tests__/setup-java.test.ts
+++ b/__tests__/setup-java.test.ts
@@ -161,6 +161,36 @@ describe('setup action orchestration', () => {
     expect(factory.getJavaDistribution).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['temurin', undefined, true],
+    ['microsoft', undefined, true],
+    ['zulu', undefined, false],
+    ['temurin', false, false]
+  ])(
+    'defaults signature verification for %s with explicit value %s to %s',
+    async (distribution, explicitValue, expectedValue) => {
+      inputs.set('distribution', distribution);
+      multilineInputs.set('java-version', ['21']);
+      if (explicitValue !== undefined) {
+        booleanInputs.set('verify-signature', explicitValue);
+      }
+      (factory.getJavaDistribution as jest.Mock).mockReturnValue({
+        setupJava: jest.fn(async () => ({
+          version: '21.0.4+7',
+          path: '/opt/java/21'
+        }))
+      });
+
+      await run();
+
+      expect(factory.getJavaDistribution).toHaveBeenCalledWith(
+        distribution,
+        expect.objectContaining({verifySignature: expectedValue}),
+        ''
+      );
+    }
+  );
+
   it('requires distribution when it cannot be inferred from the version file', async () => {
     inputs.set('java-version-file', '.java-version');
     (fs.readFileSync as jest.Mock).mockReturnValue(Buffer.from('21'));
@@ -200,7 +230,6 @@ describe('setup action orchestration', () => {
     booleanInputs.set('check-latest', true);
     booleanInputs.set('force-download', true);
     booleanInputs.set('set-default', false);
-    booleanInputs.set('verify-signature', true);
     inputs.set('verify-signature-public-key', 'public-key');
     (fs.readFileSync as jest.Mock).mockReturnValue(
       Buffer.from('java=21.0.5-tem')

--- a/__tests__/setup-java.test.ts
+++ b/__tests__/setup-java.test.ts
@@ -162,16 +162,17 @@ describe('setup action orchestration', () => {
   });
 
   it.each([
-    ['temurin', undefined, true],
-    ['microsoft', undefined, true],
-    ['zulu', undefined, false],
-    ['temurin', false, false]
+    ['temurin', undefined, undefined],
+    ['zulu', undefined, undefined],
+    ['temurin', false, false],
+    ['zulu', true, true]
   ])(
-    'defaults signature verification for %s with explicit value %s to %s',
+    'passes signature verification input for %s with explicit value %s as %s',
     async (distribution, explicitValue, expectedValue) => {
       inputs.set('distribution', distribution);
       multilineInputs.set('java-version', ['21']);
       if (explicitValue !== undefined) {
+        inputs.set('verify-signature', String(explicitValue));
         booleanInputs.set('verify-signature', explicitValue);
       }
       (factory.getJavaDistribution as jest.Mock).mockReturnValue({
@@ -261,7 +262,7 @@ describe('setup action orchestration', () => {
         forceDownload: true,
         cacheJdk: false,
         setDefault: false,
-        verifySignature: true,
+        verifySignature: undefined,
         verifySignaturePublicKey: 'public-key'
       },
       '/tmp/java.tar.gz'

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,6 @@ inputs:
   verify-signature:
     description: 'Verify downloaded Java package signatures when supported by the selected distribution'
     required: false
-    default: false
   verify-signature-public-key:
     description: 'ASCII-armored GPG public key used to verify the downloaded package signature. Overrides the default bundled key for the selected distribution.'
     required: false

--- a/dist/setup/242.index.js
+++ b/dist/setup/242.index.js
@@ -244,7 +244,8 @@ class JavaBase {
             installerOptions.setDefault !== undefined
                 ? installerOptions.setDefault
                 : true;
-        this.verifySignature = installerOptions.verifySignature ?? false;
+        this.verifySignature =
+            installerOptions.verifySignature ?? this.supportsSignatureVerification();
         this.verifySignaturePublicKey = installerOptions.verifySignaturePublicKey;
     }
     async downloadAndVerify(javaRelease) {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -36362,6 +36362,7 @@ var toolchain_ids = __nccwpck_require__(7083);
 
 
 
+const SIGNATURE_VERIFICATION_DISTRIBUTIONS = new Set(['temurin', 'microsoft']);
 async function run() {
     const versions = setup_java_core/* getMultilineInput */.q3(constants/* INPUT_JAVA_VERSION */.QM);
     let distributionName = setup_java_core/* getInput */.V4(constants/* INPUT_DISTRIBUTION */.g_);
@@ -36376,7 +36377,6 @@ async function run() {
     const checkLatest = (0,util/* getBooleanInput */.Vt)(constants/* INPUT_CHECK_LATEST */.YM, false);
     const forceDownload = (0,util/* getBooleanInput */.Vt)(constants/* INPUT_FORCE_DOWNLOAD */.I9, false);
     const setDefault = (0,util/* getBooleanInput */.Vt)(constants/* INPUT_SET_DEFAULT */.E8, true);
-    const verifySignature = (0,util/* getBooleanInput */.Vt)(constants/* INPUT_VERIFY_SIGNATURE */.qy, false);
     const verifySignaturePublicKey = setup_java_core/* getInput */.V4(constants/* INPUT_VERIFY_SIGNATURE_PUBLIC_KEY */.u) || undefined;
     const toolchainIds = setup_java_core/* getMultilineInput */.q3(constants/* INPUT_MVN_TOOLCHAIN_ID */.nr);
     let actionError;
@@ -36404,6 +36404,7 @@ async function run() {
             else if (!distributionName) {
                 throw new Error('distribution input is required when not specified in the version file');
             }
+            const verifySignature = (0,util/* getBooleanInput */.Vt)(constants/* INPUT_VERIFY_SIGNATURE */.qy, SIGNATURE_VERIFICATION_DISTRIBUTIONS.has(distributionName));
             const installerInputsOptions = {
                 architecture,
                 packageType,
@@ -36428,6 +36429,7 @@ async function run() {
             if (!distributionName) {
                 throw new Error('distribution input is required');
             }
+            const verifySignature = (0,util/* getBooleanInput */.Vt)(constants/* INPUT_VERIFY_SIGNATURE */.qy, SIGNATURE_VERIFICATION_DISTRIBUTIONS.has(distributionName));
             const installerInputsOptions = {
                 architecture,
                 packageType,

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -36362,7 +36362,6 @@ var toolchain_ids = __nccwpck_require__(7083);
 
 
 
-const SIGNATURE_VERIFICATION_DISTRIBUTIONS = new Set(['temurin', 'microsoft']);
 async function run() {
     const versions = setup_java_core/* getMultilineInput */.q3(constants/* INPUT_JAVA_VERSION */.QM);
     let distributionName = setup_java_core/* getInput */.V4(constants/* INPUT_DISTRIBUTION */.g_);
@@ -36404,7 +36403,7 @@ async function run() {
             else if (!distributionName) {
                 throw new Error('distribution input is required when not specified in the version file');
             }
-            const verifySignature = (0,util/* getBooleanInput */.Vt)(constants/* INPUT_VERIFY_SIGNATURE */.qy, SIGNATURE_VERIFICATION_DISTRIBUTIONS.has(distributionName));
+            const verifySignature = getVerifySignatureInput();
             const installerInputsOptions = {
                 architecture,
                 packageType,
@@ -36429,7 +36428,7 @@ async function run() {
             if (!distributionName) {
                 throw new Error('distribution input is required');
             }
-            const verifySignature = (0,util/* getBooleanInput */.Vt)(constants/* INPUT_VERIFY_SIGNATURE */.qy, SIGNATURE_VERIFICATION_DISTRIBUTIONS.has(distributionName));
+            const verifySignature = getVerifySignatureInput();
             const installerInputsOptions = {
                 architecture,
                 packageType,
@@ -36493,6 +36492,11 @@ function getJdkFileInput() {
         setup_java_core/* warning */.$e(`The '${constants/* INPUT_JDK_FILE_DEPRECATED */.wc}' input is deprecated and may be removed in a future release. Please use '${constants/* INPUT_JDK_FILE */.kM}' instead.`);
     }
     return jdkFile || deprecatedJdkFile;
+}
+function getVerifySignatureInput() {
+    return setup_java_core/* getInput */.V4(constants/* INPUT_VERIFY_SIGNATURE */.qy).trim()
+        ? (0,util/* getBooleanInput */.Vt)(constants/* INPUT_VERIFY_SIGNATURE */.qy)
+        : undefined;
 }
 async function installVersion(version, options, toolchainId = 0) {
     const { distributionName, jdkFile, architecture, packageType, checkLatest, forceDownload, cacheJdk, setDefault, verifySignature, verifySignaturePublicKey, toolchainIds } = options;

--- a/src/distributions/base-installer.ts
+++ b/src/distributions/base-installer.ts
@@ -68,7 +68,8 @@ export abstract class JavaBase {
       installerOptions.setDefault !== undefined
         ? installerOptions.setDefault
         : true;
-    this.verifySignature = installerOptions.verifySignature ?? false;
+    this.verifySignature =
+      installerOptions.verifySignature ?? this.supportsSignatureVerification();
     this.verifySignaturePublicKey = installerOptions.verifySignaturePublicKey;
   }
 

--- a/src/setup-java.ts
+++ b/src/setup-java.ts
@@ -13,6 +13,8 @@ import {JavaInstallerOptions} from './distributions/base-models.js';
 import {configureProblemMatcher} from './problem-matcher.js';
 import {validateToolchainIds} from './toolchain-ids.js';
 
+const SIGNATURE_VERIFICATION_DISTRIBUTIONS = new Set(['temurin', 'microsoft']);
+
 export async function run() {
   const versions = core.getMultilineInput(constants.INPUT_JAVA_VERSION);
   let distributionName = core.getInput(constants.INPUT_DISTRIBUTION);
@@ -29,10 +31,6 @@ export async function run() {
   const checkLatest = getBooleanInput(constants.INPUT_CHECK_LATEST, false);
   const forceDownload = getBooleanInput(constants.INPUT_FORCE_DOWNLOAD, false);
   const setDefault = getBooleanInput(constants.INPUT_SET_DEFAULT, true);
-  const verifySignature = getBooleanInput(
-    constants.INPUT_VERIFY_SIGNATURE,
-    false
-  );
   const verifySignaturePublicKey =
     core.getInput(constants.INPUT_VERIFY_SIGNATURE_PUBLIC_KEY) || undefined;
   const toolchainIds = core.getMultilineInput(constants.INPUT_MVN_TOOLCHAIN_ID);
@@ -80,6 +78,11 @@ export async function run() {
         );
       }
 
+      const verifySignature = getBooleanInput(
+        constants.INPUT_VERIFY_SIGNATURE,
+        SIGNATURE_VERIFICATION_DISTRIBUTIONS.has(distributionName)
+      );
+
       const installerInputsOptions: installerInputsOptions = {
         architecture,
         packageType,
@@ -106,6 +109,11 @@ export async function run() {
       if (!distributionName) {
         throw new Error('distribution input is required');
       }
+
+      const verifySignature = getBooleanInput(
+        constants.INPUT_VERIFY_SIGNATURE,
+        SIGNATURE_VERIFICATION_DISTRIBUTIONS.has(distributionName)
+      );
 
       const installerInputsOptions: installerInputsOptions = {
         architecture,

--- a/src/setup-java.ts
+++ b/src/setup-java.ts
@@ -13,8 +13,6 @@ import {JavaInstallerOptions} from './distributions/base-models.js';
 import {configureProblemMatcher} from './problem-matcher.js';
 import {validateToolchainIds} from './toolchain-ids.js';
 
-const SIGNATURE_VERIFICATION_DISTRIBUTIONS = new Set(['temurin', 'microsoft']);
-
 export async function run() {
   const versions = core.getMultilineInput(constants.INPUT_JAVA_VERSION);
   let distributionName = core.getInput(constants.INPUT_DISTRIBUTION);
@@ -78,10 +76,7 @@ export async function run() {
         );
       }
 
-      const verifySignature = getBooleanInput(
-        constants.INPUT_VERIFY_SIGNATURE,
-        SIGNATURE_VERIFICATION_DISTRIBUTIONS.has(distributionName)
-      );
+      const verifySignature = getVerifySignatureInput();
 
       const installerInputsOptions: installerInputsOptions = {
         architecture,
@@ -110,10 +105,7 @@ export async function run() {
         throw new Error('distribution input is required');
       }
 
-      const verifySignature = getBooleanInput(
-        constants.INPUT_VERIFY_SIGNATURE,
-        SIGNATURE_VERIFICATION_DISTRIBUTIONS.has(distributionName)
-      );
+      const verifySignature = getVerifySignatureInput();
 
       const installerInputsOptions: installerInputsOptions = {
         architecture,
@@ -200,6 +192,12 @@ function getJdkFileInput(): string {
   return jdkFile || deprecatedJdkFile;
 }
 
+function getVerifySignatureInput(): boolean | undefined {
+  return core.getInput(constants.INPUT_VERIFY_SIGNATURE).trim()
+    ? getBooleanInput(constants.INPUT_VERIFY_SIGNATURE)
+    : undefined;
+}
+
 async function installVersion(
   version: string,
   options: installerInputsOptions,
@@ -271,7 +269,7 @@ interface installerInputsOptions {
   forceDownload: boolean;
   cacheJdk: boolean;
   setDefault: boolean;
-  verifySignature: boolean;
+  verifySignature: boolean | undefined;
   verifySignaturePublicKey: string | undefined;
   distributionName: string;
   jdkFile: string;


### PR DESCRIPTION

This pull request updates the Java setup action to change how signature verification is handled for downloaded Java packages. Signature verification is now enabled by default for the `temurin` and `microsoft` distributions, while remaining disabled for others unless explicitly set. The changes also update documentation, input handling, and tests to reflect this new default behavior.

Key changes include:

**Default Behavior and Input Handling:**
- Signature verification (`verify-signature`) now defaults to enabled for `temurin` and `microsoft` distributions, and is disabled for others unless explicitly specified. The input is now optional, and if not provided, the action determines the default based on the distribution. [[1]](diffhunk://#diff-c95cf181295db10e39ecf69d97011c885155842b632a7430031cd109ff4afd5eL71-R72) [[2]](diffhunk://#diff-e772932decb56983cfa2a5407622cc591584e298164f4bdcb16ea534c9b2f690R195-R200) [[3]](diffhunk://#diff-e772932decb56983cfa2a5407622cc591584e298164f4bdcb16ea534c9b2f690L266-R272)
- The `action.yml` and `README.md` have been updated to reflect the new default behavior for `verify-signature`. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L44) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L162-R162)
- The input parsing logic in `src/setup-java.ts` now uses a new function `getVerifySignatureInput()` to correctly handle undefined or explicit values for `verify-signature`. [[1]](diffhunk://#diff-e772932decb56983cfa2a5407622cc591584e298164f4bdcb16ea534c9b2f690R79-R80) [[2]](diffhunk://#diff-e772932decb56983cfa2a5407622cc591584e298164f4bdcb16ea534c9b2f690R108-R109) [[3]](diffhunk://#diff-e772932decb56983cfa2a5407622cc591584e298164f4bdcb16ea534c9b2f690R195-R200)

**Testing and Validation:**
- Tests for both `temurin` and `microsoft` installers have been updated to verify that signature verification is enabled by default, and to check that it can be explicitly disabled when requested. [[1]](diffhunk://#diff-cdf7b4ff4516e2dce71abdea1d89aa4f60cf78d225196173261608c2c6874b19L460-R466) [[2]](diffhunk://#diff-cdf7b4ff4516e2dce71abdea1d89aa4f60cf78d225196173261608c2c6874b19R484-R504) [[3]](diffhunk://#diff-cdf7b4ff4516e2dce71abdea1d89aa4f60cf78d225196173261608c2c6874b19L502-R523) [[4]](diffhunk://#diff-272c2bf2ef4bc0677521993b6650e21fb727e879a712285dc9771fe07a93927cL401-R406)
- Orchestration tests in `setup-java.test.ts` have been updated to check that the correct signature verification value is passed to the distribution based on input and defaults. [[1]](diffhunk://#diff-c01f51cd26c06433e4c75630de3240db4bb1d7544269e8ba24439061e04da9ccR164-R194) [[2]](diffhunk://#diff-c01f51cd26c06433e4c75630de3240db4bb1d7544269e8ba24439061e04da9ccL203) [[3]](diffhunk://#diff-c01f51cd26c06433e4c75630de3240db4bb1d7544269e8ba24439061e04da9ccL235-R265)

These changes ensure better security defaults for supported distributions while allowing users to override signature verification behavior as needed.