### PR TITLE
Group and slow routine Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,25 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  # Enable version updates for npm
   - package-ecosystem: 'npm'
-    # Look for `package.json` and `lock` files in the `root` directory
     directory: '/'
-    # Check the npm registry for updates every day (weekdays)
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
+    cooldown:
+      default-days: 7
+    groups:
+      monthly-npm-updates:
+        applies-to: 'version-updates'
+        patterns:
+          - '*'
 
-  # Enable version updates for GitHub Actions
   - package-ecosystem: 'github-actions'
-    # Workflow files stored in the default location of `.github/workflows`
-    # You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
+    cooldown:
+      default-days: 7
+    groups:
+      monthly-actions-updates:
+        applies-to: 'version-updates'
+        patterns:
+          - '*'


### PR DESCRIPTION
**Description:**
Routine Dependabot updates currently arrive as separate weekly pull requests, creating unnecessary review and CI noise. Move npm and GitHub Actions version updates to grouped monthly batches and add a seven-day cooldown so newly published releases have time to receive community scrutiny. Security updates remain immediate and ungrouped.

**Related issue:**
N/A

**Check list:**
- [ ] Ran `npm run check` locally (format, lint, build, test) and all checks pass.
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.