### PR TITLE
Fix alpine failures by switching default back to only warn on verific…

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ steps:
 - Added Oracle OpenJDK (`oracle-openjdk`), Red Hat Build of OpenJDK (`redhat`), and Liberica Native Image Kit (`liberica-nik`), and expanded Tencent Kona support through JDK 25.
 - Added `java-version: latest` to resolve the newest stable GA release from the distribution's remote metadata.
 - Expanded install compatibility with JEP 322 multi-field versions such as `18.0.1.1`, Temurin `jdk+jmods` packages, and native musl artifacts on Alpine for Dragonwell, Corretto, Zulu, and Liberica.
-- JDK downloads now automatically verify authoritative checksums, and package signature verification defaults to enabled for Temurin and Microsoft builds.
+- JDK downloads now automatically verify authoritative checksums. Package signature verification is supported for Temurin and Microsoft builds, with configurable strict enforcement.
 - Added `force-download: true` to bypass the tool cache and perform a reproducible fresh install.
 - Dependency caching now supports custom paths with `cache-path` and restore-only operation with `cache-read-only: true`.
 - Dependency cache keys now include `.mvn/extensions.xml` and `gradle.properties`, preventing stale restores when Maven extensions or Gradle dependency properties change.
@@ -156,8 +156,8 @@ steps:
 | `force-download` | Always download Java and replace any matching version in the tool cache. | `false` |
 | `set-default` | Add Java to `PATH` and set `JAVA_HOME`. When `false`, only version-specific `JAVA_HOME_<major>_<arch>` variables are set. | `true` |
 | `problem-matcher` | Register Java compiler and uncaught exception problem matchers. | `true` |
-| `verify-signature` | Verify downloaded Java package signatures when supported. Defaults to `true` for `temurin` and `microsoft`, and `false` for other distributions. | Automatically enabled for `temurin` and `microsoft` |
-| `verify-signature-public-key` | ASCII-armored GPG public key to use for signature verification. Overrides the bundled key. | |
+| `verify-signature` | Verify downloaded Java package signatures when supported. Explicitly setting this to `true` makes verification failures fatal. | Distribution-dependent; see [Download integrity and signatures](#download-integrity-and-signatures) |
+| `verify-signature-public-key` | One or more ASCII-armored GPG public keys used for signature verification. Concatenate multiple armored key blocks. Custom keys replace the bundled distribution keys. | |
 | `token` | Token for fetching GitHub.com-hosted version manifests, useful on GitHub Enterprise Server when unauthenticated requests are rate-limited. | `${{ github.token }}` on GitHub.com; empty string on GHES |
 | `cache` | Enable dependency caching for `maven`, `gradle`, or `sbt`. | |
 | `cache-jdk` | Cache downloaded JDK installations between jobs. When omitted, JDK caching is enabled only if `cache` is set. Set explicitly to `true` or `false` to override. | Enabled when `cache` is set |
@@ -247,7 +247,34 @@ GitHub-hosted runners primarily pre-cache Eclipse Temurin JDKs. See the installe
 
 Distributions or individual releases without an authoritative checksum continue to install normally, with the omission reported in debug logs. Installations resolved directly from the runner tool cache — including JDKs preinstalled on the runner image and JDKs installed by an earlier step of the same job — are not downloaded again and are not reverified, even when `verify-signature: true` is set. Use `force-download: true` to always download and verify the archive.
 
-Use `verify-signature: true` to verify package signatures for distributions that support it. Currently supported distributions are `temurin` and `microsoft`; setting it for an unsupported distribution fails the workflow.
+Package signature verification is supported for `temurin` and `microsoft`. When `verify-signature` is omitted, the action checks the signature and warns if GPG is unavailable or verification fails, but does not enforce the result. Explicitly setting `verify-signature: true` enforces verification and makes these failures fatal. Setting `verify-signature: true` for an unsupported distribution also fails the workflow.
+
+> [!WARNING]
+> Requesting explicit signature verification with verify-signature can fail a build after an unexpected but legitimate vendor signing-key rotation, because the action's bundled keys may not yet include the new key. Confirm a new key through the vendor's trusted documentation before using it.
+
+After confirming a legitimate rotation, configure the updated key with `verify-signature-public-key`. The input accepts one or more ASCII-armored public keys; concatenate complete armored key blocks when both old and new vendor keys are needed during a transition. Custom keys replace, rather than extend, the keys bundled with the selected distribution.
+
+```yaml
+- uses: actions/setup-java@v6
+  with:
+    distribution: temurin
+    java-version: '25'
+    verify-signature: true
+    verify-signature-public-key: |
+      -----BEGIN PGP PUBLIC KEY BLOCK-----
+      ...vendor key material...
+      -----END PGP PUBLIC KEY BLOCK-----
+```
+
+As a temporary fallback while a legitimate rotation is being investigated, set `verify-signature: false`. This disables package signature verification, although authoritative checksum verification still applies when the vendor publishes a checksum.
+
+```yaml
+- uses: actions/setup-java@v6
+  with:
+    distribution: temurin
+    java-version: '25'
+    verify-signature: false
+```
 
 ## Caching
 

--- a/__tests__/cleanup-java.test.ts
+++ b/__tests__/cleanup-java.test.ts
@@ -393,7 +393,7 @@ function createRegisteredJdk(version = '21.0.8+9') {
     architecture: 'x64',
     version,
     source: `sha256:${path.basename(root)}`,
-    verification: 'unverified',
+    verification: 'disabled',
     path: jdkPath
   };
   registerJdk(jdk);

--- a/__tests__/distributors/base-installer.test.ts
+++ b/__tests__/distributors/base-installer.test.ts
@@ -71,8 +71,11 @@ jest.unstable_mockModule('@actions/tool-cache', () => ({
 }));
 
 jest.unstable_mockModule('../../src/jdk-cache.js', () => ({
-  getJdkVerificationIdentity: jest.fn((verified: boolean, key?: string) =>
-    verified ? (key ? 'verified:custom' : 'verified:bundled') : 'unverified'
+  getJdkVerificationIdentity: jest.fn(
+    (verified: boolean, enforced: boolean, key?: string) =>
+      verified
+        ? `${enforced ? 'enforced' : 'check-and-warn'}:${key ? 'custom' : 'bundled'}`
+        : 'disabled'
   ),
   registerJdk: jest.fn(),
   restoreJdk: jest.fn()
@@ -395,8 +398,10 @@ describe('setupJava', () => {
 
   beforeEach(() => {
     (jdkCache.getJdkVerificationIdentity as jest.Mock).mockImplementation(
-      (verified: boolean, key?: string) =>
-        verified ? (key ? 'verified:custom' : 'verified:bundled') : 'unverified'
+      (verified: boolean, enforced: boolean, key?: string) =>
+        verified
+          ? `${enforced ? 'enforced' : 'check-and-warn'}:${key ? 'custom' : 'bundled'}`
+          : 'disabled'
     );
     spyGetToolcachePath = util.getToolcachePath as jest.Mock;
     spyGetToolcachePath.mockImplementation(
@@ -826,7 +831,7 @@ describe('setupJava', () => {
     expect(jdkCache.registerJdk).toHaveBeenCalledWith(
       expect.objectContaining({
         version: actualJavaVersion,
-        verification: 'unverified'
+        verification: 'disabled'
       })
     );
   });
@@ -886,7 +891,7 @@ describe('setupJava', () => {
       architecture: 'x86',
       version: actualJavaVersion,
       source: `some/random_url/java/${actualJavaVersion}`,
-      verification: 'unverified',
+      verification: 'disabled',
       path: path.join(toolCachePath, 'Java_Empty_jdk', actualJavaVersion)
     });
     expect(downloadTool).not.toHaveBeenCalled();
@@ -919,7 +924,7 @@ describe('setupJava', () => {
       architecture: 'x86',
       version: actualJavaVersion,
       source: `some/random_url/java/${actualJavaVersion}`,
-      verification: 'unverified',
+      verification: 'disabled',
       path: path.join(toolCachePath, 'Java_Empty_jdk', actualJavaVersion)
     };
     expect(jdkCache.restoreJdk).toHaveBeenCalledWith(expectedIdentity);

--- a/__tests__/distributors/local-installer.test.ts
+++ b/__tests__/distributors/local-installer.test.ts
@@ -58,7 +58,7 @@ jest.unstable_mockModule('@actions/tool-cache', () => ({
 }));
 
 jest.unstable_mockModule('../../src/jdk-cache.js', () => ({
-  getJdkVerificationIdentity: jest.fn(() => 'unverified'),
+  getJdkVerificationIdentity: jest.fn(() => 'disabled'),
   registerJdk: jest.fn(),
   restoreJdk: jest.fn()
 }));
@@ -106,7 +106,7 @@ describe('setupJava', () => {
 
   beforeEach(() => {
     (jdkCache.getJdkVerificationIdentity as jest.Mock).mockReturnValue(
-      'unverified'
+      'disabled'
     );
     spyGetToolcachePath = util.getToolcachePath as jest.Mock;
     spyGetToolcachePath.mockImplementation(
@@ -283,7 +283,7 @@ describe('setupJava', () => {
           expect.objectContaining({
             distribution: 'jdkfile',
             version: actualJavaVersion,
-            verification: 'unverified'
+            verification: 'disabled'
           })
         );
       } finally {

--- a/__tests__/distributors/microsoft-installer.test.ts
+++ b/__tests__/distributors/microsoft-installer.test.ts
@@ -444,6 +444,64 @@ describe('downloadTool', () => {
     );
   });
 
+  it('warns with key rotation recovery guidance when default verification fails', async () => {
+    spyVerifySignature.mockRejectedValue(new Error('bad signature'));
+    const signedDistribution = new MicrosoftDistributions({
+      version: '17',
+      architecture: 'x64',
+      packageType: 'jdk',
+      checkLatest: false
+    });
+
+    await signedDistribution['downloadTool']({
+      version: '17.0.14+7',
+      url: 'https://example.com/jdk.tar.gz',
+      signatureUrl: 'https://example.com/jdk.tar.gz.sig'
+    });
+
+    expect(core.warning).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /bad signature.*https:\/\/github\.com\/actions\/setup-java#download-integrity-and-signatures/
+      )
+    );
+    expect(spyExtractJdkFile).toHaveBeenCalled();
+  });
+
+  it('fails with recovery guidance when verification is explicitly enabled', async () => {
+    spyVerifySignature.mockRejectedValue(new Error('bad signature'));
+    const signedDistribution = new MicrosoftDistributions({
+      version: '17',
+      architecture: 'x64',
+      packageType: 'jdk',
+      checkLatest: false,
+      verifySignature: true
+    });
+
+    await expect(
+      signedDistribution['downloadTool']({
+        version: '17.0.14+7',
+        url: 'https://example.com/jdk.tar.gz',
+        signatureUrl: 'https://example.com/jdk.tar.gz.sig'
+      })
+    ).rejects.toThrow(
+      /bad signature.*https:\/\/github\.com\/actions\/setup-java#download-integrity-and-signatures/
+    );
+    expect(spyExtractJdkFile).not.toHaveBeenCalled();
+  });
+
+  it('warns when the signature is missing during default verification', async () => {
+    await distribution['downloadTool']({
+      version: '17.0.14+7',
+      url: 'https://example.com/jdk.tar.gz'
+    });
+
+    expect(core.warning).toHaveBeenCalledWith(
+      "Input 'verify-signature' is enabled, but no signature URL was found for Microsoft Build of OpenJDK version 17.0.14+7."
+    );
+    expect(spyVerifySignature).not.toHaveBeenCalled();
+    expect(spyExtractJdkFile).toHaveBeenCalled();
+  });
+
   it('fails when signature is missing and verification is enabled', async () => {
     const signedDistribution = new MicrosoftDistributions({
       version: '17',

--- a/__tests__/distributors/temurin-installer.test.ts
+++ b/__tests__/distributors/temurin-installer.test.ts
@@ -73,6 +73,7 @@ jest.unstable_mockModule('../../src/util.js', () => ({
 jest.unstable_mockModule('../../src/gpg.js', () => ({
   importKey: jest.fn(),
   removeGpgHome: jest.fn(),
+  isGpgAvailable: jest.fn(),
   verifyPackageSignature: jest.fn()
 }));
 
@@ -437,6 +438,7 @@ describe('downloadTool', () => {
   beforeEach(() => {
     spyDownloadTool = tc.downloadTool as jest.Mock;
     spyDownloadTool.mockResolvedValue('/tmp/jdk.tar.gz');
+    (gpg.isGpgAvailable as jest.Mock).mockResolvedValue(true);
     spyVerifySignature = gpg.verifyPackageSignature as jest.Mock;
     spyVerifySignature.mockResolvedValue(undefined);
     spyExtractJdkFile = util.extractJdkFile as jest.Mock;
@@ -499,6 +501,133 @@ describe('downloadTool', () => {
       signatureUrl: 'https://example.com/jdk.tar.gz.sig'
     });
 
+    expect(spyVerifySignature).not.toHaveBeenCalled();
+  });
+
+  it('skips implicit signature verification when gpg is unavailable', async () => {
+    (gpg.isGpgAvailable as jest.Mock).mockResolvedValue(false);
+    const distribution = new TemurinDistribution(
+      {
+        version: '17',
+        architecture: 'x64',
+        packageType: 'jdk',
+        checkLatest: false
+      },
+      TemurinImplementation.Hotspot
+    );
+
+    await expect(
+      distribution['downloadTool']({
+        version: '17.0.14+7',
+        url: 'https://example.com/jdk.tar.gz',
+        signatureUrl: 'https://example.com/jdk.tar.gz.sig'
+      })
+    ).resolves.toEqual({version: '17.0.14+7', path: '/tmp/toolcache'});
+
+    expect(spyVerifySignature).not.toHaveBeenCalled();
+    expect(core.warning).toHaveBeenCalledWith(
+      "Input 'verify-signature' is enabled, but gpg is not available."
+    );
+  });
+
+  it('fails when signature verification is explicitly enabled without gpg', async () => {
+    (gpg.isGpgAvailable as jest.Mock).mockResolvedValue(false);
+    const distribution = new TemurinDistribution(
+      {
+        version: '17',
+        architecture: 'x64',
+        packageType: 'jdk',
+        checkLatest: false,
+        verifySignature: true
+      },
+      TemurinImplementation.Hotspot
+    );
+
+    await expect(
+      distribution['downloadTool']({
+        version: '17.0.14+7',
+        url: 'https://example.com/jdk.tar.gz',
+        signatureUrl: 'https://example.com/jdk.tar.gz.sig'
+      })
+    ).rejects.toThrow(
+      "Input 'verify-signature' is enabled, but gpg is not available."
+    );
+
+    expect(spyVerifySignature).not.toHaveBeenCalled();
+  });
+
+  it('warns when implicit signature verification fails', async () => {
+    spyVerifySignature.mockRejectedValue(new Error('bad signature'));
+    const distribution = new TemurinDistribution(
+      {
+        version: '17',
+        architecture: 'x64',
+        packageType: 'jdk',
+        checkLatest: false
+      },
+      TemurinImplementation.Hotspot
+    );
+
+    await expect(
+      distribution['downloadTool']({
+        version: '17.0.14+7',
+        url: 'https://example.com/jdk.tar.gz',
+        signatureUrl: 'https://example.com/jdk.tar.gz.sig'
+      })
+    ).resolves.toEqual({version: '17.0.14+7', path: '/tmp/toolcache'});
+
+    expect(core.warning).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'https://github.com/actions/setup-java#download-integrity-and-signatures'
+      )
+    );
+  });
+
+  it('fails when explicitly requested signature verification fails', async () => {
+    spyVerifySignature.mockRejectedValue(new Error('bad signature'));
+    const distribution = new TemurinDistribution(
+      {
+        version: '17',
+        architecture: 'x64',
+        packageType: 'jdk',
+        checkLatest: false,
+        verifySignature: true
+      },
+      TemurinImplementation.Hotspot
+    );
+
+    await expect(
+      distribution['downloadTool']({
+        version: '17.0.14+7',
+        url: 'https://example.com/jdk.tar.gz',
+        signatureUrl: 'https://example.com/jdk.tar.gz.sig'
+      })
+    ).rejects.toThrow(
+      /Failed to verify signature for Temurin version 17\.0\.14\+7.*bad signature.*https:\/\/github\.com\/actions\/setup-java#download-integrity-and-signatures/
+    );
+  });
+
+  it('warns when a signature is missing and verification is implicit', async () => {
+    const distribution = new TemurinDistribution(
+      {
+        version: '17',
+        architecture: 'x64',
+        packageType: 'jdk',
+        checkLatest: false
+      },
+      TemurinImplementation.Hotspot
+    );
+
+    await expect(
+      distribution['downloadTool']({
+        version: '17.0.14+7',
+        url: 'https://example.com/jdk.tar.gz'
+      })
+    ).resolves.toEqual({version: '17.0.14+7', path: '/tmp/toolcache'});
+
+    expect(core.warning).toHaveBeenCalledWith(
+      "Input 'verify-signature' is enabled, but no signature URL was found for Temurin version 17.0.14+7."
+    );
     expect(spyVerifySignature).not.toHaveBeenCalled();
   });
 

--- a/__tests__/gpg.test.ts
+++ b/__tests__/gpg.test.ts
@@ -245,7 +245,7 @@ describe('gpg tests', () => {
           expect.any(String),
           '--batch',
           '--import',
-          expect.stringContaining('public-key.asc')
+          expect.stringContaining('public-key-0.asc')
         ],
         expect.objectContaining({silent: true})
       );
@@ -262,6 +262,33 @@ describe('gpg tests', () => {
         ],
         expect.objectContaining({silent: true})
       );
+    });
+
+    it('imports multiple bundled keys before verifying the package', async () => {
+      (tc.downloadTool as jest.Mock<any>).mockResolvedValue(
+        '/tmp/jdk.tar.gz.sig'
+      );
+
+      await gpg.verifyPackageSignature(
+        '/tmp/jdk.tar.gz',
+        'https://example.com/jdk.tar.gz.sig',
+        ['public-key-a', 'public-key-b']
+      );
+
+      expect(exec.exec).toHaveBeenNthCalledWith(
+        1,
+        'gpg',
+        [
+          '--homedir',
+          expect.any(String),
+          '--batch',
+          '--import',
+          expect.stringContaining('public-key-0.asc'),
+          expect.stringContaining('public-key-1.asc')
+        ],
+        expect.objectContaining({silent: true})
+      );
+      expect(exec.exec).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/__tests__/jdk-cache.test.ts
+++ b/__tests__/jdk-cache.test.ts
@@ -43,7 +43,7 @@ const jdk = {
   architecture: 'x64',
   version: '21.0.8+9',
   source: 'sha256:abc123',
-  verification: 'unverified',
+  verification: 'disabled',
   path: '/toolcache/Java_temurin_jdk/21.0.8-9'
 };
 
@@ -117,32 +117,59 @@ describe('JDK cache', () => {
     );
   });
 
-  it('separates unverified, bundled-key, and custom-key caches', () => {
-    const unverified = getJdkVerificationIdentity(false);
-    const bundled = getJdkVerificationIdentity(true);
+  it('separates verification policies and keys', () => {
+    const disabled = getJdkVerificationIdentity(false, false);
+    const checkAndWarnBundled = getJdkVerificationIdentity(true, false);
+    const enforcedBundled = getJdkVerificationIdentity(true, true);
     const customA = getJdkVerificationIdentity(
+      true,
       true,
       '-----BEGIN PGP PUBLIC KEY BLOCK-----\r\nkey-a\r\n-----END PGP PUBLIC KEY BLOCK-----\r\n'
     );
     const customANormalized = getJdkVerificationIdentity(
       true,
+      true,
       '-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey-a\n-----END PGP PUBLIC KEY BLOCK-----'
     );
-    const customB = getJdkVerificationIdentity(true, 'different-key');
-
-    expect(new Set([unverified, bundled, customA, customB])).toHaveProperty(
-      'size',
-      4
+    const customB = getJdkVerificationIdentity(true, true, 'different-key');
+    const checkAndWarnCustomA = getJdkVerificationIdentity(
+      true,
+      false,
+      '-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey-a\n-----END PGP PUBLIC KEY BLOCK-----'
     );
+    const customList = getJdkVerificationIdentity(true, true, [
+      'key-a',
+      'key-b'
+    ]);
+    const customListWithDifferentBoundary = getJdkVerificationIdentity(
+      true,
+      true,
+      ['key-ak', 'ey-b']
+    );
+
+    expect(
+      new Set([
+        disabled,
+        checkAndWarnBundled,
+        enforcedBundled,
+        customA,
+        customB
+      ])
+    ).toHaveProperty('size', 5);
+    expect(disabled).toBe('disabled');
+    expect(checkAndWarnBundled).toBe('check-and-warn:bundled');
+    expect(enforcedBundled).toBe('enforced:bundled');
+    expect(checkAndWarnCustomA).not.toBe(customA);
     expect(customA).toBe(customANormalized);
     expect(customA).not.toContain('key-a');
+    expect(customList).not.toBe(customListWithDifferentBoundary);
     expect(
       new Set(
-        [unverified, bundled, customA, customB].map(verification =>
-          buildJdkCacheKey({...jdk, verification})
+        [disabled, checkAndWarnBundled, enforcedBundled, customA, customB].map(
+          verification => buildJdkCacheKey({...jdk, verification})
         )
       )
-    ).toHaveProperty('size', 4);
+    ).toHaveProperty('size', 5);
   });
 
   it('restores and records an exact JDK cache hit', async () => {
@@ -210,12 +237,12 @@ describe('JDK cache', () => {
 
   it('saves only the key matching the installation that occupies the path', async () => {
     const jdkPath = createInstallation();
-    const verified = {...jdk, path: jdkPath, verification: 'verified:bundled'};
-    const unverified = {...jdk, path: jdkPath};
+    const enforced = {...jdk, path: jdkPath, verification: 'enforced:bundled'};
+    const disabled = {...jdk, path: jdkPath};
 
-    registerJdk(verified);
+    registerJdk(enforced);
     writeInstallation(jdkPath, 'force-downloaded-without-verification');
-    registerJdk(unverified);
+    registerJdk(disabled);
     (core.getState as jest.Mock).mockReturnValue(lastState());
     (cache.saveCache as jest.Mock).mockResolvedValue(1);
 
@@ -223,11 +250,11 @@ describe('JDK cache', () => {
 
     expect(cache.saveCache).not.toHaveBeenCalledWith(
       [jdkPath],
-      buildJdkCacheKey(verified)
+      buildJdkCacheKey(enforced)
     );
     expect(cache.saveCache).toHaveBeenCalledWith(
       [jdkPath],
-      buildJdkCacheKey(unverified)
+      buildJdkCacheKey(disabled)
     );
   });
 

--- a/action.yml
+++ b/action.yml
@@ -39,10 +39,10 @@ inputs:
     required: false
     default: true
   verify-signature:
-    description: 'Verify downloaded Java package signatures when supported by the selected distribution'
+    description: 'Check downloaded Java package signatures when supported by the selected distribution. When omitted, failures produce warnings. Explicitly setting this to true enforces verification and makes failures fatal, including failures caused by an unexpected vendor signing-key rotation.'
     required: false
   verify-signature-public-key:
-    description: 'ASCII-armored GPG public key used to verify the downloaded package signature. Overrides the default bundled key for the selected distribution.'
+    description: 'One or more ASCII-armored GPG public keys used to verify downloaded package signatures. Concatenate multiple armored key blocks. Custom keys replace the bundled keys for the selected distribution.'
     required: false
   server-id:
     description: 'ID of the distributionManagement repository in the pom.xml

--- a/dist/cleanup/314.index.js
+++ b/dist/cleanup/314.index.js
@@ -122,16 +122,25 @@ function getInstallationIdentity(jdkPath, architecture) {
         return undefined;
     }
 }
-function getJdkVerificationIdentity(verifySignature, publicKey) {
+function getJdkVerificationIdentity(verifySignature, enforceSignatureVerification, publicKey) {
     if (!verifySignature) {
-        return 'unverified';
+        return 'disabled';
     }
+    const verificationPolicy = enforceSignatureVerification
+        ? 'enforced'
+        : 'check-and-warn';
     if (!publicKey) {
-        return 'verified:bundled';
+        return `${verificationPolicy}:bundled`;
     }
-    const normalizedKey = publicKey.replace(/\r\n?/g, '\n').trim();
-    const fingerprint = createHash('sha256').update(normalizedKey).digest('hex');
-    return `verified:custom:sha256:${fingerprint}`;
+    const publicKeys = Array.isArray(publicKey) ? publicKey : [publicKey];
+    const normalizedKeys = publicKeys.map(key => key.replace(/\r\n?/g, '\n').trim());
+    const fingerprintSource = Array.isArray(publicKey)
+        ? normalizedKeys.map(key => `${Buffer.byteLength(key)}:${key}`).join('')
+        : normalizedKeys[0];
+    const fingerprint = createHash('sha256')
+        .update(fingerprintSource)
+        .digest('hex');
+    return `${verificationPolicy}:custom:sha256:${fingerprint}`;
 }
 async function saveJdkCaches() {
     const state = lib_core/* getState */.Gu(STATE_JDK_CACHES);

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -30774,7 +30774,7 @@ module.exports = {
 /* harmony export */   gk: () => (/* binding */ INPUT_CACHE),
 /* harmony export */   wG: () => (/* binding */ INPUT_JOB_STATUS)
 /* harmony export */ });
-/* unused harmony exports MACOS_JAVA_CONTENT_POSTFIX, INPUT_JAVA_VERSION, INPUT_JAVA_VERSION_FILE, INPUT_ARCHITECTURE, INPUT_JAVA_PACKAGE, INPUT_DISTRIBUTION, INPUT_JDK_FILE, INPUT_JDK_FILE_DEPRECATED, INPUT_CHECK_LATEST, INPUT_FORCE_DOWNLOAD, INPUT_SET_DEFAULT, INPUT_PROBLEM_MATCHER, INPUT_VERIFY_SIGNATURE, INPUT_VERIFY_SIGNATURE_PUBLIC_KEY, INPUT_MVN_SERVER_CREDENTIALS, INPUT_MVN_REPOSITORIES, INPUT_MVN_REPOSITORIES_INCLUDE_CENTRAL, INPUT_MVN_REPOSITORIES_PRIORITIZE_CENTRAL, INPUT_SERVER_ID, INPUT_SERVER_USERNAME_ENV_VAR, INPUT_SERVER_PASSWORD_ENV_VAR, INPUT_SERVER_USERNAME_DEPRECATED, INPUT_SERVER_PASSWORD_DEPRECATED, INPUT_SETTINGS_PATH, INPUT_OVERWRITE_SETTINGS, INPUT_GPG_PRIVATE_KEY, INPUT_GPG_PASSPHRASE_ENV_VAR, INPUT_GPG_PASSPHRASE_DEPRECATED, INPUT_DEFAULT_SERVER_USERNAME, INPUT_DEFAULT_SERVER_PASSWORD, INPUT_DEFAULT_GPG_PRIVATE_KEY, INPUT_DEFAULT_GPG_PASSPHRASE, MAVEN_GPG_PASSPHRASE_DEFAULT_ENV, GPG_PASSPHRASE_PROFILE_ID, MAVEN_REPOSITORIES_PROFILE_ID, MAVEN_CENTRAL_REPOSITORY_ID, MAVEN_CENTRAL_REPOSITORY_URL, INPUT_CACHE_DEPENDENCY_PATH, INPUT_CACHE_PATH, M2_DIR, MVN_SETTINGS_FILE, MVN_TOOLCHAINS_FILE, INPUT_MVN_TOOLCHAIN_ID, INPUT_MVN_TOOLCHAIN_VENDOR, INPUT_SHOW_DOWNLOAD_PROGRESS, MAVEN_ARGS_ENV, MAVEN_NO_TRANSFER_PROGRESS_FLAG, MAVEN_NO_TRANSFER_PROGRESS_LONG_FLAG, DISTRIBUTIONS_ONLY_MAJOR_VERSION */
+/* unused harmony exports MACOS_JAVA_CONTENT_POSTFIX, INPUT_JAVA_VERSION, INPUT_JAVA_VERSION_FILE, INPUT_ARCHITECTURE, INPUT_JAVA_PACKAGE, INPUT_DISTRIBUTION, INPUT_JDK_FILE, INPUT_JDK_FILE_DEPRECATED, INPUT_CHECK_LATEST, INPUT_FORCE_DOWNLOAD, INPUT_SET_DEFAULT, INPUT_PROBLEM_MATCHER, INPUT_VERIFY_SIGNATURE, INPUT_VERIFY_SIGNATURE_PUBLIC_KEY, SIGNATURE_VERIFICATION_DOCUMENTATION_URL, SIGNATURE_VERIFICATION_FAILURE_HELP, INPUT_MVN_SERVER_CREDENTIALS, INPUT_MVN_REPOSITORIES, INPUT_MVN_REPOSITORIES_INCLUDE_CENTRAL, INPUT_MVN_REPOSITORIES_PRIORITIZE_CENTRAL, INPUT_SERVER_ID, INPUT_SERVER_USERNAME_ENV_VAR, INPUT_SERVER_PASSWORD_ENV_VAR, INPUT_SERVER_USERNAME_DEPRECATED, INPUT_SERVER_PASSWORD_DEPRECATED, INPUT_SETTINGS_PATH, INPUT_OVERWRITE_SETTINGS, INPUT_GPG_PRIVATE_KEY, INPUT_GPG_PASSPHRASE_ENV_VAR, INPUT_GPG_PASSPHRASE_DEPRECATED, INPUT_DEFAULT_SERVER_USERNAME, INPUT_DEFAULT_SERVER_PASSWORD, INPUT_DEFAULT_GPG_PRIVATE_KEY, INPUT_DEFAULT_GPG_PASSPHRASE, MAVEN_GPG_PASSPHRASE_DEFAULT_ENV, GPG_PASSPHRASE_PROFILE_ID, MAVEN_REPOSITORIES_PROFILE_ID, MAVEN_CENTRAL_REPOSITORY_ID, MAVEN_CENTRAL_REPOSITORY_URL, INPUT_CACHE_DEPENDENCY_PATH, INPUT_CACHE_PATH, M2_DIR, MVN_SETTINGS_FILE, MVN_TOOLCHAINS_FILE, INPUT_MVN_TOOLCHAIN_ID, INPUT_MVN_TOOLCHAIN_VENDOR, INPUT_SHOW_DOWNLOAD_PROGRESS, MAVEN_ARGS_ENV, MAVEN_NO_TRANSFER_PROGRESS_FLAG, MAVEN_NO_TRANSFER_PROGRESS_LONG_FLAG, DISTRIBUTIONS_ONLY_MAJOR_VERSION */
 const MACOS_JAVA_CONTENT_POSTFIX = 'Contents/Home';
 const INPUT_JAVA_VERSION = 'java-version';
 const INPUT_JAVA_VERSION_FILE = 'java-version-file';
@@ -30789,6 +30789,8 @@ const INPUT_SET_DEFAULT = 'set-default';
 const INPUT_PROBLEM_MATCHER = 'problem-matcher';
 const INPUT_VERIFY_SIGNATURE = 'verify-signature';
 const INPUT_VERIFY_SIGNATURE_PUBLIC_KEY = 'verify-signature-public-key';
+const SIGNATURE_VERIFICATION_DOCUMENTATION_URL = 'https://github.com/actions/setup-java#download-integrity-and-signatures';
+const SIGNATURE_VERIFICATION_FAILURE_HELP = (/* unused pure expression or super */ null && (`If this is a legitimate vendor signing-key rotation, see ${SIGNATURE_VERIFICATION_DOCUMENTATION_URL} for instructions to configure the updated public key or temporarily disable signature verification.`));
 const INPUT_MVN_SERVER_CREDENTIALS = 'mvn-server-credentials';
 const INPUT_MVN_REPOSITORIES = 'mvn-repositories';
 const INPUT_MVN_REPOSITORIES_INCLUDE_CENTRAL = 'mvn-repositories-include-central';
@@ -35767,6 +35769,9 @@ var src_util = __nccwpck_require__(4527);
 
 const GPG_HOME_PREFIX = 'setup-java-gpg-';
 const VERIFY_GPG_HOME_PREFIX = 'verify-signature-gpg-home-';
+async function isGpgAvailable() {
+    return Boolean(await io.which('gpg', false));
+}
 // Convert a Windows path (D:\a\_temp\...) to a POSIX path (/d/a/_temp/...).
 // The Git-bundled GPG on Windows (MSYS2-based) uses POSIX path conventions
 // internally. Passing Windows paths with backslashes can cause fatal GPG errors
@@ -35850,15 +35855,21 @@ async function verifyPackageSignature(archivePath, signatureUrl, publicKeyConten
         throw new Error(`Failed to create temporary GPG home directory for signature verification: ${error.message}`, { cause: error });
     }
     try {
-        const publicKeyFile = path.join(gpgHome, 'public-key.asc');
-        fs.writeFileSync(publicKeyFile, publicKeyContent, { encoding: 'utf-8' });
+        const publicKeys = Array.isArray(publicKeyContent)
+            ? publicKeyContent
+            : [publicKeyContent];
+        const publicKeyFiles = publicKeys.map((publicKey, index) => {
+            const publicKeyFile = path.join(gpgHome, `public-key-${index}.asc`);
+            fs.writeFileSync(publicKeyFile, publicKey, { encoding: 'utf-8' });
+            return toGpgPath(publicKeyFile);
+        });
         const options = { silent: true };
         await exec.exec('gpg', [
             '--homedir',
             toGpgPath(gpgHome),
             '--batch',
             '--import',
-            toGpgPath(publicKeyFile)
+            ...publicKeyFiles
         ], options);
         await exec.exec('gpg', [
             '--homedir',

--- a/dist/setup/19.index.js
+++ b/dist/setup/19.index.js
@@ -65,7 +65,7 @@ class LocalDistribution extends _base_installer_js__WEBPACK_IMPORTED_MODULE_3__/
                     architecture: this.architecture,
                     version: this.version,
                     source,
-                    verification: getJdkVerificationIdentity(false),
+                    verification: getJdkVerificationIdentity(false, false),
                     path: this.getJdkCachePath(this.version)
                 };
             }

--- a/dist/setup/220.index.js
+++ b/dist/setup/220.index.js
@@ -42,6 +42,8 @@ Fa133tP85xzJEq1XeXm8WeLFo2wV
 =rHCS
 -----END PGP PUBLIC KEY BLOCK-----`;
 
+// EXTERNAL MODULE: ./src/constants.ts
+var constants = __webpack_require__(7242);
 // EXTERNAL MODULE: ./node_modules/@actions/core/lib/core.js + 7 modules
 var core = __webpack_require__(3838);
 // EXTERNAL MODULE: ./node_modules/@actions/tool-cache/lib/tool-cache.js + 2 modules
@@ -62,6 +64,7 @@ var external_path_default = /*#__PURE__*/__webpack_require__.n(external_path_);
 
 
 
+
 class MicrosoftDistributions extends base_installer/* JavaBase */.O {
     constructor(installerOptions) {
         super('Microsoft', installerOptions);
@@ -70,15 +73,23 @@ class MicrosoftDistributions extends base_installer/* JavaBase */.O {
         core/* info */.pq(`Downloading Java ${javaRelease.version} (${this.distribution}) from ${javaRelease.url} ...`);
         let javaArchivePath = await this.downloadAndVerify(javaRelease);
         if (this.verifySignature) {
-            if (!javaRelease.signatureUrl) {
-                throw new Error(`Input 'verify-signature' is enabled, but no signature URL was found for Microsoft Build of OpenJDK version ${javaRelease.version}.`);
-            }
-            core/* info */.pq(`Verifying Java package signature...`);
             try {
-                await gpg/* verifyPackageSignature */.Yi(javaArchivePath, javaRelease.signatureUrl, this.verifySignaturePublicKey ?? MICROSOFT_PUBLIC_KEY);
+                if (!javaRelease.signatureUrl) {
+                    throw new Error(`Input 'verify-signature' is enabled, but no signature URL was found for Microsoft Build of OpenJDK version ${javaRelease.version}.`);
+                }
+                core/* info */.pq(`Verifying Java package signature...`);
+                try {
+                    await gpg/* verifyPackageSignature */.Yi(javaArchivePath, javaRelease.signatureUrl, this.verifySignaturePublicKey ?? MICROSOFT_PUBLIC_KEY);
+                }
+                catch (error) {
+                    throw new Error(`Failed to verify signature for Microsoft Build of OpenJDK version ${javaRelease.version}. Signature URL: ${javaRelease.signatureUrl}. Error: ${error.message} ${constants/* SIGNATURE_VERIFICATION_FAILURE_HELP */.kQ}`, { cause: error });
+                }
             }
             catch (error) {
-                throw new Error(`Failed to verify signature for Microsoft Build of OpenJDK version ${javaRelease.version}. Signature URL: ${javaRelease.signatureUrl}. Error: ${error.message}`, { cause: error });
+                if (this.verifySignatureExplicitlyRequested) {
+                    throw error;
+                }
+                core/* warning */.$e(error instanceof Error ? error.message : `Unknown error: ${error}`);
             }
         }
         core/* info */.pq(`Extracting Java archive...`);
@@ -167,7 +178,8 @@ class MicrosoftDistributions extends base_installer/* JavaBase */.O {
 /* harmony export */   Fh: () => (/* binding */ importKey),
 /* harmony export */   Yi: () => (/* binding */ verifyPackageSignature),
 /* harmony export */   mS: () => (/* binding */ removeGpgHome),
-/* harmony export */   nY: () => (/* binding */ toGpgPath)
+/* harmony export */   nY: () => (/* binding */ toGpgPath),
+/* harmony export */   o6: () => (/* binding */ isGpgAvailable)
 /* harmony export */ });
 /* unused harmony export GPG_HOME_PREFIX */
 /* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(9896);
@@ -189,6 +201,9 @@ class MicrosoftDistributions extends base_installer/* JavaBase */.O {
 
 const GPG_HOME_PREFIX = 'setup-java-gpg-';
 const VERIFY_GPG_HOME_PREFIX = 'verify-signature-gpg-home-';
+async function isGpgAvailable() {
+    return Boolean(await _actions_io__WEBPACK_IMPORTED_MODULE_3__/* .which */ .K7('gpg', false));
+}
 // Convert a Windows path (D:\a\_temp\...) to a POSIX path (/d/a/_temp/...).
 // The Git-bundled GPG on Windows (MSYS2-based) uses POSIX path conventions
 // internally. Passing Windows paths with backslashes can cause fatal GPG errors
@@ -272,15 +287,21 @@ async function verifyPackageSignature(archivePath, signatureUrl, publicKeyConten
         throw new Error(`Failed to create temporary GPG home directory for signature verification: ${error.message}`, { cause: error });
     }
     try {
-        const publicKeyFile = path__WEBPACK_IMPORTED_MODULE_1__.join(gpgHome, 'public-key.asc');
-        fs__WEBPACK_IMPORTED_MODULE_0__.writeFileSync(publicKeyFile, publicKeyContent, { encoding: 'utf-8' });
+        const publicKeys = Array.isArray(publicKeyContent)
+            ? publicKeyContent
+            : [publicKeyContent];
+        const publicKeyFiles = publicKeys.map((publicKey, index) => {
+            const publicKeyFile = path__WEBPACK_IMPORTED_MODULE_1__.join(gpgHome, `public-key-${index}.asc`);
+            fs__WEBPACK_IMPORTED_MODULE_0__.writeFileSync(publicKeyFile, publicKey, { encoding: 'utf-8' });
+            return toGpgPath(publicKeyFile);
+        });
         const options = { silent: true };
         await _actions_exec__WEBPACK_IMPORTED_MODULE_4__/* .exec */ .m('gpg', [
             '--homedir',
             toGpgPath(gpgHome),
             '--batch',
             '--import',
-            toGpgPath(publicKeyFile)
+            ...publicKeyFiles
         ], options);
         await _actions_exec__WEBPACK_IMPORTED_MODULE_4__/* .exec */ .m('gpg', [
             '--homedir',

--- a/dist/setup/242.index.js
+++ b/dist/setup/242.index.js
@@ -226,6 +226,7 @@ class JavaBase {
     floatingVersionVerified = false;
     setDefault;
     verifySignature;
+    verifySignatureExplicitlyRequested;
     verifySignaturePublicKey;
     constructor(distribution, installerOptions) {
         this.distribution = distribution;
@@ -246,6 +247,8 @@ class JavaBase {
                 : true;
         this.verifySignature =
             installerOptions.verifySignature ?? this.supportsSignatureVerification();
+        this.verifySignatureExplicitlyRequested =
+            installerOptions.verifySignature === true;
         this.verifySignaturePublicKey = installerOptions.verifySignaturePublicKey;
     }
     async downloadAndVerify(javaRelease) {
@@ -481,7 +484,7 @@ class JavaBase {
             architecture: this.architecture,
             version: javaRelease.version,
             source: this.getJdkReleaseIdentity(javaRelease),
-            verification: getJdkVerificationIdentity(this.verifySignature, this.verifySignaturePublicKey),
+            verification: getJdkVerificationIdentity(this.verifySignature, this.verifySignatureExplicitlyRequested, this.verifySignaturePublicKey),
             path: this.getJdkCachePath(javaRelease.version)
         };
     }

--- a/dist/setup/463.index.js
+++ b/dist/setup/463.index.js
@@ -159,15 +159,32 @@ class TemurinDistribution extends base_installer/* JavaBase */.O {
     async downloadPackage(release) {
         const archivePath = await this.downloadAndVerify(release);
         if (this.verifySignature) {
-            if (!release.signatureUrl) {
-                throw new Error(`Input 'verify-signature' is enabled, but no signature URL was found for Temurin version ${release.version}.`);
-            }
-            core/* info */.pq(`Verifying Java package signature...`);
             try {
-                await gpg/* verifyPackageSignature */.Yi(archivePath, release.signatureUrl, this.verifySignaturePublicKey ?? ADOPTIUM_PUBLIC_KEY);
+                if (!(await gpg/* isGpgAvailable */.o6())) {
+                    throw new Error("Input 'verify-signature' is enabled, but gpg is not available.");
+                }
+                if (!release.signatureUrl) {
+                    throw new Error(`Input 'verify-signature' is enabled, but no signature URL was found for Temurin version ${release.version}.`);
+                }
+                core/* info */.pq(`Verifying Java package signature...`);
+                try {
+                    await gpg/* verifyPackageSignature */.Yi(archivePath, release.signatureUrl, this.verifySignaturePublicKey ?? ADOPTIUM_PUBLIC_KEY);
+                }
+                catch (error) {
+                    const verificationError = new Error(`Failed to verify signature for Temurin version ${release.version} from ${release.signatureUrl}: ${error.message} ${constants/* SIGNATURE_VERIFICATION_FAILURE_HELP */.kQ}`, { cause: error });
+                    if (this.verifySignatureExplicitlyRequested) {
+                        throw verificationError;
+                    }
+                    else {
+                        core/* warning */.$e(verificationError.message);
+                    }
+                }
             }
             catch (error) {
-                throw new Error(`Failed to verify signature for Temurin version ${release.version} from ${release.signatureUrl}: ${error.message}`, { cause: error });
+                if (this.verifySignatureExplicitlyRequested) {
+                    throw error;
+                }
+                core/* warning */.$e(error instanceof Error ? error.message : `Unknown error: ${error}`);
             }
         }
         return archivePath;
@@ -273,7 +290,8 @@ class TemurinDistribution extends base_installer/* JavaBase */.O {
 /* harmony export */   Fh: () => (/* binding */ importKey),
 /* harmony export */   Yi: () => (/* binding */ verifyPackageSignature),
 /* harmony export */   mS: () => (/* binding */ removeGpgHome),
-/* harmony export */   nY: () => (/* binding */ toGpgPath)
+/* harmony export */   nY: () => (/* binding */ toGpgPath),
+/* harmony export */   o6: () => (/* binding */ isGpgAvailable)
 /* harmony export */ });
 /* unused harmony export GPG_HOME_PREFIX */
 /* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(9896);
@@ -295,6 +313,9 @@ class TemurinDistribution extends base_installer/* JavaBase */.O {
 
 const GPG_HOME_PREFIX = 'setup-java-gpg-';
 const VERIFY_GPG_HOME_PREFIX = 'verify-signature-gpg-home-';
+async function isGpgAvailable() {
+    return Boolean(await _actions_io__WEBPACK_IMPORTED_MODULE_3__/* .which */ .K7('gpg', false));
+}
 // Convert a Windows path (D:\a\_temp\...) to a POSIX path (/d/a/_temp/...).
 // The Git-bundled GPG on Windows (MSYS2-based) uses POSIX path conventions
 // internally. Passing Windows paths with backslashes can cause fatal GPG errors
@@ -378,15 +399,21 @@ async function verifyPackageSignature(archivePath, signatureUrl, publicKeyConten
         throw new Error(`Failed to create temporary GPG home directory for signature verification: ${error.message}`, { cause: error });
     }
     try {
-        const publicKeyFile = path__WEBPACK_IMPORTED_MODULE_1__.join(gpgHome, 'public-key.asc');
-        fs__WEBPACK_IMPORTED_MODULE_0__.writeFileSync(publicKeyFile, publicKeyContent, { encoding: 'utf-8' });
+        const publicKeys = Array.isArray(publicKeyContent)
+            ? publicKeyContent
+            : [publicKeyContent];
+        const publicKeyFiles = publicKeys.map((publicKey, index) => {
+            const publicKeyFile = path__WEBPACK_IMPORTED_MODULE_1__.join(gpgHome, `public-key-${index}.asc`);
+            fs__WEBPACK_IMPORTED_MODULE_0__.writeFileSync(publicKeyFile, publicKey, { encoding: 'utf-8' });
+            return toGpgPath(publicKeyFile);
+        });
         const options = { silent: true };
         await _actions_exec__WEBPACK_IMPORTED_MODULE_4__/* .exec */ .m('gpg', [
             '--homedir',
             toGpgPath(gpgHome),
             '--batch',
             '--import',
-            toGpgPath(publicKeyFile)
+            ...publicKeyFiles
         ], options);
         await _actions_exec__WEBPACK_IMPORTED_MODULE_4__/* .exec */ .m('gpg', [
             '--homedir',

--- a/dist/setup/779.index.js
+++ b/dist/setup/779.index.js
@@ -127,16 +127,25 @@ function getInstallationIdentity(jdkPath, architecture) {
         return undefined;
     }
 }
-function getJdkVerificationIdentity(verifySignature, publicKey) {
+function getJdkVerificationIdentity(verifySignature, enforceSignatureVerification, publicKey) {
     if (!verifySignature) {
-        return 'unverified';
+        return 'disabled';
     }
+    const verificationPolicy = enforceSignatureVerification
+        ? 'enforced'
+        : 'check-and-warn';
     if (!publicKey) {
-        return 'verified:bundled';
+        return `${verificationPolicy}:bundled`;
     }
-    const normalizedKey = publicKey.replace(/\r\n?/g, '\n').trim();
-    const fingerprint = (0,crypto__WEBPACK_IMPORTED_MODULE_0__.createHash)('sha256').update(normalizedKey).digest('hex');
-    return `verified:custom:sha256:${fingerprint}`;
+    const publicKeys = Array.isArray(publicKey) ? publicKey : [publicKey];
+    const normalizedKeys = publicKeys.map(key => key.replace(/\r\n?/g, '\n').trim());
+    const fingerprintSource = Array.isArray(publicKey)
+        ? normalizedKeys.map(key => `${Buffer.byteLength(key)}:${key}`).join('')
+        : normalizedKeys[0];
+    const fingerprint = (0,crypto__WEBPACK_IMPORTED_MODULE_0__.createHash)('sha256')
+        .update(fingerprintSource)
+        .digest('hex');
+    return `${verificationPolicy}:custom:sha256:${fingerprint}`;
 }
 async function saveJdkCaches() {
     const state = _actions_core__WEBPACK_IMPORTED_MODULE_4__/* .getState */ .Gu(STATE_JDK_CACHES);

--- a/dist/setup/81.index.js
+++ b/dist/setup/81.index.js
@@ -265,7 +265,8 @@ async function write(directory, settings, overwriteSettings) {
 /* harmony export */   Fh: () => (/* binding */ importKey),
 /* harmony export */   Yi: () => (/* binding */ verifyPackageSignature),
 /* harmony export */   mS: () => (/* binding */ removeGpgHome),
-/* harmony export */   nY: () => (/* binding */ toGpgPath)
+/* harmony export */   nY: () => (/* binding */ toGpgPath),
+/* harmony export */   o6: () => (/* binding */ isGpgAvailable)
 /* harmony export */ });
 /* unused harmony export GPG_HOME_PREFIX */
 /* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(9896);
@@ -287,6 +288,9 @@ async function write(directory, settings, overwriteSettings) {
 
 const GPG_HOME_PREFIX = 'setup-java-gpg-';
 const VERIFY_GPG_HOME_PREFIX = 'verify-signature-gpg-home-';
+async function isGpgAvailable() {
+    return Boolean(await _actions_io__WEBPACK_IMPORTED_MODULE_3__/* .which */ .K7('gpg', false));
+}
 // Convert a Windows path (D:\a\_temp\...) to a POSIX path (/d/a/_temp/...).
 // The Git-bundled GPG on Windows (MSYS2-based) uses POSIX path conventions
 // internally. Passing Windows paths with backslashes can cause fatal GPG errors
@@ -370,15 +374,21 @@ async function verifyPackageSignature(archivePath, signatureUrl, publicKeyConten
         throw new Error(`Failed to create temporary GPG home directory for signature verification: ${error.message}`, { cause: error });
     }
     try {
-        const publicKeyFile = path__WEBPACK_IMPORTED_MODULE_1__.join(gpgHome, 'public-key.asc');
-        fs__WEBPACK_IMPORTED_MODULE_0__.writeFileSync(publicKeyFile, publicKeyContent, { encoding: 'utf-8' });
+        const publicKeys = Array.isArray(publicKeyContent)
+            ? publicKeyContent
+            : [publicKeyContent];
+        const publicKeyFiles = publicKeys.map((publicKey, index) => {
+            const publicKeyFile = path__WEBPACK_IMPORTED_MODULE_1__.join(gpgHome, `public-key-${index}.asc`);
+            fs__WEBPACK_IMPORTED_MODULE_0__.writeFileSync(publicKeyFile, publicKey, { encoding: 'utf-8' });
+            return toGpgPath(publicKeyFile);
+        });
         const options = { silent: true };
         await _actions_exec__WEBPACK_IMPORTED_MODULE_4__/* .exec */ .m('gpg', [
             '--homedir',
             toGpgPath(gpgHome),
             '--batch',
             '--import',
-            toGpgPath(publicKeyFile)
+            ...publicKeyFiles
         ], options);
         await _actions_exec__WEBPACK_IMPORTED_MODULE_4__/* .exec */ .m('gpg', [
             '--homedir',

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -30801,6 +30801,7 @@ module.exports = {
 /* harmony export */   jv: () => (/* binding */ MAVEN_CENTRAL_REPOSITORY_URL),
 /* harmony export */   kM: () => (/* binding */ INPUT_JDK_FILE),
 /* harmony export */   kN: () => (/* binding */ MAVEN_NO_TRANSFER_PROGRESS_LONG_FLAG),
+/* harmony export */   kQ: () => (/* binding */ SIGNATURE_VERIFICATION_FAILURE_HELP),
 /* harmony export */   ko: () => (/* binding */ MAVEN_GPG_PASSPHRASE_DEFAULT_ENV),
 /* harmony export */   m7: () => (/* binding */ INPUT_MVN_TOOLCHAIN_VENDOR),
 /* harmony export */   nr: () => (/* binding */ INPUT_MVN_TOOLCHAIN_ID),
@@ -30821,7 +30822,7 @@ module.exports = {
 /* harmony export */   xg: () => (/* binding */ MAVEN_CENTRAL_REPOSITORY_ID),
 /* harmony export */   xp: () => (/* binding */ INPUT_DEFAULT_SERVER_PASSWORD)
 /* harmony export */ });
-/* unused harmony exports INPUT_CACHE_READ_ONLY, INPUT_JOB_STATUS */
+/* unused harmony exports SIGNATURE_VERIFICATION_DOCUMENTATION_URL, INPUT_CACHE_READ_ONLY, INPUT_JOB_STATUS */
 const MACOS_JAVA_CONTENT_POSTFIX = 'Contents/Home';
 const INPUT_JAVA_VERSION = 'java-version';
 const INPUT_JAVA_VERSION_FILE = 'java-version-file';
@@ -30836,6 +30837,8 @@ const INPUT_SET_DEFAULT = 'set-default';
 const INPUT_PROBLEM_MATCHER = 'problem-matcher';
 const INPUT_VERIFY_SIGNATURE = 'verify-signature';
 const INPUT_VERIFY_SIGNATURE_PUBLIC_KEY = 'verify-signature-public-key';
+const SIGNATURE_VERIFICATION_DOCUMENTATION_URL = 'https://github.com/actions/setup-java#download-integrity-and-signatures';
+const SIGNATURE_VERIFICATION_FAILURE_HELP = `If this is a legitimate vendor signing-key rotation, see ${SIGNATURE_VERIFICATION_DOCUMENTATION_URL} for instructions to configure the updated public key or temporarily disable signature verification.`;
 const INPUT_MVN_SERVER_CREDENTIALS = 'mvn-server-credentials';
 const INPUT_MVN_REPOSITORIES = 'mvn-repositories';
 const INPUT_MVN_REPOSITORIES_INCLUDE_CENTRAL = 'mvn-repositories-include-central';

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -539,18 +539,27 @@ tool-cache installation short-circuits setup, so a changed `jdk-file` is not
 re-extracted for a version that is already installed. Use
 `force-download: true` when the archive contents change but the version does not.
 
-The verification identity separates unverified downloads from packages verified
-with the distribution's bundled signing key and from packages verified with each
-custom key. Custom public keys are represented by a SHA-256 fingerprint of
-normalized key material; the key itself is not placed in the cache key, the logs,
-or action state. A verified exact-key hit reuses content that was
-signature-verified when it was downloaded by the run that saved the entry,
-instead of downloading and verifying it again.
+The verification identity separates requests that disable signature verification,
+check and warn without enforcement, or explicitly enforce verification. Disabled
+and check-and-warn requests have the same non-enforcement guarantee, but they are
+kept separate so an entry downloaded with verification disabled cannot prevent a
+later check-and-warn request from attempting verification. The identity also
+separates the distribution's bundled signing keys from custom keys. Custom
+public-key sets are represented by a SHA-256 fingerprint of normalized,
+boundary-delimited key material; the keys themselves are not placed in the cache
+key, the logs, or action state. Enforced requests only restore entries created by
+an enforced request whose signature verification succeeded. Check-and-warn entries
+may have been saved after verification succeeded or after a verification failure
+was reported as a warning.
+
+For signature-verification defaults, enforced failure behavior, and recovery from
+a legitimate vendor signing-key rotation, see
+[Download integrity and signatures](../README.md#download-integrity-and-signatures).
 
 > [!IMPORTANT]
-> The JDK cache **key** is what isolates verification modes and release
-> identity: a JDK cache entry created by an unverified download can never be
-> restored for a request that sets `verify-signature: true`, and vice versa.
+> The JDK cache **key** isolates disabled, check-and-warn, and enforced verification
+> modes as well as release identity. A check-and-warn entry can never be restored
+> for a request that sets `verify-signature: true`, and vice versa.
 > `cache-jdk` does not change how the runner tool cache is used. setup-java
 > first looks for an installation in the runner tool cache — a preinstalled
 > JDK, or one installed by an earlier step of the same job — and uses it as-is. Such an installation is not downloaded again, and its checksum

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,9 @@ export const INPUT_SET_DEFAULT = 'set-default';
 export const INPUT_PROBLEM_MATCHER = 'problem-matcher';
 export const INPUT_VERIFY_SIGNATURE = 'verify-signature';
 export const INPUT_VERIFY_SIGNATURE_PUBLIC_KEY = 'verify-signature-public-key';
+export const SIGNATURE_VERIFICATION_DOCUMENTATION_URL =
+  'https://github.com/actions/setup-java#download-integrity-and-signatures';
+export const SIGNATURE_VERIFICATION_FAILURE_HELP = `If this is a legitimate vendor signing-key rotation, see ${SIGNATURE_VERIFICATION_DOCUMENTATION_URL} for instructions to configure the updated public key or temporarily disable signature verification.`;
 export const INPUT_MVN_SERVER_CREDENTIALS = 'mvn-server-credentials';
 export const INPUT_MVN_REPOSITORIES = 'mvn-repositories';
 export const INPUT_MVN_REPOSITORIES_INCLUDE_CENTRAL =

--- a/src/distributions/base-installer.ts
+++ b/src/distributions/base-installer.ts
@@ -9,12 +9,13 @@ import {
   getToolcachePath,
   isVersionSatisfies
 } from '../util.js';
-import {
+import type {
   ChecksumAlgorithm,
   ChecksumMetadata,
   JavaDownloadRelease,
   JavaInstallerOptions,
-  JavaInstallerResults
+  JavaInstallerResults,
+  SignatureVerificationKey
 } from './base-models.js';
 import {MACOS_JAVA_CONTENT_POSTFIX} from '../constants.js';
 import {RetryingHttpClient} from '../retrying-http-client.js';
@@ -44,7 +45,8 @@ export abstract class JavaBase {
   private floatingVersionVerified = false;
   protected setDefault: boolean;
   protected verifySignature: boolean;
-  protected verifySignaturePublicKey: string | undefined;
+  protected verifySignatureExplicitlyRequested: boolean;
+  protected verifySignaturePublicKey: SignatureVerificationKey | undefined;
 
   constructor(
     protected distribution: string,
@@ -70,6 +72,8 @@ export abstract class JavaBase {
         : true;
     this.verifySignature =
       installerOptions.verifySignature ?? this.supportsSignatureVerification();
+    this.verifySignatureExplicitlyRequested =
+      installerOptions.verifySignature === true;
     this.verifySignaturePublicKey = installerOptions.verifySignaturePublicKey;
   }
 
@@ -369,6 +373,7 @@ export abstract class JavaBase {
       source: this.getJdkReleaseIdentity(javaRelease),
       verification: getJdkVerificationIdentity(
         this.verifySignature,
+        this.verifySignatureExplicitlyRequested,
         this.verifySignaturePublicKey
       ),
       path: this.getJdkCachePath(javaRelease.version)

--- a/src/distributions/base-models.ts
+++ b/src/distributions/base-models.ts
@@ -1,3 +1,5 @@
+export type SignatureVerificationKey = string | readonly string[];
+
 export interface JavaInstallerOptions {
   version: string;
   architecture: string;
@@ -7,7 +9,7 @@ export interface JavaInstallerOptions {
   cacheJdk?: boolean;
   setDefault?: boolean;
   verifySignature?: boolean;
-  verifySignaturePublicKey?: string;
+  verifySignaturePublicKey?: SignatureVerificationKey;
 }
 
 export interface JavaInstallerResults {

--- a/src/distributions/local/installer.ts
+++ b/src/distributions/local/installer.ts
@@ -65,7 +65,7 @@ export class LocalDistribution extends JavaBase {
           architecture: this.architecture,
           version: this.version,
           source,
-          verification: getJdkVerificationIdentity(false),
+          verification: getJdkVerificationIdentity(false, false),
           path: this.getJdkCachePath(this.version)
         };
       }

--- a/src/distributions/microsoft/installer.ts
+++ b/src/distributions/microsoft/installer.ts
@@ -12,6 +12,7 @@ import {
 } from '../../util.js';
 import * as gpg from '../../gpg.js';
 import {MICROSOFT_PUBLIC_KEY} from './microsoft-key.js';
+import {SIGNATURE_VERIFICATION_FAILURE_HELP} from '../../constants.js';
 import * as core from '@actions/core';
 import * as tc from '@actions/tool-cache';
 import fs from 'fs';
@@ -34,22 +35,31 @@ export class MicrosoftDistributions extends JavaBase {
     let javaArchivePath = await this.downloadAndVerify(javaRelease);
 
     if (this.verifySignature) {
-      if (!javaRelease.signatureUrl) {
-        throw new Error(
-          `Input 'verify-signature' is enabled, but no signature URL was found for Microsoft Build of OpenJDK version ${javaRelease.version}.`
-        );
-      }
-      core.info(`Verifying Java package signature...`);
       try {
-        await gpg.verifyPackageSignature(
-          javaArchivePath,
-          javaRelease.signatureUrl,
-          this.verifySignaturePublicKey ?? MICROSOFT_PUBLIC_KEY
-        );
+        if (!javaRelease.signatureUrl) {
+          throw new Error(
+            `Input 'verify-signature' is enabled, but no signature URL was found for Microsoft Build of OpenJDK version ${javaRelease.version}.`
+          );
+        }
+        core.info(`Verifying Java package signature...`);
+        try {
+          await gpg.verifyPackageSignature(
+            javaArchivePath,
+            javaRelease.signatureUrl,
+            this.verifySignaturePublicKey ?? MICROSOFT_PUBLIC_KEY
+          );
+        } catch (error) {
+          throw new Error(
+            `Failed to verify signature for Microsoft Build of OpenJDK version ${javaRelease.version}. Signature URL: ${javaRelease.signatureUrl}. Error: ${(error as Error).message} ${SIGNATURE_VERIFICATION_FAILURE_HELP}`,
+            {cause: error}
+          );
+        }
       } catch (error) {
-        throw new Error(
-          `Failed to verify signature for Microsoft Build of OpenJDK version ${javaRelease.version}. Signature URL: ${javaRelease.signatureUrl}. Error: ${(error as Error).message}`,
-          {cause: error}
+        if (this.verifySignatureExplicitlyRequested) {
+          throw error;
+        }
+        core.warning(
+          error instanceof Error ? error.message : `Unknown error: ${error}`
         );
       }
     }

--- a/src/distributions/temurin/installer.ts
+++ b/src/distributions/temurin/installer.ts
@@ -8,7 +8,10 @@ import * as gpg from '../../gpg.js';
 import {ADOPTIUM_PUBLIC_KEY} from './adoptium-key.js';
 import {JavaBase} from '../base-installer.js';
 import {ITemurinAvailableVersions} from './models.js';
-import {MACOS_JAVA_CONTENT_POSTFIX} from '../../constants.js';
+import {
+  MACOS_JAVA_CONTENT_POSTFIX,
+  SIGNATURE_VERIFICATION_FAILURE_HELP
+} from '../../constants.js';
 import {
   JavaDownloadRelease,
   JavaInstallerOptions,
@@ -141,24 +144,41 @@ export class TemurinDistribution extends JavaBase {
     const archivePath = await this.downloadAndVerify(release);
 
     if (this.verifySignature) {
-      if (!release.signatureUrl) {
-        throw new Error(
-          `Input 'verify-signature' is enabled, but no signature URL was found for Temurin version ${release.version}.`
-        );
-      }
-      core.info(`Verifying Java package signature...`);
       try {
-        await gpg.verifyPackageSignature(
-          archivePath,
-          release.signatureUrl,
-          this.verifySignaturePublicKey ?? ADOPTIUM_PUBLIC_KEY
-        );
+        if (!(await gpg.isGpgAvailable())) {
+          throw new Error(
+            "Input 'verify-signature' is enabled, but gpg is not available."
+          );
+        }
+        if (!release.signatureUrl) {
+          throw new Error(
+            `Input 'verify-signature' is enabled, but no signature URL was found for Temurin version ${release.version}.`
+          );
+        }
+        core.info(`Verifying Java package signature...`);
+        try {
+          await gpg.verifyPackageSignature(
+            archivePath,
+            release.signatureUrl,
+            this.verifySignaturePublicKey ?? ADOPTIUM_PUBLIC_KEY
+          );
+        } catch (error) {
+          const verificationError = new Error(
+            `Failed to verify signature for Temurin version ${release.version} from ${release.signatureUrl}: ${(error as Error).message} ${SIGNATURE_VERIFICATION_FAILURE_HELP}`,
+            {cause: error}
+          );
+          if (this.verifySignatureExplicitlyRequested) {
+            throw verificationError;
+          } else {
+            core.warning(verificationError.message);
+          }
+        }
       } catch (error) {
-        throw new Error(
-          `Failed to verify signature for Temurin version ${release.version} from ${release.signatureUrl}: ${
-            (error as Error).message
-          }`,
-          {cause: error}
+        if (this.verifySignatureExplicitlyRequested) {
+          throw error;
+        }
+        core.warning(
+          error instanceof Error ? error.message : `Unknown error: ${error}`
         );
       }
     }

--- a/src/gpg.ts
+++ b/src/gpg.ts
@@ -5,10 +5,15 @@ import * as io from '@actions/io';
 import * as exec from '@actions/exec';
 import * as tc from '@actions/tool-cache';
 import * as util from './util.js';
-import {ExecOptions} from '@actions/exec';
+import type {ExecOptions} from '@actions/exec';
+import type {SignatureVerificationKey} from './distributions/base-models.js';
 
 export const GPG_HOME_PREFIX = 'setup-java-gpg-';
 const VERIFY_GPG_HOME_PREFIX = 'verify-signature-gpg-home-';
+
+export async function isGpgAvailable(): Promise<boolean> {
+  return Boolean(await io.which('gpg', false));
+}
 
 // Convert a Windows path (D:\a\_temp\...) to a POSIX path (/d/a/_temp/...).
 // The Git-bundled GPG on Windows (MSYS2-based) uses POSIX path conventions
@@ -97,7 +102,7 @@ export async function removeGpgHome(gpgHome: string): Promise<void> {
 export async function verifyPackageSignature(
   archivePath: string,
   signatureUrl: string,
-  publicKeyContent: string
+  publicKeyContent: SignatureVerificationKey
 ) {
   const signaturePath = await tc.downloadTool(signatureUrl);
   let gpgHome: string;
@@ -117,8 +122,14 @@ export async function verifyPackageSignature(
     );
   }
   try {
-    const publicKeyFile = path.join(gpgHome, 'public-key.asc');
-    fs.writeFileSync(publicKeyFile, publicKeyContent, {encoding: 'utf-8'});
+    const publicKeys = Array.isArray(publicKeyContent)
+      ? publicKeyContent
+      : [publicKeyContent];
+    const publicKeyFiles = publicKeys.map((publicKey, index) => {
+      const publicKeyFile = path.join(gpgHome, `public-key-${index}.asc`);
+      fs.writeFileSync(publicKeyFile, publicKey, {encoding: 'utf-8'});
+      return toGpgPath(publicKeyFile);
+    });
     const options: ExecOptions = {silent: true};
     await exec.exec(
       'gpg',
@@ -127,7 +138,7 @@ export async function verifyPackageSignature(
         toGpgPath(gpgHome),
         '--batch',
         '--import',
-        toGpgPath(publicKeyFile)
+        ...publicKeyFiles
       ],
       options
     );

--- a/src/jdk-cache.ts
+++ b/src/jdk-cache.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import * as cache from '@actions/cache';
 import * as core from '@actions/core';
 import {isCacheFeatureAvailable} from './cache-feature.js';
+import type {SignatureVerificationKey} from './distributions/base-models.js';
 
 const STATE_JDK_CACHES = 'jdk-caches';
 const JDK_CACHE_KEY_VERSION = 1;
@@ -117,18 +118,30 @@ function getInstallationIdentity(
 
 export function getJdkVerificationIdentity(
   verifySignature: boolean,
-  publicKey?: string
+  enforceSignatureVerification: boolean,
+  publicKey?: SignatureVerificationKey
 ): string {
   if (!verifySignature) {
-    return 'unverified';
+    return 'disabled';
   }
+  const verificationPolicy = enforceSignatureVerification
+    ? 'enforced'
+    : 'check-and-warn';
   if (!publicKey) {
-    return 'verified:bundled';
+    return `${verificationPolicy}:bundled`;
   }
 
-  const normalizedKey = publicKey.replace(/\r\n?/g, '\n').trim();
-  const fingerprint = createHash('sha256').update(normalizedKey).digest('hex');
-  return `verified:custom:sha256:${fingerprint}`;
+  const publicKeys = Array.isArray(publicKey) ? publicKey : [publicKey];
+  const normalizedKeys = publicKeys.map(key =>
+    key.replace(/\r\n?/g, '\n').trim()
+  );
+  const fingerprintSource = Array.isArray(publicKey)
+    ? normalizedKeys.map(key => `${Buffer.byteLength(key)}:${key}`).join('')
+    : normalizedKeys[0];
+  const fingerprint = createHash('sha256')
+    .update(fingerprintSource)
+    .digest('hex');
+  return `${verificationPolicy}:custom:sha256:${fingerprint}`;
 }
 
 export async function saveJdkCaches(): Promise<void> {


### PR DESCRIPTION
…ation failures. To prevent build failures due to missing GPG or rotated vendor keys.

Also allow multiple GPG keys to be provided.

**Description:**
Describe your changes.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Ran `npm run check` locally (format, lint, build, test) and all checks pass.
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.